### PR TITLE
Fixes broken validation tests.

### DIFF
--- a/pkg/apis/serving/v1alpha1/kfservice_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/kfservice_validation_test.go
@@ -26,13 +26,14 @@ func TestRejectMultipleModelSpecs(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	kfsvc := TFExampleKFService.DeepCopy()
 	kfsvc.Spec.Default.ScikitLearn = &ScikitLearnSpec{ModelURI: "gs://testbucket/testmodel"}
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("Exactly one of [Custom, Tensorflow, ScikitLearn, XGBoost] may be specified in ModelSpec"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneModelSpecViolatedError))
 }
+
 func TestRejectModelSpecMissing(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	kfsvc := TFExampleKFService.DeepCopy()
 	kfsvc.Spec.Default.Tensorflow = nil
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("Exactly one of [Custom, Tensorflow, ScikitLearn, XGBoost] may be specified in ModelSpec"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneModelSpecViolatedError))
 }
 func TestRejectMultipleCanaryModelSpecs(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
@@ -41,14 +42,14 @@ func TestRejectMultipleCanaryModelSpecs(t *testing.T) {
 		ScikitLearn: &ScikitLearnSpec{ModelURI: "gs://testbucket/testmodel"},
 		Tensorflow:  kfsvc.Spec.Default.Tensorflow,
 	}}
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("Exactly one of [Custom, Tensorflow, ScikitLearn, XGBoost] may be specified in ModelSpec"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneModelSpecViolatedError))
 }
 
 func TestRejectCanaryModelSpecMissing(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	kfsvc := TFExampleKFService.DeepCopy()
 	kfsvc.Spec.Canary = &CanarySpec{ModelSpec: ModelSpec{}}
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("Exactly one of [Custom, Tensorflow, ScikitLearn, XGBoost] may be specified in ModelSpec"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneModelSpecViolatedError))
 }
 
 func TestRejectBadCanaryTrafficValues(t *testing.T) {
@@ -58,20 +59,20 @@ func TestRejectBadCanaryTrafficValues(t *testing.T) {
 		TrafficPercent: -1,
 		ModelSpec:      kfsvc.Spec.Default,
 	}
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("TrafficPercent must be between [0, 100]"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(TrafficBoundsExceededError))
 	kfsvc.Spec.Canary.TrafficPercent = 101
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("TrafficPercent must be between [0, 100]"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(TrafficBoundsExceededError))
 }
 
 func TestBadReplicaValues(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	kfsvc := TFExampleKFService.DeepCopy()
 	kfsvc.Spec.MinReplicas = -1
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("MinReplicas cannot be less than 0"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(MinReplicasLowerBoundExceededError))
 	kfsvc.Spec.MinReplicas = 1
 	kfsvc.Spec.MaxReplicas = -1
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("MaxReplicas cannot be less than 0"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(MaxReplicasLowerBoundExceededError))
 	kfsvc.Spec.MinReplicas = 2
 	kfsvc.Spec.MaxReplicas = 1
-	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError("MinReplicas cannot be greater than MaxReplicas"))
+	g.Expect(kfsvc.ValidateCreate()).Should(gomega.MatchError(MinReplicasShouldBeLessThanMaxError))
 }

--- a/pkg/reconciler/ksvc/reconciler.go
+++ b/pkg/reconciler/ksvc/reconciler.go
@@ -48,9 +48,9 @@ func (c *ServiceReconciler) Reconcile(ctx context.Context, desiredService *knser
 	err := c.client.Get(context.TODO(), types.NamespacedName{Name: desiredService.Name, Namespace: desiredService.Namespace}, service)
 	if err != nil {
 		if errors.IsNotFound(err) {
-		  log.Info("Creating Knative Serving Service", "namespace", service.Namespace, "name", service.Name)
-		  err = c.client.Create(context.TODO(), desiredService)
-		  return desiredService, err
+			log.Info("Creating Knative Serving Service", "namespace", service.Namespace, "name", service.Name)
+			err = c.client.Create(context.TODO(), desiredService)
+			return desiredService, err
 		}
 		return nil, err
 	}


### PR DESCRIPTION
A recent commit broke these tests. They're working now. +1 to automating testing.

➜  kfserving git:(validate) make all
go generate ./pkg/... ./cmd/...
go fmt ./pkg/... ./cmd/...
go vet ./pkg/... ./cmd/...
go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go all
CRD manifests generated under '/Users/ellisbigelow/go/src/github.com/kubeflow/kfserving/config/crds'
RBAC manifests generated under '/Users/ellisbigelow/go/src/github.com/kubeflow/kfserving/config/rbac'
go test ./pkg/... ./cmd/... -coverprofile cover.out
?   	github.com/kubeflow/kfserving/pkg/apis	[no test files]
?   	github.com/kubeflow/kfserving/pkg/apis/serving	[no test files]
ok  	github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha1	8.309s	coverage: 42.5% of statements
?   	github.com/kubeflow/kfserving/pkg/controller	[no test files]
ok  	github.com/kubeflow/kfserving/pkg/controller/kfservice	7.831s	coverage: 72.0% of statements
?   	github.com/kubeflow/kfserving/pkg/frameworks/tensorflow	[no test files]
ok  	github.com/kubeflow/kfserving/pkg/reconciler/ksvc	7.798s	coverage: 81.8% of statements
ok  	github.com/kubeflow/kfserving/pkg/reconciler/ksvc/resources	0.498s	coverage: 100.0% of statements
?   	github.com/kubeflow/kfserving/cmd/manager	[no test files]
go build -o bin/manager ./cmd/manager

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/43)
<!-- Reviewable:end -->
