### PR TITLE
Fix python sklearn test cases with the correct model_dir

### DIFF
--- a/python/sklearnserver/sklearnserver/test_model.py
+++ b/python/sklearnserver/sklearnserver/test_model.py
@@ -4,7 +4,7 @@ from sklearnserver import SKLearnModel
 import joblib
 import os
 
-model_dir = "/path/to/kfserving/docs/samples/sklearn"
+model_dir = "../../docs/samples/sklearn"
 JOBLIB_FILE = "model.joblib"
 
 def test_model():


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Since #92, we now can load files using relative path. This fix makes the python scikit-learn test cases actually work with the correct `model_dir` relative path.

**Special notes for your reviewer**:


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/98)
<!-- Reviewable:end -->
