### PR TITLE
Adds release for automated GitOps triggered image builds for KFServing

### DIFF
--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/kfserving/kfserving-controller-head:latest
+      - image: gcr.io/kfserving/kfserving-controller:master
         name: manager

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: kfserving-controller:latest
+      - image: gcr.io/kfserving/kfserving-controller-head:latest
         name: manager

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/kfserving/kfserving-controller:master
+      - image: gcr.io/kfserving/kfserving-controller:latest
         name: manager

--- a/release/README.md
+++ b/release/README.md
@@ -1,0 +1,10 @@
+# Release Process
+KFServing's automated release processes run in Google Cloud Build under the project `kfserving`. For permissions to this project, please contact ellisbigelow@google.com.
+
+
+## Latest Release
+KFServing's release process relies on Github build triggers in Google Cloud Build. This build trigger was configured manually to execute the configurations in cloud-build-configs. For each build config, whenever a change is made to this repository, a Cloud Build is triggered which rebuilds all relevant images with a tag suffixed with `-head` and pushes them to `gcr.io/kfserving`. For example, `kfserving-controller.cloud-build.yaml` will result in an image called `gcr.io/kfserving/kfserving-controller-head`
+
+## Versioned Releases
+This process is currently TBD, but we will eventually provide releases of the form `gcr.io/kfserving/$IMAGE_NAME-$VERSION`
+

--- a/release/README.md
+++ b/release/README.md
@@ -1,10 +1,12 @@
 # Release Process
 KFServing's automated release processes run in Google Cloud Build under the project `kfserving`. For permissions to this project, please contact ellisbigelow@google.com.
 
+Builds are available at https://console.cloud.google.com/cloud-build/builds?project=kfserving.
+To view builds, you must be a member of kubeflow-discuss@googlegroups.com.
 
 ## Latest Release
-KFServing's release process relies on Github build triggers in Google Cloud Build. This build trigger was configured manually to execute the configurations in cloud-build-configs. For each build config, whenever a change is made to this repository, a Cloud Build is triggered which rebuilds all relevant images with a tag suffixed with `-head` and pushes them to `gcr.io/kfserving`. For example, `kfserving-controller.cloud-build.yaml` will result in an image called `gcr.io/kfserving/kfserving-controller-head`
+KFServing's release process relies on Github build triggers in Google Cloud Build. This build trigger was configured manually to execute the configurations in cloud-build-configs. For each build config, whenever a change is made to this repository, a Cloud Build is triggered which rebuilds all relevant images with a tag and pushes them to `gcr.io/kfserving`. For example, `kfserving-controller.cloud-build.yaml` will result in an image called `gcr.io/kfserving/kfserving-controller:latest`
 
 ## Versioned Releases
-This process is currently TBD, but we will eventually provide releases of the form `gcr.io/kfserving/$IMAGE_NAME-$VERSION`
+This process is currently TBD, but we will eventually provide releases of the form `gcr.io/kfserving/$IMAGE_NAME:$GIT_BRANCH`
 

--- a/release/cloud-build-configs/kfserving-controller.cloud-build.yaml
+++ b/release/cloud-build-configs/kfserving-controller.cloud-build.yaml
@@ -1,0 +1,8 @@
+steps:
+- name: 'gcr.io/cloud-builders/go'
+  args: ['install', './cmd/manager']
+  env: 
+    - 'PROJECT_ROOT=github.com/kubeflow/kfserving'
+- name: 'gcr.io/cloud-builders/docker'
+  args: ['build', '-t', 'gcr.io/kfserving/kfserving-controller-${_VERSION}', '.']
+images: ['gcr.io/kfserving/kfserving-controller-${_VERSION}']

--- a/release/cloud-build-configs/kfserving-controller.cloud-build.yaml
+++ b/release/cloud-build-configs/kfserving-controller.cloud-build.yaml
@@ -1,8 +1,7 @@
 steps:
 - name: 'gcr.io/cloud-builders/go'
   args: ['install', './cmd/manager']
-  env: 
-    - 'PROJECT_ROOT=github.com/kubeflow/kfserving'
+  env:  ['PROJECT_ROOT=github.com/kubeflow/kfserving']
 - name: 'gcr.io/cloud-builders/docker'
-  args: ['build', '-t', 'gcr.io/kfserving/kfserving-controller-${_VERSION}', '.']
-images: ['gcr.io/kfserving/kfserving-controller-${_VERSION}']
+  args: ['build', '-t', 'gcr.io/kfserving/kfserving-controller:latest', '.']
+images: ['gcr.io/kfserving/kfserving-controller:latest']


### PR DESCRIPTION
**What this PR does / why we need it**:
This PR enables images built from HEAD. This will be the foundation of our image versioning system. The images will be provided in gcr.io and paid for by Google until further notice.

**Special notes for your reviewer**:
I was considering going the PROW route, but I'm really not a fan of the kubeflow infrastructure for this. This enables a simple, straightforward, cloudbuilder experience to build images for head.

Of course, our release process will mature over time, but I imagine we being cutting release branches which tag images after successful e2e testing.

**Release note**:
NONE

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/99)
<!-- Reviewable:end -->
