### PR TITLE
Adds Animesh as an Approver

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -2,7 +2,7 @@ approvers:
   - ellis-bigelow
   - yuzisun
   - cliveseldon
+  - animeshsingh
 reviewers:
   - gaocegege
   - rakelkar
-  - animeshsingh


### PR DESCRIPTION
Hey Clive, Dan, and Abhishek, 
Animesh has been helping coordinate IBM resources (Tommy Li, Guang Ya Liu, and Hougang Liu) to help with KFServing. He's been improving our docs to be more cohesive and has contributed sklearn compatibility. He's also made significant contributions to the discussion in KFServing weeklies.

In the interest of maintaining a diverse set of perspectives and a strong foundation of stakeholders from different organizations, I propose adding him as an approver on this project.

I'd like to hold until there is unanimous support from you all. My only reservation is that I'd like to see Animesh (or a representative IBMer) attending our weeklies. It's important that at minimum, all approvers remain on the same page regarding project technical direction and product priorities.

/assign @yuzisun, 
/assign @abhi-g 
/assign @cliveseldon

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/93)
<!-- Reviewable:end -->
