### PR TITLE
Added the python model download methods for S3 and GCS.

### DIFF
--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -12,7 +12,10 @@ KFServing provides many functionalities, including among others:
 KFServing supports the following storage providers:
 
 * Google Cloud Storage with a prefix: "gs://"
+    * By default, it uses `GOOGLE_APPLICATION_CREDENTIALS` environment variable for user authentication.
+    * If the GCS data source is public, `gsutil` will be used to download the artifacts.
 * S3 Compatible Object Storage with a prefix "s3://"
+    * By default, it uses `S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` environment variables for user authentication.
 * Local filesystem either without any prefix or with a prefix "file://". For example:
     * Absolute path: `/absolute/path` or `file:///absolute/path`
     * Relative path: `relative/path` or `file://relative/path`

--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -13,7 +13,7 @@ KFServing supports the following storage providers:
 
 * Google Cloud Storage with a prefix: "gs://"
     * By default, it uses `GOOGLE_APPLICATION_CREDENTIALS` environment variable for user authentication.
-    * If the GCS data source is public, `gsutil` will be used to download the artifacts.
+    * If `GOOGLE_APPLICATION_CREDENTIALS` is not provided, anonymous client will be used to download the artifacts.
 * S3 Compatible Object Storage with a prefix "s3://"
     * By default, it uses `S3_ENDPOINT`, `AWS_ACCESS_KEY_ID`, and `AWS_SECRET_ACCESS_KEY` environment variables for user authentication.
 * Local filesystem either without any prefix or with a prefix "file://". For example:

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -15,10 +15,10 @@
 import logging
 import tempfile
 import os
-import subprocess
 import re
-from minio import Minio, error
-from google.cloud import storage, exceptions
+from minio import Minio
+from google.cloud import storage
+from google.auth import exceptions
 
 _GCS_PREFIX = "gs://"
 _S3_PREFIX = "s3://"
@@ -48,41 +48,33 @@ class Storage(object):
     @staticmethod
     def _download_s3(uri, temp_dir: str):
         client = Storage._create_minio_client()
-        try:
-            bucket_args = uri.replace(_S3_PREFIX, "", 1).split("/", 1)
-            bucket_name = bucket_args[0]
-            bucket_path = bucket_args[1] if len(bucket_args) > 1 else ""
-            objects = client.list_objects(bucket_name, prefix=bucket_path, recursive=True)
-            for obj in objects:
-                object_file_name = obj.object_name.replace(bucket_path, "", 1).strip("/")
-                client.fget_object(bucket_name, obj.object_name, temp_dir + "/" + object_file_name)
-        except error.NoSuchBucket as e:
-            raise error.NoSuchBucket("Bucket is not found, please double check the bucket name.")
-        except error.AccessDenied as e:
-            raise error.AccessDenied("Access Denied. Make sure the S3 credentials has the right access to this bucket.")
+        bucket_args = uri.replace(_S3_PREFIX, "", 1).split("/", 1)
+        bucket_name = bucket_args[0]
+        bucket_path = bucket_args[1] if len(bucket_args) > 1 else ""
+        objects = client.list_objects(bucket_name, prefix=bucket_path, recursive=True)
+        for obj in objects:
+            object_file_name = obj.object_name.replace(bucket_path, "", 1).strip("/")
+            client.fget_object(bucket_name, obj.object_name, temp_dir + "/" + object_file_name)
 
     @staticmethod
     def _download_gcs(uri, temp_dir: str):
         try:
             storage_client = storage.Client()
-            bucket_args = uri.replace(_GCS_PREFIX, "", 1).split("/", 1)
-            bucket_name = bucket_args[0]
-            bucket_path = bucket_args[1] if len(bucket_args) > 1 else ""
-            bucket = storage_client.get_bucket(bucket_name)
-            blobs = bucket.list_blobs(prefix=bucket_path)
-            for blob in blobs:
-                object_file_name = blob.name.replace(bucket_path, "", 1).strip("/")
-                blob.download_to_filename(temp_dir + "/" + object_file_name)
-        except exceptions.Forbidden as e:
-            logging.info("Google cloud storage Python SDK failed. Trying with gsutil to access the data in public")
-            uri_files = uri.strip("/") + "/*"
-            process = subprocess.run(["gsutil", "cp", "-r", uri_files, temp_dir], stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-            logging.info(process.stdout)
-            logging.info(process.stderr)
-            if process.returncode != 0:
-                raise exceptions.Forbidden("gsutil error: files didn't copy to temp_dir. Please double check the GCS path or credentials.")
-        except exceptions.NotFound as e:
-            raise exceptions.NotFound("Bucket is not found, please double check the bucket name.")
+        except exceptions.DefaultCredentialsError as e:
+            storage_client = storage.Client.create_anonymous_client()
+        bucket_args = uri.replace(_GCS_PREFIX, "", 1).split("/", 1)
+        bucket_name = bucket_args[0]
+        bucket_path = bucket_args[1] if len(bucket_args) > 1 else ""
+        bucket = storage_client.bucket(bucket_name)
+        blobs = bucket.list_blobs(prefix=bucket_path)
+        for blob in blobs:
+            object_file_name = blob.name.replace(bucket_path, "", 1).strip("/")
+            # Create necessary subdirectory
+            if "/" in object_file_name:
+                object_file_path = temp_dir + "/" + object_file_name.rsplit("/", 1)[0]
+                if not os.path.isdir(object_file_path):
+                    os.makedirs(object_file_path)
+            blob.download_to_filename(temp_dir + "/" + object_file_name)
 
     @staticmethod
     def _download_local(uri):
@@ -93,13 +85,10 @@ class Storage(object):
 
     @staticmethod
     def _create_minio_client():
-        try:
-            # Remove possible http scheme for Minio
-            url = re.compile(r"https?://")
-            minioClient = Minio(url.sub("", os.getenv("S3_ENDPOINT", "")),
-                                access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),
-                                secret_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-                                secure=True)
-        except IndexError as err:
-            raise IndexError('Error: Incorrect syntax with the S3 endpoint or credentials. \n' + err)
+        # Remove possible http scheme for Minio
+        url = re.compile(r"https?://")
+        minioClient = Minio(url.sub("", os.getenv("S3_ENDPOINT", "")),
+                            access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),
+                            secret_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
+                            secure=True)
         return minioClient

