### PR TITLE
Remove DEPRECATED RevisionTemplate

### DIFF
--- a/pkg/controller/kfservice/kfservice_controller_test.go
+++ b/pkg/controller/kfservice/kfservice_controller_test.go
@@ -139,7 +139,7 @@ func TestReconcile(t *testing.T) {
 			Namespace: instance.Namespace,
 		},
 		Spec: knservingv1alpha1.ConfigurationSpec{
-			RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+			Template: &knservingv1alpha1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"serving.kubeflow.org/kfservice": "foo"},
 				},
@@ -231,7 +231,7 @@ func TestCanaryReconcile(t *testing.T) {
 			Namespace: canary.Namespace,
 		},
 		Spec: knservingv1alpha1.ConfigurationSpec{
-			RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+			Template: &knservingv1alpha1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: map[string]string{"serving.kubeflow.org/kfservice": "bar"},
 				},

--- a/pkg/reconciler/ksvc/reconciler_test.go
+++ b/pkg/reconciler/ksvc/reconciler_test.go
@@ -37,7 +37,7 @@ func TestKnativeConfigurationReconcile(t *testing.T) {
 			Namespace: "default",
 		},
 		Spec: knservingv1alpha1.ConfigurationSpec{
-			RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+			Template: &knservingv1alpha1.RevisionTemplateSpec{
 				Spec: knservingv1alpha1.RevisionSpec{
 					Container: &v1.Container{
 						Image: tensorflow.TensorflowServingImageName + ":" +
@@ -68,7 +68,7 @@ func TestKnativeConfigurationReconcile(t *testing.T) {
 					Namespace: "default",
 				},
 				Spec: knservingv1alpha1.ConfigurationSpec{
-					RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+					Template: &knservingv1alpha1.RevisionTemplateSpec{
 						Spec: knservingv1alpha1.RevisionSpec{
 							Container: &v1.Container{
 								Image: tensorflow.TensorflowServingImageName + ":" +
@@ -100,7 +100,7 @@ func TestKnativeConfigurationReconcile(t *testing.T) {
 					},
 				},
 				Spec: knservingv1alpha1.ConfigurationSpec{
-					RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+					Template: &knservingv1alpha1.RevisionTemplateSpec{
 						Spec: knservingv1alpha1.RevisionSpec{
 							Container: &v1.Container{
 								Image: tensorflow.TensorflowServingImageName + ":" +

--- a/pkg/reconciler/ksvc/resources/knative_configuration.go
+++ b/pkg/reconciler/ksvc/resources/knative_configuration.go
@@ -43,7 +43,7 @@ func CreateKnativeConfiguration(kfsvc *v1alpha1.KFService) (*knservingv1alpha1.C
 			Annotations: union(kfsvc.Annotations, annotations),
 		},
 		Spec: knservingv1alpha1.ConfigurationSpec{
-			RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+			Template: &knservingv1alpha1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
 					Labels: union(kfsvc.Labels, map[string]string{
 						constants.KFServicePodLabelKey: kfsvc.Name,
@@ -66,7 +66,7 @@ func CreateKnativeConfiguration(kfsvc *v1alpha1.KFService) (*knservingv1alpha1.C
 				Annotations: union(kfsvc.Annotations, annotations),
 			},
 			Spec: knservingv1alpha1.ConfigurationSpec{
-				RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+				Template: &knservingv1alpha1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
 						Labels: union(kfsvc.Labels, map[string]string{
 							constants.KFServicePodLabelKey: kfsvc.Name,

--- a/pkg/reconciler/ksvc/resources/knative_configuration_test.go
+++ b/pkg/reconciler/ksvc/resources/knative_configuration_test.go
@@ -52,7 +52,7 @@ var defaultConfiguration = knservingv1alpha1.Configuration{
 		Annotations: map[string]string{"autoscaling.knative.dev/maxScale": "3", "autoscaling.knative.dev/minScale": "1"},
 	},
 	Spec: knservingv1alpha1.ConfigurationSpec{
-		RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+		Template: &knservingv1alpha1.RevisionTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{"serving.kubeflow.org/kfservice": "mnist"},
 			},
@@ -79,7 +79,7 @@ var canaryConfiguration = knservingv1alpha1.Configuration{
 		Annotations: map[string]string{"autoscaling.knative.dev/maxScale": "3", "autoscaling.knative.dev/minScale": "1"},
 	},
 	Spec: knservingv1alpha1.ConfigurationSpec{
-		RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+		Template: &knservingv1alpha1.RevisionTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
 				Labels: map[string]string{"serving.kubeflow.org/kfservice": "mnist"},
 			},
@@ -166,7 +166,7 @@ func TestKnativeConfiguration(t *testing.T) {
 					Annotations: map[string]string{},
 				},
 				Spec: knservingv1alpha1.ConfigurationSpec{
-					RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+					Template: &knservingv1alpha1.RevisionTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
 							Labels: map[string]string{"serving.kubeflow.org/kfservice": "scikit"},
 						},


### PR DESCRIPTION
`RevisionTemplate` field is dropped now, `Template` replaced it instead in Knative serving

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/78)
<!-- Reviewable:end -->
