### PR TITLE
Enables outbound traffic by default to allow model downloading

### DIFF
--- a/pkg/controller/kfservice/kfservice_controller_test.go
+++ b/pkg/controller/kfservice/kfservice_controller_test.go
@@ -141,7 +141,8 @@ func TestReconcile(t *testing.T) {
 		Spec: knservingv1alpha1.ConfigurationSpec{
 			RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"serving.kubeflow.org/kfservice": "foo"},
+					Labels:      map[string]string{"serving.kubeflow.org/kfservice": "foo"},
+					Annotations: map[string]string{"traffic.sidecar.istio.io/includeOutboundIPRanges": ""},
 				},
 				Spec: knservingv1alpha1.RevisionSpec{
 					Container: &v1.Container{
@@ -233,7 +234,8 @@ func TestCanaryReconcile(t *testing.T) {
 		Spec: knservingv1alpha1.ConfigurationSpec{
 			RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
 				ObjectMeta: metav1.ObjectMeta{
-					Labels: map[string]string{"serving.kubeflow.org/kfservice": "bar"},
+					Labels:      map[string]string{"serving.kubeflow.org/kfservice": "bar"},
+					Annotations: map[string]string{"traffic.sidecar.istio.io/includeOutboundIPRanges": ""},
 				},
 				Spec: knservingv1alpha1.RevisionSpec{
 					Container: &v1.Container{

--- a/pkg/reconciler/ksvc/resources/knative_configuration_test.go
+++ b/pkg/reconciler/ksvc/resources/knative_configuration_test.go
@@ -54,7 +54,8 @@ var defaultConfiguration = knservingv1alpha1.Configuration{
 	Spec: knservingv1alpha1.ConfigurationSpec{
 		RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"serving.kubeflow.org/kfservice": "mnist"},
+				Labels:      map[string]string{"serving.kubeflow.org/kfservice": "mnist"},
+				Annotations: map[string]string{"traffic.sidecar.istio.io/includeOutboundIPRanges": ""},
 			},
 			Spec: knservingv1alpha1.RevisionSpec{
 				Container: &v1.Container{
@@ -81,7 +82,8 @@ var canaryConfiguration = knservingv1alpha1.Configuration{
 	Spec: knservingv1alpha1.ConfigurationSpec{
 		RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
 			ObjectMeta: metav1.ObjectMeta{
-				Labels: map[string]string{"serving.kubeflow.org/kfservice": "mnist"},
+				Labels:      map[string]string{"serving.kubeflow.org/kfservice": "mnist"},
+				Annotations: map[string]string{"traffic.sidecar.istio.io/includeOutboundIPRanges": ""},
 			},
 			Spec: knservingv1alpha1.RevisionSpec{
 				Container: &v1.Container{
@@ -168,7 +170,8 @@ func TestKnativeConfiguration(t *testing.T) {
 				Spec: knservingv1alpha1.ConfigurationSpec{
 					RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
 						ObjectMeta: metav1.ObjectMeta{
-							Labels: map[string]string{"serving.kubeflow.org/kfservice": "scikit"},
+							Labels:      map[string]string{"serving.kubeflow.org/kfservice": "scikit"},
+							Annotations: map[string]string{"traffic.sidecar.istio.io/includeOutboundIPRanges": ""},
 						},
 						Spec: knservingv1alpha1.RevisionSpec{
 							Container: &v1.Container{


### PR DESCRIPTION
Eventually we may want to bake the models into the image to avoid this workaround. This may cause other challenges with multi-model-serving. Either way, this workaround is necessary for now.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/83)
<!-- Reviewable:end -->