--- a/python/kfserving/kfserving/test_storage.py
+++ b/python/kfserving/kfserving/test_storage.py
@@ -18,15 +18,6 @@ import os
 from minio import error
 from google.cloud import exceptions
 
-# Environment for testing
-GCS_PRIVATE_PATH = 'gs://bucket/path'
-GOOGLE_APPLICATION_CREDENTIALS = ''
-
-S3_PATH = 's3://bucket/path'
-S3_ENDPOINT = ''
-AWS_ACCESS_KEY_ID = ''
-AWS_SECRET_ACCESS_KEY = ''
-
 
 def test_storage_local_path():
     abs_path = 'file:///'
@@ -54,19 +45,15 @@ def test_public_gcs():
 
 
 def test_private_gcs():
-    if GOOGLE_APPLICATION_CREDENTIALS:
-        os.environ["GOOGLE_APPLICATION_CREDENTIALS"] = GOOGLE_APPLICATION_CREDENTIALS
-        assert kfserving.Storage.download(GCS_PRIVATE_PATH)
+    if os.getenv("GOOGLE_APPLICATION_CREDENTIALS", "") and os.getenv("GCS_PRIVATE_PATH", ""):
+        assert kfserving.Storage.download(os.getenv("GCS_PRIVATE_PATH", ""))
     else:
         print('Ignore private GCS bucket test since credentials are not provided')
 
 
 def test_private_s3():
-    if S3_ENDPOINT and AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY:
-        os.environ["S3_ENDPOINT"] = S3_ENDPOINT
-        os.environ["AWS_ACCESS_KEY_ID"] = AWS_ACCESS_KEY_ID
-        os.environ["AWS_SECRET_ACCESS_KEY"] = AWS_SECRET_ACCESS_KEY
-        assert kfserving.Storage.download(S3_PATH)
+    if os.getenv("S3_ENDPOINT", "") and os.getenv("AWS_ACCESS_KEY_ID", "") and os.getenv("AWS_SECRET_ACCESS_KEY", "") and os.getenv("S3_PRIVATE_PATH", ""):
+        assert kfserving.Storage.download(os.getenv("S3_PRIVATE_PATH", ""))
     else:
         print('Ignore S3 bucket test since credentials are not provided')
 

--- a/python/kfserving/kfserving/test_storage.py
+++ b/python/kfserving/kfserving/test_storage.py
@@ -15,6 +15,8 @@
 import pytest
 import kfserving
 import os
+from minio import error
+from google.cloud import exceptions
 
 # Environment for testing
 GCS_PRIVATE_PATH = 'gs://bucket/path'
@@ -72,6 +74,7 @@ def test_private_s3():
 def test_no_permission_buckets():
     bad_s3_path = "s3://random/path"
     bad_gcs_path = "gs://random/path"
-    with pytest.raises(Exception):
+    with pytest.raises(error.AccessDenied):
         kfserving.Storage.download(bad_s3_path)
+    with pytest.raises(exceptions.Forbidden):
         kfserving.Storage.download(bad_gcs_path)

--- a/python/kfserving/kfserving/test_storage.py
+++ b/python/kfserving/kfserving/test_storage.py
@@ -66,13 +66,16 @@ def test_mock_minio(mock_connection, mock_minio):
     assert kfserving.Storage.download(minio_path)
 
 
+@mock.patch('urllib3.PoolManager')
 @mock.patch(STORAGE_MODULE + '.Minio')
