### PR TITLE
Made python kfserving.storage return uri if local path exists

### DIFF
--- a/docs/samples/sklearn/README.md
+++ b/docs/samples/sklearn/README.md
@@ -16,7 +16,7 @@ dump(clf, 'model.joblib')
 Then, we can run the Scikit-learn Server using the generated model and test for prediction. Models can be on local filesystem, S3 compatible object storage or Google Cloud Storage.
 
 ```shell
-python -m sklearnserver --model_dir file://model.joblib --model_name svm
+python -m sklearnserver --model_dir model.joblib --model_name svm
 ```
 
 We can also use the inbuilt sklearn support for sample datasets and do some simple predictions

--- a/docs/samples/sklearn/README.md
+++ b/docs/samples/sklearn/README.md
@@ -16,7 +16,7 @@ dump(clf, 'model.joblib')
 Then, we can run the Scikit-learn Server using the generated model and test for prediction. Models can be on local filesystem, S3 compatible object storage or Google Cloud Storage.
 
 ```shell
-python -m sklearnserver --model_dir model.joblib --model_name svm
+python -m sklearnserver --model_dir file://model.joblib --model_name svm
 ```
 
 We can also use the inbuilt sklearn support for sample datasets and do some simple predictions

--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -2,7 +2,7 @@
 
 KFServing is a unit of model serving. KFServing's python libraries implement a standardized KFServer library that is extended by model serving frameworks such as XGBoost and PyTorch. It encapsulates data plane API definitions and storage retrieval for models.
 
-KFServing provides many funtionalities, including among others:
+KFServing provides many functionalities, including among others:
 
 * Registering a model and starting the server
 * Prediction Handler
@@ -13,9 +13,10 @@ KFServing supports the following storage providers:
 
 * Google Cloud Storage with a prefix: "gs://"
 * S3 Compatible Object Storage with a prefix "s3://"
-* Local filesystem either with a prefix "file://" or without any prefix. For example:
-    * Absolute path: `file:///absolute/path` or `/absolute/path`
-    * Relative path: `file://relative/path` or `relative/path`
+* Local filesystem either without any prefix or with a prefix "file://". For example:
+    * Absolute path: `/absolute/path` or `file:///absolute/path`
+    * Relative path: `relative/path` or `file://relative/path`
+    * For local filesystem, we recommended to use relative path without any prefix.
 
 To start the server locally on your machine for development needs, run the following command under this folder
 

--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -6,14 +6,14 @@ KFServing provides many funtionalities, including among others:
 
 * Registering a model and starting the server
 * Prediction Handler
-* Liveness Handler 
-* Metrics Handler 
+* Liveness Handler
+* Metrics Handler
 
 KFServing supports the following storage providers:
 
 * Google Cloud Storage with a prefix: "gs://"
 * S3 Compatible Object Storage with a prefix "s3://"
-* Local filesystem with a prefix "/"
+* Local filesystem with a prefix "file://"
 
 To start the server locally on your machine for development needs, run the following command under this folder
 

--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -13,7 +13,9 @@ KFServing supports the following storage providers:
 
 * Google Cloud Storage with a prefix: "gs://"
 * S3 Compatible Object Storage with a prefix "s3://"
-* Local filesystem with a prefix "file://"
+* Local filesystem with a prefix "file://". For example:
+    * With absolute path: `file:///absolute/path`
+    * With relative path: `file://./relative/path` or `file://relative/path`
 
 To start the server locally on your machine for development needs, run the following command under this folder
 

--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -13,9 +13,9 @@ KFServing supports the following storage providers:
 
 * Google Cloud Storage with a prefix: "gs://"
 * S3 Compatible Object Storage with a prefix "s3://"
-* Local filesystem with a prefix "file://". For example:
-    * With absolute path: `file:///absolute/path`
-    * With relative path: `file://./relative/path` or `file://relative/path`
+* Local filesystem either with a prefix "file://" or without any prefix. For example:
+    * Absolute path: `file:///absolute/path` or `/absolute/path`
+    * Relative path: `file://relative/path` or `relative/path`
 
 To start the server locally on your machine for development needs, run the following command under this folder
 

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -1,5 +1,6 @@
 import logging
 import tempfile
+import os
 
 _GCS_PREFIX = "gs://"
 _S3_PREFIX = "s3://"
@@ -10,7 +11,7 @@ class Storage(object):
     @staticmethod
     def download(uri: str) -> str:
         logging.info("Copying contents of %s to local" % uri)
