### PR TITLE
Fix test error caused by crds dir changed

### DIFF
--- a/pkg/apis/serving/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/serving/v1alpha1/v1alpha1_suite_test.go
@@ -33,7 +33,7 @@ var c client.Client
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "crds")},
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "..", "config", "default", "crds")},
 	}
 
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)

--- a/pkg/controller/kfservice/kfservice_controller_suite_test.go
+++ b/pkg/controller/kfservice/kfservice_controller_suite_test.go
@@ -38,7 +38,7 @@ var cfg *rest.Config
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds"),
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "default", "crds"),
 			filepath.Join("..", "..", "..", "test", "crds")},
 	}
 	err := apis.AddToScheme(scheme.Scheme)

--- a/pkg/reconciler/ksvc/ksvc_suite_test.go
+++ b/pkg/reconciler/ksvc/ksvc_suite_test.go
@@ -33,7 +33,7 @@ var c client.Client
 
 func TestMain(m *testing.M) {
 	t := &envtest.Environment{
-		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "crds"),
+		CRDDirectoryPaths: []string{filepath.Join("..", "..", "..", "config", "default", "crds"),
 			filepath.Join("..", "..", "..", "test", "crds")},
 	}
 

--- a/prow_config.yaml
+++ b/prow_config.yaml
@@ -9,6 +9,7 @@ workflows:
     include_dirs:
     - pkg/*
     - cmd/*
+    - config/*
     - test/*
     - Dockerfile
     - python/*
@@ -24,6 +25,7 @@ workflows:
     include_dirs:
     - pkg/*
     - cmd/*
+    - config/*
     - test/*
     - Dockerfile
     - python/*


### PR DESCRIPTION
After `config/crds` dir changed, tests which depend on files of it need be updated, too. Also, include `config` dir into prow config to make changes of `config` trigger test, too

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/96)
<!-- Reviewable:end -->