-def test_no_permission_buckets(mock_minio):
+def test_no_permission_buckets(mock_connection, mock_minio):
     bad_s3_path = "s3://random/path"
     bad_gcs_path = "gs://random/path"
     # Access private buckets without credentials
     mock_minio.return_value = Minio("s3.us.cloud-object-storage.appdomain.cloud", secure=True)
+    mock_connection.side_effect = error.AccessDenied(None)
     with pytest.raises(error.AccessDenied):
         kfserving.Storage.download(bad_s3_path)
+    mock_connection.side_effect = exceptions.Forbidden(None)
     with pytest.raises(exceptions.Forbidden):
         kfserving.Storage.download(bad_gcs_path)

--- a/python/kfserving/setup.py
+++ b/python/kfserving/setup.py
@@ -33,6 +33,8 @@ setup(
     install_requires=[
         "tornado >= 1.4.1",
         "argparse >= 1.4.0",
+        "minio >= 4.0.9",
+        "google-cloud-storage >= 1.16.0",
         "numpy"
     ],
     tests_require=tests_require,

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -1,14 +1,7 @@
 FROM python:3.7-slim
 
-# gsutil required packages
-RUN apt-get update && apt-get install -y curl lsb-release gnupg
-RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN apt-get update && apt-get install -y google-cloud-sdk
-
 COPY . .
 RUN pip install --upgrade pip && pip install -e ./kfserving
 RUN pip install -e ./sklearnserver
 COPY sklearnserver/model.joblib /tmp/models/model.joblib
-
 ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -1,7 +1,13 @@
 FROM python:3.7-slim
 
+# gsutil required packages
+RUN apt-get update && apt-get install -y curl lsb-release gnupg
+RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+RUN apt-get update && apt-get install -y google-cloud-sdk
+
 COPY . .
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./sklearnserver
-COPY sklearnserver/model.joblib /tmp/models/model.joblib
+RUN pip install -e ./kfserving && pip install -e ./sklearnserver
+COPY model.joblib /tmp/models/model.joblib
+
 ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -7,7 +7,8 @@ RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
 RUN apt-get update && apt-get install -y google-cloud-sdk
 
 COPY . .
-RUN pip install -e ./kfserving && pip install -e ./sklearnserver
-COPY model.joblib /tmp/models/model.joblib
+RUN pip install --upgrade pip && pip install -e ./kfserving
+RUN pip install -e ./sklearnserver
+COPY sklearnserver/model.joblib /tmp/models/model.joblib
 
 ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -1,8 +1,15 @@
 FROM python:3.7-slim
 
-RUN apt-get update && apt-get install libgomp1
+RUN apt-get update && apt-get install -y libgomp1 curl lsb-release gnupg
+
+# gsutil required packages
+RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
+RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
+RUN apt-get update && apt-get install -y google-cloud-sdk
+
+
 COPY . .
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./xgbserver
-COPY xgbserver/model.bst /tmp/models/model.bst
+RUN pip install -e ./kfserving && pip install -e ./xgbserver
+COPY model.bst /tmp/models/model.bst
+
 ENTRYPOINT ["python", "-m", "xgbserver"]

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -9,7 +9,8 @@ RUN apt-get update && apt-get install -y google-cloud-sdk
 
 
 COPY . .
-RUN pip install -e ./kfserving && pip install -e ./xgbserver
-COPY model.bst /tmp/models/model.bst
+RUN pip install --upgrade pip && pip install -e ./kfserving
+RUN pip install -e ./xgbserver
+COPY xgbserver/model.bst /tmp/models/model.bst
 
 ENTRYPOINT ["python", "-m", "xgbserver"]

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -1,16 +1,8 @@
 FROM python:3.7-slim
 
-RUN apt-get update && apt-get install -y libgomp1 curl lsb-release gnupg
-
-# gsutil required packages
-RUN export CLOUD_SDK_REPO="cloud-sdk-$(lsb_release -c -s)" && echo "deb http://packages.cloud.google.com/apt $CLOUD_SDK_REPO main" | tee -a /etc/apt/sources.list.d/google-cloud-sdk.list
-RUN curl https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN apt-get update && apt-get install -y google-cloud-sdk
-
-
+RUN apt-get update && apt-get install libgomp1
 COPY . .
 RUN pip install --upgrade pip && pip install -e ./kfserving
 RUN pip install -e ./xgbserver
 COPY xgbserver/model.bst /tmp/models/model.bst
-
 ENTRYPOINT ["python", "-m", "xgbserver"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR implements the python model download methods for S3 and GCS. Since KFServing can provide S3 and GCS credentials as environment variables, we will be using those environment variables for user authentication.

I also added the gsutil to the docker images since we need it for accessing public GCS data artifacts.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #87

**Special notes for your reviewer**:

1. It would be nice if we can upload the current sklearn and xgboost sample models to the `gs://kfserving-samples` bucket, so we can update the example to use gcs and don't have to include the sample models in the docker image.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/116)
<!-- Reviewable:end -->