-        if uri.startswith(_LOCAL_PREFIX):
+        if uri.startswith(_LOCAL_PREFIX) or os.path.exists(uri):
             return uri
 
         temp_dir = tempfile.mkdtemp()

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -4,15 +4,15 @@ import os
 
 _GCS_PREFIX = "gs://"
 _S3_PREFIX = "s3://"
-_LOCAL_PREFIX = "/"
+_LOCAL_PREFIX = "file://"
 
 
 class Storage(object):
     @staticmethod
     def download(uri: str) -> str:
         logging.info("Copying contents of %s to local" % uri)
-        if uri.startswith(_LOCAL_PREFIX) or os.path.exists(uri):
-            return uri
+        if uri.startswith(_LOCAL_PREFIX):
+            return Storage._download_local(uri)
 
         temp_dir = tempfile.mkdtemp()
         if uri.startswith(_GCS_PREFIX):
@@ -20,7 +20,9 @@ class Storage(object):
         elif uri.startswith(_S3_PREFIX):
             Storage._download_s3(uri, temp_dir)
         else:
-            raise Exception("Cannot recognize storage type for " + uri)
+            raise Exception("Cannot recognize storage type for " + uri +
+                            "\n'%s', '%s', and '%s' are the current available storage type." %
+                            (_GCS_PREFIX, _S3_PREFIX, _LOCAL_PREFIX))
 
         logging.info("Successfully copied %s to %s" % (uri, temp_dir))
         return temp_dir
@@ -32,3 +34,10 @@ class Storage(object):
     @staticmethod
     def _download_gcs(uri, temp_dir: str):
         raise NotImplementedError
+
+    @staticmethod
+    def _download_local(uri):
+        local_path = uri.replace(_LOCAL_PREFIX, "", 1)
+        if not os.path.exists(local_path):
+            raise Exception("Local path %s does not exist." % (uri))
+        return local_path

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -11,7 +11,7 @@ class Storage(object):
     @staticmethod
     def download(uri: str) -> str:
         logging.info("Copying contents of %s to local" % uri)
-        if uri.startswith(_LOCAL_PREFIX):
+        if uri.startswith(_LOCAL_PREFIX) or os.path.exists(uri):
             return Storage._download_local(uri)
 
         temp_dir = tempfile.mkdtemp()

--- a/python/kfserving/kfserving/test_storage.py
+++ b/python/kfserving/kfserving/test_storage.py
@@ -1,0 +1,8 @@
+import pytest
+import kfserving
+
+def test_storage_local_path():
+    abs_path = '/tmp/file'
+    relative_path = '.'
+    assert kfserving.Storage.download(abs_path) == abs_path
+    assert kfserving.Storage.download(relative_path) == relative_path

--- a/python/kfserving/kfserving/test_storage.py
+++ b/python/kfserving/kfserving/test_storage.py
@@ -13,3 +13,10 @@ def test_storage_local_path_exception():
     not_exist_path = 'file:///some/random/path'
     with pytest.raises(Exception):
         kfserving.Storage.download(not_exist_path)
+
+
+def test_no_prefix_local_path():
+    abs_path = '/'
+    relative_path = '.'
+    assert kfserving.Storage.download(abs_path) == abs_path
+    assert kfserving.Storage.download(relative_path) == relative_path

--- a/python/kfserving/kfserving/test_storage.py
+++ b/python/kfserving/kfserving/test_storage.py
@@ -1,8 +1,15 @@
 import pytest
 import kfserving
 
+
 def test_storage_local_path():
-    abs_path = '/tmp/file'
-    relative_path = '.'
-    assert kfserving.Storage.download(abs_path) == abs_path
-    assert kfserving.Storage.download(relative_path) == relative_path
+    abs_path = 'file:///'
+    relative_path = 'file://.'
+    assert kfserving.Storage.download(abs_path) == abs_path.replace("file://", "", 1)
+    assert kfserving.Storage.download(relative_path) == relative_path.replace("file://", "", 1)
+
+
+def test_storage_local_path_exception():
+    not_exist_path = 'file:///some/random/path'
+    with pytest.raises(Exception):
+        kfserving.Storage.download(not_exist_path)


### PR DESCRIPTION
The current `kfserving.storage` implementation only takes absolute local paths. It should also apply to any relative/absolute local path that exists on the local system.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/92)
<!-- Reviewable:end -->
