### PR TITLE
Reconcile labels and annotations for configuration/route

### DIFF
--- a/pkg/controller/kfservice/kfservice_controller.go
+++ b/pkg/controller/kfservice/kfservice_controller.go
@@ -132,30 +132,30 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	serviceReconciler := ksvc.NewServiceReconciler(r.Client)
 	// Reconcile configurations
-	desiredDefault, desiredCanary := resources.CreateKnativeConfiguration(kfsvc)
+	desiredDefaultConfiguration, desiredCanaryConfiguration := resources.CreateKnativeConfiguration(kfsvc)
 
-	if err := controllerutil.SetControllerReference(kfsvc, desiredDefault, r.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(kfsvc, desiredDefaultConfiguration, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if desiredCanary != nil {
-		if err := controllerutil.SetControllerReference(kfsvc, desiredCanary, r.scheme); err != nil {
+	if desiredCanaryConfiguration != nil {
+		if err := controllerutil.SetControllerReference(kfsvc, desiredCanaryConfiguration, r.scheme); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
-	defaultConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredDefault)
+	defaultConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredDefaultConfiguration)
 	if err != nil {
-		log.Error(err, "Failed to reconcile default model spec", "name", desiredDefault.Name)
+		log.Error(err, "Failed to reconcile default model spec", "name", desiredDefaultConfiguration.Name)
 		r.Recorder.Eventf(kfsvc, v1.EventTypeWarning, "InternalError", err.Error())
 		return reconcile.Result{}, err
 	}
 	kfsvc.Status.PropagateDefaultConfigurationStatus(&defaultConfiguration.Status)
 
-	if desiredCanary != nil {
-		canaryConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredCanary)
+	if desiredCanaryConfiguration != nil {
+		canaryConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredCanaryConfiguration)
 		if err != nil {
-			log.Error(err, "Failed to reconcile canary model spec", "name", desiredCanary.Name)
+			log.Error(err, "Failed to reconcile canary model spec", "name", desiredCanaryConfiguration.Name)
 			r.Recorder.Eventf(kfsvc, v1.EventTypeWarning, "InternalError", err.Error())
 			return reconcile.Result{}, err
 		}

--- a/pkg/controller/kfservice/kfservice_controller.go
+++ b/pkg/controller/kfservice/kfservice_controller.go
@@ -132,30 +132,30 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 
 	serviceReconciler := ksvc.NewServiceReconciler(r.Client)
 	// Reconcile configurations
-	desiredDefaultConfiguration, desiredCanaryConfiguration := resources.CreateKnativeConfiguration(kfsvc)
+	desiredDefault, desiredCanary := resources.CreateKnativeConfiguration(kfsvc)
 
-	if err := controllerutil.SetControllerReference(kfsvc, desiredDefaultConfiguration, r.scheme); err != nil {
+	if err := controllerutil.SetControllerReference(kfsvc, desiredDefault, r.scheme); err != nil {
 		return reconcile.Result{}, err
 	}
 
-	if desiredCanaryConfiguration != nil {
-		if err := controllerutil.SetControllerReference(kfsvc, desiredCanaryConfiguration, r.scheme); err != nil {
+	if desiredCanary != nil {
+		if err := controllerutil.SetControllerReference(kfsvc, desiredCanary, r.scheme); err != nil {
 			return reconcile.Result{}, err
 		}
 	}
 
-	defaultConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredDefaultConfiguration)
+	defaultConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredDefault)
 	if err != nil {
-		log.Error(err, "Failed to reconcile default model spec", "name", desiredDefaultConfiguration.Name)
+		log.Error(err, "Failed to reconcile default model spec", "name", desiredDefault.Name)
 		r.Recorder.Eventf(kfsvc, v1.EventTypeWarning, "InternalError", err.Error())
 		return reconcile.Result{}, err
 	}
 	kfsvc.Status.PropagateDefaultConfigurationStatus(&defaultConfiguration.Status)
 
-	if desiredCanaryConfiguration != nil {
-		canaryConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredCanaryConfiguration)
+	if desiredCanary != nil {
+		canaryConfiguration, err := serviceReconciler.ReconcileConfiguarion(context.TODO(), desiredCanary)
 		if err != nil {
-			log.Error(err, "Failed to reconcile canary model spec", "name", desiredCanaryConfiguration.Name)
+			log.Error(err, "Failed to reconcile canary model spec", "name", desiredCanary.Name)
 			r.Recorder.Eventf(kfsvc, v1.EventTypeWarning, "InternalError", err.Error())
 			return reconcile.Result{}, err
 		}

--- a/pkg/reconciler/ksvc/reconciler.go
+++ b/pkg/reconciler/ksvc/reconciler.go
@@ -69,6 +69,8 @@ func (c *ServiceReconciler) ReconcileConfiguarion(ctx context.Context, desiredCo
 	log.Info("Reconciling configuration diff (-desired, +observed): %s", "diff", diff)
 
 	configuration.Spec = desiredConfiguration.Spec
+	configuration.ObjectMeta.Labels = desiredConfiguration.ObjectMeta.Labels
+	configuration.ObjectMeta.Annotations = desiredConfiguration.ObjectMeta.Annotations
 	log.Info("Updating configuration", "namespace", configuration.Namespace, "name", configuration.Name)
 	err = c.client.Update(context.TODO(), configuration)
 	if err != nil {
@@ -101,6 +103,8 @@ func (c *ServiceReconciler) ReconcileRoute(ctx context.Context, desiredRoute *kn
 	log.Info("Reconciling route diff (-desired, +observed): %s", "diff", diff)
 
 	route.Spec = desiredRoute.Spec
+	route.ObjectMeta.Labels = desiredRoute.ObjectMeta.Labels
+	route.ObjectMeta.Annotations = desiredRoute.ObjectMeta.Annotations
 	log.Info("Updating route", "namespace", route.Namespace, "name", route.Name)
 	err = c.client.Update(context.TODO(), route)
 	if err != nil {

--- a/pkg/reconciler/ksvc/reconciler_test.go
+++ b/pkg/reconciler/ksvc/reconciler_test.go
@@ -111,6 +111,38 @@ func TestKnativeConfigurationReconcile(t *testing.T) {
 				},
 			},
 		},
+		"Reconcile new labels and annotations": {
+                        update: true,
+                        desiredConfiguration: &knservingv1alpha1.Configuration{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:      "mnist",
+                                        Namespace: "default",
+                                        Labels: map[string]string{
+                                                "serving.knative.dev/configuration": "dream",
+                                        },
+                                        Annotations: map[string]string{
+                                                "serving.knative.dev/lastPinned": "1111111111",
+                                        },
+                                },
+                                Spec: knservingv1alpha1.ConfigurationSpec{
+                                        RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+                                                Spec: knservingv1alpha1.RevisionSpec{
+                                                        Container: &v1.Container{
+                                                                Image: tensorflow.TensorflowServingImageName + ":" +
+                                                                        v1alpha1.DefaultTensorflowVersion,
+                                                                Command: []string{tensorflow.TensorflowEntrypointCommand},
+                                                                Args: []string{
+                                                                        "--port=" + tensorflow.TensorflowServingGRPCPort,
+                                                                        "--rest_api_port=" + tensorflow.TensorflowServingRestPort,
+                                                                        "--model_name=mnist",
+                                                                        "--model_base_path=s3://test/mnist/export",
+                                                                },
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                },
 	}
 
 	serviceReconciler := NewServiceReconciler(c)
@@ -127,7 +159,7 @@ func TestKnativeConfigurationReconcile(t *testing.T) {
 			if err != nil {
 				t.Errorf("Test %q failed: returned error: %v", name, err)
 			}
-			if diff := cmp.Diff(scenario.desiredConfiguration.Spec, configuration.Spec); diff != "" {
+			if diff := cmp.Diff(scenario.desiredConfiguration, configuration); diff != "" {
 				t.Errorf("Test %q unexpected configuration (-want +got): %v", name, diff)
 			}
 		}
@@ -202,6 +234,31 @@ func TestKnativeRouteReconcile(t *testing.T) {
 				},
 			},
 		},
+		"Reconcile new labels and annotations": {
+                        update: true,
+                        desiredRoute: &knservingv1alpha1.Route{
+                                ObjectMeta: metav1.ObjectMeta{
+                                        Name:        "mnist",
+                                        Namespace:   "default",
+                                        Labels:      map[string]string{
+                                                "serving.knative.dev/route": "dream",
+                                        },
+                                        Annotations: map[string]string{
+                                                "cherub": "rock",
+                                        },
+                                },
+                                Spec: knservingv1alpha1.RouteSpec{
+                                        Traffic: []knservingv1alpha1.TrafficTarget{
+                                                {
+                                                        TrafficTarget: v1beta1.TrafficTarget{
+                                                                ConfigurationName: "mnist-default",
+                                                                Percent:           100,
+                                                        },
+                                                },
+                                        },
+                                },
+                        },
+                },
 	}
 
 	serviceReconciler := NewServiceReconciler(c)
@@ -218,7 +275,7 @@ func TestKnativeRouteReconcile(t *testing.T) {
 			if err != nil {
 				t.Errorf("Test %q failed: returned error: %v", name, err)
 			}
-			if diff := cmp.Diff(scenario.desiredRoute.Spec, route.Spec); diff != "" {
+			if diff := cmp.Diff(scenario.desiredRoute, route); diff != "" {
 				t.Errorf("Test %q unexpected configuration (-want +got): %v", name, diff)
 			}
 		}


### PR DESCRIPTION
for knative serving,  it reconciles `Labels` of configuration and route, not just spec. refer to [here](https://github.com/knative/serving/blob/master/pkg/reconciler/service/service.go#L414)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/64)
<!-- Reviewable:end -->
