### PR TITLE
Removes kfserving prefix from Kustomize and explicitly applies it to all resources

### DIFF
--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -1,13 +1,6 @@
 # Adds namespace to all resources.
 namespace: kfserving-system
 
-# Value of this field is prepended to the
-# names of all resources, e.g. a deployment named
-# "wordpress" becomes "alices-wordpress".
-# Note that it should also match with the prefix (text before '-') of the namespace
-# field above.
-namePrefix: kfserving-
-
 # Labels to add to all resources and selectors.
 #commonLabels:
 #  someName: someValue
@@ -42,10 +35,3 @@ patches:
   # Only one of manager_auth_proxy_patch.yaml and
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
-
-vars:
-- name: WEBHOOK_SECRET_NAME
-  objref:
-    kind: Secret
-    name: webhook-server-secret
-    apiVersion: v1

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
-  namespace: system
+  name: kfserving-controller-manager
+  namespace: kfserving-system
   labels:
     control-plane: kfserving-controller-manager
     controller-tools.k8s.io: "1.0"
@@ -30,7 +30,7 @@ spec:
               fieldRef:
                 fieldPath: metadata.namespace
           - name: SECRET_NAME
-            value: $(WEBHOOK_SECRET_NAME)
+            value: kfserving-webhook-server-secret
         resources:
           limits:
             cpu: 100m
@@ -51,10 +51,10 @@ spec:
       - name: cert
         secret:
           defaultMode: 420
-          secretName: webhook-server-secret
+          secretName: kfserving-webhook-server-secret
 ---
 apiVersion: v1
 kind: Secret
 metadata:
-  name: webhook-server-secret
-  namespace: system
+  name: kfserving-webhook-server-secret
+  namespace: kfserving-system

--- a/config/default/manager/service.yaml
+++ b/config/default/manager/service.yaml
@@ -5,13 +5,13 @@ metadata:
     control-plane: kfserving-controller-manager
     controller-tools.k8s.io: "1.0"
     istio-injection: disabled
-  name: system
+  name: kfserving-system
 ---
 apiVersion: v1
 kind: Service
 metadata:
-  name: controller-manager-service
-  namespace: system
+  name: kfserving-controller-manager-service
+  namespace: kfserving-system
   labels:
     control-plane: kfserving-controller-manager
     controller-tools.k8s.io: "1.0"

--- a/config/default/manager_auth_proxy_patch.yaml
+++ b/config/default/manager_auth_proxy_patch.yaml
@@ -3,8 +3,8 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
-  namespace: system
+  name: kfserving-controller-manager
+  namespace: kfserving-system
 spec:
   template:
     spec:

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -1,8 +1,8 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
-  namespace: system
+  name: kfserving-controller-manager
+  namespace: kfserving-system
 spec:
   template:
     spec:

--- a/config/default/manager_prometheus_metrics_patch.yaml
+++ b/config/default/manager_prometheus_metrics_patch.yaml
@@ -2,8 +2,8 @@
 apiVersion: apps/v1
 kind: StatefulSet
 metadata:
-  name: controller-manager
-  namespace: system
+  name: kfserving-controller-manager
+  namespace: kfserving-system
 spec:
   template:
     metadata:

--- a/config/default/rbac/auth_proxy_role.yaml
+++ b/config/default/rbac/auth_proxy_role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:
-  name: proxy-role
+  name: kfserving-proxy-role
 rules:
 - apiGroups: ["authentication.k8s.io"]
   resources:

--- a/config/default/rbac/auth_proxy_role_binding.yaml
+++ b/config/default/rbac/auth_proxy_role_binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
-  name: proxy-rolebinding
+  name: kfserving-proxy-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: ClusterRole

--- a/config/default/rbac/auth_proxy_service.yaml
+++ b/config/default/rbac/auth_proxy_service.yaml
@@ -8,8 +8,8 @@ metadata:
   labels:
     control-plane: controller-manager
     controller-tools.k8s.io: "1.0"
-  name: controller-manager-metrics-service
-  namespace: system
+  name: kfserving-controller-manager-metrics-service
+  namespace: kfserving-system
 spec:
   ports:
   - name: https

--- a/image_patch_dev.sh
+++ b/image_patch_dev.sh
@@ -5,7 +5,7 @@ cat > config/overlays/development/manager_image_patch.yaml << EOF
 apiVersion: apps/v1
 kind: StatefulSet 
 metadata:
-  name: controller-manager
+  name: kfserving-controller-manager
 spec:
   template:
     spec:


### PR DESCRIPTION
Kustomize prefix is typically used for namespacing different deployments in the same cluster (i.e., deploying both dev and prod to the same cluster).

I see namespacing based off of our kfserving name as an anti-pattern, as none of these resources should be fundamentally renamed by any consumer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/104)
<!-- Reviewable:end -->
