### PR TITLE
Set ServiceAccount on Knative Configuration

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -1075,6 +1075,7 @@
     "github.com/google/go-cmp/cmp",
     "github.com/knative/pkg/apis/duck/v1alpha1",
     "github.com/knative/pkg/kmp",
+    "github.com/knative/serving/pkg/apis/autoscaling",
     "github.com/knative/serving/pkg/apis/serving",
     "github.com/knative/serving/pkg/apis/serving/v1alpha1",
     "github.com/knative/serving/pkg/apis/serving/v1beta1",

--- a/pkg/reconciler/ksvc/resources/knative_configuration.go
+++ b/pkg/reconciler/ksvc/resources/knative_configuration.go
@@ -18,6 +18,7 @@ package resources
 
 import (
 	"fmt"
+
 	"github.com/knative/serving/pkg/apis/autoscaling"
 	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
 	"github.com/knative/serving/pkg/apis/serving/v1beta1"
@@ -68,6 +69,9 @@ func CreateKnativeConfiguration(name string, metadata metav1.ObjectMeta, modelSp
 						// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 						// we may need to expose this field in future
 						TimeoutSeconds: &constants.DefaultTimeout,
+						PodSpec: v1beta1.PodSpec{
+							ServiceAccountName: modelSpec.ServiceAccountName,
+						},
 					},
 					Container: modelSpec.CreateModelServingContainer(metadata.Name),
 				},

--- a/pkg/reconciler/ksvc/resources/knative_configuration_test.go
+++ b/pkg/reconciler/ksvc/resources/knative_configuration_test.go
@@ -42,6 +42,7 @@ var kfsvc = &v1alpha1.KFService{
 				ModelURI:       "s3://test/mnist/export",
 				RuntimeVersion: "1.13",
 			},
+			ServiceAccountName: "testsvcacc",
 		},
 	},
 }
@@ -65,6 +66,9 @@ var defaultConfiguration = knservingv1alpha1.Configuration{
 			Spec: knservingv1alpha1.RevisionSpec{
 				RevisionSpec: v1beta1.RevisionSpec{
 					TimeoutSeconds: &constants.DefaultTimeout,
+					PodSpec: v1beta1.PodSpec{
+						ServiceAccountName: "testsvcacc",
+					},
 				},
 				Container: &v1.Container{
 					Image:   v1alpha1.TensorflowServingImageName + ":" + kfsvc.Spec.Default.Tensorflow.RuntimeVersion,
@@ -140,6 +144,7 @@ func TestKnativeConfiguration(t *testing.T) {
 							ModelURI:       "s3://test/mnist/export",
 							RuntimeVersion: "1.13",
 						},
+						ServiceAccountName: "testsvcacc",
 					},
 					CanaryTrafficPercent: 20,
 					Canary: &v1alpha1.ModelSpec{


### PR DESCRIPTION
What this PR does / why we need it:
This PR sets the ServiceAccountName on the Kantive Configuration PodSpec.
Enables pulling images from private registries for KfService etc.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/115)
<!-- Reviewable:end -->
