### PR TITLE
Add Developer guide for KFServing

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -120,12 +120,16 @@ kubectl get pods -n kubeflow-system -l control-plane=kfserving-controller-manage
 NAME                             READY   STATUS    RESTARTS   AGE
 kfserving-controller-manager-0   2/2     Running   0          13m
 ```
-- **Note**: By default it installs to `kubeflow-system` namespace.
+- **Note**: By default it installs to `kubeflow-system` namespace with the published
+`kfserving-controller-manager` image.
 
 ### Deploy KFServing with your own version
 ```bash
 make deploy-test
 ```
+- **Note**: `deploy-test` builds the image from your local code, publishes to `KO_DOCKER_REPO`
+and deploys the `kfserving-controller-manager` with the image digest to your cluster for testing.
+
 
 ### Smoke test after deployment
 ```bash

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -11,7 +11,7 @@ to `kfserving`. Also take a look at:
 
 Follow the instructions below to set up your development environment. Once you
 meet these requirements, you can make changes and
-[deploy your own version of kfserving](#starting-kfserving)!
+[deploy your own version of kfserving](#deploy-kfserving)!
 
 Before submitting a PR, see also [CONTRIBUTING.md](../CONTRIBUTING.md).
 
@@ -120,13 +120,24 @@ kubectl get pods -n kubeflow-system -l control-plane=kfserving-controller-manage
 NAME                             READY   STATUS    RESTARTS   AGE
 kfserving-controller-manager-0   2/2     Running   0          13m
 ```
+- **Note**: By default it installs to `kubeflow-system` namespace.
 
 ### Deploy KFServing with your own version
 ```bash
 make deploy-test
 ```
 
-- **Note**: By default it installs to `kubeflow-system` namespace.
+### Smoke test after deployment
+```bash
+kubectl apply -f docs/samples/tensorflow.yaml
+```
+You should see model serving deployment running under default or your specified namespace.
+
+```console
+kubectl get pods -n default -l serving.knative.dev/configuration=my-model-default
+NAME                                                READY   STATUS    RESTARTS   AGE
+my-model-default-htz8r-deployment-8fd979f9b-w2qbv   3/3     Running   0          10s
+```
 
 ## Iterating
 
@@ -138,7 +149,7 @@ of:
 
   - API type definitions in
     [pkg/apis/serving/v1alpha1/](../pkg/apis/serving/v1alpha1/.),
-  - Types definitions annotated with `// +k8s:deepcopy-gen=true`.
+  - Manifests or kustomize patches stored in [config](../config).
 
 - **If you change a package's deps** (including adding external dep), then you
   must run `dep ensure`.
@@ -147,7 +158,7 @@ These are both idempotent, and we expect that running these at `HEAD` to have no
 diffs. Code generation and dependencies are automatically checked to produce no
 diffs for each pull request.
 
-update-deps.sh runs "dep ensure" command. In some cases, if newer dependencies
+In some cases, if newer dependencies
 are required, you need to run "dep ensure -update package-name" manually.
 
 Once the codegen and dependency information is correct, redeploying the

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -1,3 +1,22 @@
+<!-- START doctoc generated TOC please keep comment here to allow auto update -->
+<!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
+**Table of Contents**  *generated with [DocToc](https://github.com/thlorenz/doctoc)*
+
+- [Development](#development)
+  - [Prerequisites](#prerequisites)
+    - [Install requirements](#install-requirements)
+    - [Install Knative on a Kubernetes cluster](#install-knative-on-a-kubernetes-cluster)
+    - [Setup your environment](#setup-your-environment)
+    - [Checkout your fork](#checkout-your-fork)
+  - [Deploy KFServing](#deploy-kfserving)
+    - [Check Knative Serving installation](#check-knative-serving-installation)
+    - [Deploy KFServing from default](#deploy-kfserving-from-default)
+    - [Deploy KFServing with your own version](#deploy-kfserving-with-your-own-version)
+    - [Smoke test after deployment](#smoke-test-after-deployment)
+  - [Iterating](#iterating)
+
+<!-- END doctoc generated TOC please keep comment here to allow auto update -->
+
 # Development
 
 This doc explains how to setup a development environment so you can get started
@@ -14,11 +33,6 @@ meet these requirements, you can make changes and
 [deploy your own version of kfserving](#deploy-kfserving)!
 
 Before submitting a PR, see also [CONTRIBUTING.md](../CONTRIBUTING.md).
-
-### Sign up for GitHub
-
-Start by creating [a GitHub account](https://github.com/join), then setup
-[GitHub access via SSH](https://help.github.com/articles/connecting-to-github-with-ssh/).
 
 ### Install requirements
 
@@ -89,7 +103,7 @@ To check out this repository:
 mkdir -p ${GOPATH}/src/github.com/kubeflow
 cd ${GOPATH}/src/github.com/kubeflow
 git clone git@github.com:${YOUR_GITHUB_USERNAME}/kfserving.git
-cd serving
+cd kfserving
 git remote add upstream git@github.com:kubeflow/kfserving.git
 git remote set-url --push upstream no_push
 ```
@@ -106,7 +120,7 @@ described below.
 Once you've [setup your development environment](#prerequisites), you can see things running with:
 
 ```console
-kubectl -n knative-serving get pods
+$ kubectl -n knative-serving get pods
 NAME                          READY     STATUS    RESTARTS   AGE
 activator-c8495dc9-z7xpz      2/2       Running   0          6d
 autoscaler-66897845df-t5cwg   2/2       Running   0          6d
@@ -121,7 +135,7 @@ make deploy
 
 After above step you can see things running with:
 ```console
-kubectl get pods -n kubeflow-system -l control-plane=kfserving-controller-manager
+$ kubectl get pods -n kubeflow-system -l control-plane=kfserving-controller-manager
 NAME                             READY   STATUS    RESTARTS   AGE
 kfserving-controller-manager-0   2/2     Running   0          13m
 ```
@@ -130,9 +144,9 @@ kfserving-controller-manager-0   2/2     Running   0          13m
 
 ### Deploy KFServing with your own version
 ```bash
-make deploy-test
+make deploy-dev
 ```
-- **Note**: `deploy-test` builds the image from your local code, publishes to `KO_DOCKER_REPO`
+- **Note**: `deploy-dev` builds the image from your local code, publishes to `KO_DOCKER_REPO`
 and deploys the `kfserving-controller-manager` with the image digest to your cluster for testing.
 
 
@@ -143,7 +157,7 @@ kubectl apply -f docs/samples/tensorflow.yaml
 You should see model serving deployment running under default or your specified namespace.
 
 ```console
-kubectl get pods -n default -l serving.knative.dev/configuration=my-model-default
+$ kubectl get pods -n default -l serving.knative.dev/configuration=my-model-default
 NAME                                                READY   STATUS    RESTARTS   AGE
 my-model-default-htz8r-deployment-8fd979f9b-w2qbv   3/3     Running   0          10s
 ```
@@ -175,5 +189,5 @@ Once the codegen and dependency information is correct, redeploying the
 controller is simply:
 
 ```shell
-make deploy-test
+make deploy-dev
 ```

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -24,20 +24,24 @@ Start by creating [a GitHub account](https://github.com/join), then setup
 
 You must install these tools:
 
-1. [`go`](https://golang.org/doc/install): KFServing controller is written in Go
-1. [`git`](https://help.github.com/articles/set-up-git/): For source control
+1. [`go`](https://golang.org/doc/install): KFServing controller is written in Go.
+1. [`git`](https://help.github.com/articles/set-up-git/): For source control.
 1. [`dep`](https://github.com/golang/dep): For managing external Go
    dependencies.
 1. [`ko`](https://github.com/google/ko):
    For development.
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
    managing development environments.
+1. [`kustomize`](https://github.com/kubernetes-sigs/kustomize/) To customize YAMLs for different environments
 
 ### Install Knative on a Kubernetes cluster
 
-1. [Set up a kubernetes cluster and install Knative](https://knative.dev/docs/install/)
+1. [Set up a kubernetes cluster and install Knative Serving](https://knative.dev/docs/install/)
 
-This step is required since `KFServing` relies on `Knative Serving` for serving the ML models.
+- **Note**: KFServing currently only requires `Knative Serving` for auto-scaling, canary rollout,
+ `Istio` for traffic routing and ingress. You can follow instructions on
+ [Custom Install](https://knative.dev/docs/install/knative-custom-install) to install `Istio` and `Knative Serving`,
+ observability plug-ins are good to have for monitoring.
 
 ### Setup your environment
 
@@ -55,6 +59,7 @@ recommend adding them to your `.bashrc`):
 the authentication methods and repository paths mentioned in the sections below.
    - [Google Container Registry quickstart](https://cloud.google.com/container-registry/docs/pushing-and-pulling)
    - [Docker Hub quickstart](https://docs.docker.com/docker-hub/)
+   - [Azure Container Registry quickstart](https://docs.microsoft.com/en-us/azure/container-registry/container-registry-get-started-portal)
 - **Note**: if you are using docker hub to store your images your
   `KO_DOCKER_REPO` variable should be `docker.io/<username>`.
 - **Note**: Currently Docker Hub doesn't let you create subdirs under your
@@ -156,7 +161,8 @@ of:
   - Manifests or kustomize patches stored in [config](../config).
 
 - **If you change a package's deps** (including adding external dep), then you
-  must run `dep ensure`.
+  must run `dep ensure`. Dependency changes should be a separate commit and not
+  mixed with logic changes.
 
 These are both idempotent, and we expect that running these at `HEAD` to have no
 diffs. Code generation and dependencies are automatically checked to produce no

--- a/test/README.md
+++ b/test/README.md
@@ -1,0 +1,23 @@
+# Test
+
+This directory contains tests and testing docs for `KFServing`:
+
+- [Unit tests](#running-unit-tests) currently reside in the codebase alongside
+  the code they test
+- [End-to-end tests](#running-end-to-end-tests):
+  - They are in [`/test/e2e`](./e2e)
+
+## Running unit/integration tests
+
+To run all unit tests:
+
+```bash
+make test
+```
+
+## Running end to end tests
+
+To run [the e2e tests](./e2e), you
+need to have a running environment that meets the e2e test environment requirements. (@TODO)
+
+

--- a/test/README.md
+++ b/test/README.md
@@ -7,6 +7,10 @@ This directory contains tests and testing docs for `KFServing`:
 - [End-to-end tests](#running-end-to-end-tests):
   - They are in [`/test/e2e`](./e2e)
 
+## Prerequisite
+`kfserving-controller-manager` has a few integration tests which requires mock apiserver
+and etcd, they get installed along with [`kubebuilder`](https://book.kubebuilder.io/getting_started/installation_and_setup.html).
+
 ## Running unit/integration tests
 
 To run all unit tests:


### PR DESCRIPTION
- Add perquisite installation guide
- Add test/deploy iteration guide
- Note that `make deploy-test` is introduced in https://github.com/kubeflow/kfserving/pull/65

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/67)
<!-- Reviewable:end -->
