### PR TITLE
Fix default tensorflow image

### DIFF
--- a/pkg/apis/serving/v1alpha1/kfservice_defaults.go
+++ b/pkg/apis/serving/v1alpha1/kfservice_defaults.go
@@ -7,9 +7,9 @@ import (
 
 // Default Values
 var (
-	DefaultTensorflowVersion  = "1.13.0"
-	DefaultXGBoostVersion     = "1.12"
-	DefaultScikitLearnVersion = "1.12"
+	DefaultTensorflowServingVersion  = "1.13.0"
+	DefaultXGBoostServingVersion     = "0.1.0"
+	DefaultScikitLearnServingVersion = "0.1.0"
 
 	DefaultMemoryRequests = resource.MustParse("2Gi")
 	DefaultCPURequests    = resource.MustParse("1")
@@ -38,21 +38,21 @@ func setModelSpecDefaults(modelSpec *ModelSpec) {
 
 func setTensorflowDefaults(tensorflowSpec *TensorflowSpec) {
 	if tensorflowSpec.RuntimeVersion == "" {
-		tensorflowSpec.RuntimeVersion = DefaultTensorflowVersion
+		tensorflowSpec.RuntimeVersion = DefaultTensorflowServingVersion
 	}
 	setResourceRequirementDefaults(&tensorflowSpec.Resources)
 }
 
 func setXGBoostDefaults(xgBoostSpec *XGBoostSpec) {
 	if xgBoostSpec.RuntimeVersion == "" {
-		xgBoostSpec.RuntimeVersion = DefaultXGBoostVersion
+		xgBoostSpec.RuntimeVersion = DefaultXGBoostServingVersion
 	}
 	setResourceRequirementDefaults(&xgBoostSpec.Resources)
 }
 
 func setScikitLearnDefaults(scikitLearnSpec *ScikitLearnSpec) {
 	if scikitLearnSpec.RuntimeVersion == "" {
-		scikitLearnSpec.RuntimeVersion = DefaultScikitLearnVersion
+		scikitLearnSpec.RuntimeVersion = DefaultScikitLearnServingVersion
 	}
 	setResourceRequirementDefaults(&scikitLearnSpec.Resources)
 }

--- a/pkg/apis/serving/v1alpha1/kfservice_defaults.go
+++ b/pkg/apis/serving/v1alpha1/kfservice_defaults.go
@@ -7,7 +7,7 @@ import (
 
 // Default Values
 var (
-	DefaultTensorflowVersion  = "1.12"
+	DefaultTensorflowVersion  = "1.13.0"
 	DefaultXGBoostVersion     = "1.12"
 	DefaultScikitLearnVersion = "1.12"
 


### PR DESCRIPTION
- version 1.12 does not exist and upgrade to 1.13.0 which starts to support REST call.
- these versions later should be moved to configmap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/66)
<!-- Reviewable:end -->
