### PR TITLE
update developer guide to correct file path

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -153,14 +153,14 @@ and deploys the `kfserving-controller-manager` with the image digest to your clu
 
 ### Smoke test after deployment
 ```bash
-kubectl apply -f docs/samples/tensorflow.yaml
+kubectl apply -f docs/samples/tensorflow/tensorflow.yaml
 ```
 You should see model serving deployment running under default or your specified namespace.
 
 ```console
-$ kubectl get pods -n default -l serving.kubeflow.org/kfservice=my-model
+$ kubectl get pods -n default -l serving.kubeflow.org/kfservice=flowers-sample
 NAME                                                READY   STATUS    RESTARTS   AGE
-my-model-default-htz8r-deployment-8fd979f9b-w2qbv   3/3     Running   0          10s
+flowers-sample-default-htz8r-deployment-8fd979f9b-w2qbv   3/3     Running   0          10s
 ```
 
 ## Iterating


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Seems the sample file `docs/samples/tensorflow.yaml` in developer guide has been removed by PR #118 , the PR is to correct file path to point the `tensorflow` folder sample so that the developer guide is performable. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/124)
<!-- Reviewable:end -->
