### PR TITLE
WIP: Add Orchestrator

### DIFF
--- a/Dockerfile.orchestrator
+++ b/Dockerfile.orchestrator
@@ -1,0 +1,16 @@
+# Build the orchestrator binary
+FROM golang:1.10.3 as builder
+
+# Copy in the go src
+WORKDIR /go/src/github.com/kubeflow/kfserving
+COPY pkg/    pkg/
+COPY cmd/    cmd/
+COPY vendor/ vendor/
+# Build
+RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o orchestrator ./cmd/orchestrator
+
+# Copy the orchestrator into a thin image
+FROM ubuntu:latest
+WORKDIR /
+COPY --from=builder /go/src/github.com/kubeflow/kfserving/orchestrator .
+ENTRYPOINT ["/orchestrator"]

--- a/Gopkg.toml
+++ b/Gopkg.toml
@@ -38,9 +38,9 @@ version="v1.4.7"
 
 [[override]]
   name = "github.com/knative/pkg"
-  # HEAD as of 2019-04-19
-  revision = "3c8c4a93547f62b542013c273068f51875b5c942"
-
+  # HEAD as of 2919-05-11
+  revision = "9e0db8f0a7f47def18cf65e0859066d5e0377304"
+      
 [[override]]
   name = "k8s.io/api"
   version = "kubernetes-1.12.6"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,7 @@
 
 # Image URL to use all building/pushing image targets
 IMG ?= kfserving-controller:latest
+ORCH-IMG ?= kfserving-orchestrator:latest
 
 all: test manager
 
@@ -66,3 +67,9 @@ docker-build: test
 # Push the docker image
 docker-push:
 	docker push ${IMG}
+
+docker-build-orchestrator: #test
+	docker build -f Dockerfile.orchestrator . -t ${ORCH-IMG}
+
+docker-push-orchestrator:
+	docker push ${ORCH-IMG}

--- a/cmd/orchestrator/main.go
+++ b/cmd/orchestrator/main.go
@@ -1,0 +1,62 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"net/http"
+	"sigs.k8s.io/controller-runtime/pkg/runtime/signals"
+
+	activatorhandler "github.com/knative/serving/pkg/activator/handler"
+	ohandler "github.com/kubeflow/kfserving/pkg/orchestrator/handler"
+	perrors "github.com/pkg/errors"
+	"golang.org/x/net/http2"
+	"golang.org/x/net/http2/h2c"
+	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+)
+
+var (
+	serviceFQDN = flag.String("service", "", "The FQDN of the service to proxy")
+)
+
+func main() {
+	flag.Parse()
+
+	logf.SetLogger(logf.ZapLogger(false))
+	log := logf.Log.WithName("entrypoint")
+
+	stopCh := signals.SetupSignalHandler()
+
+	// Create handler chain
+	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first
+	var oh http.Handler = ohandler.New(log, *serviceFQDN)
+	oh = &activatorhandler.ProbeHandler{NextHandler: oh}
+	oh = &ohandler.HealthHandler{Log: log, NextHandler: oh}
+
+	port := 8080
+
+	h1s := &http.Server{
+		Addr:    fmt.Sprintf(":%d", port),
+		Handler: h2c.NewHandler(oh, &http2.Server{}),
+	}
+
+	log.Info("Starting", "port", port)
+
+	errCh := make(chan error, 1)
+	go func(name string, s *http.Server) {
+		// Don't forward ErrServerClosed as that indicates we're already shutting down.
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
+			errCh <- perrors.Wrapf(err, "%s server failed", name)
+		}
+	}("default", h1s)
+
+	// Exit as soon as we see a shutdown signal or the server failed.
+	select {
+	case <-stopCh:
+	case err := <-errCh:
+		log.Error(err, "Failed to run HTTP server")
+	}
+
+	h1s.Shutdown(context.Background())
+
+}

--- a/config/default/rbac/rbac_role.yaml
+++ b/config/default/rbac/rbac_role.yaml
@@ -45,6 +45,26 @@ rules:
   - update
   - patch
 - apiGroups:
+  - serving.knative.dev
+  resources:
+  - services
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - update
+  - patch
+  - delete
+- apiGroups:
+  - serving.knative.dev
+  resources:
+  - services/status
+  verbs:
+  - get
+  - update
+  - patch
+- apiGroups:
   - serving.kubeflow.org
   resources:
   - kfservices

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -68,3 +68,11 @@ func DefaultConfigurationName(name string) string {
 func CanaryConfigurationName(name string) string {
 	return name + "-canary"
 }
+
+func DefaultModelServiceName(name string) string {
+	return name + "-default-model"
+}
+
+func CanaryModelServiceName(name string) string {
+	return name + "-canary-model"
+}

--- a/pkg/orchestrator/handler/handler.go
+++ b/pkg/orchestrator/handler/handler.go
@@ -1,0 +1,54 @@
+package handler
+
+import (
+	"github.com/go-logr/logr"
+	//"go.opencensus.io/plugin/ochttp"
+	"net/http"
+	"net/http/httputil"
+	"net/url"
+)
+
+type orchestratorHandler struct {
+	log         logr.Logger
+	serviceFQDN string
+	transport   http.RoundTripper
+}
+
+func New(log logr.Logger, serviceFQDN string) http.Handler {
+	return &orchestratorHandler{
+		log:         log,
+		serviceFQDN: serviceFQDN,
+		//transport: AutoTransport,
+	}
+}
+
+// At present we just reverse proxy to the model but in future we will
+// make calls to other components as described by the Spec and combine
+// the responses into a single response.
+func (oh *orchestratorHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	target := &url.URL{
+		Scheme: "http",
+		Host:   "istio-ingressgateway.istio-system.svc.cluster.local",
+	}
+
+	host := oh.serviceFQDN
+
+	// Update the headers to allow for SSL redirection
+	r.Header.Set("Host", host)
+	r.URL.Host = target.Host
+	r.URL.Scheme = target.Scheme
+	r.Header.Set("X-Forwarded-Host", r.Header.Get("Host"))
+	r.Host = host
+
+	oh.log.Info("About to proxy request")
+
+	proxy := httputil.NewSingleHostReverseProxy(target)
+	/*
+		proxy.Transport = &ochttp.Transport{
+			Base: oh.transport,
+		}
+	*/
+	//proxy.FlushInterval = -1
+
+	proxy.ServeHTTP(w, r)
+}

--- a/pkg/orchestrator/handler/healthz_handler.go
+++ b/pkg/orchestrator/handler/healthz_handler.go
@@ -1,0 +1,27 @@
+package handler
+
+import (
+	"github.com/go-logr/logr"
+	"net/http"
+
+	"github.com/knative/serving/pkg/network"
+)
+
+// HealthHandler handles responding to kubelet probes with a provided health check.
+type HealthHandler struct {
+	Log         logr.Logger
+	NextHandler http.Handler
+}
+
+func (h *HealthHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+
+	h.Log.Info("Headers", "values", r.Header)
+
+	if network.IsKubeletProbe(r) {
+		h.Log.Info("Health request")
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	h.NextHandler.ServeHTTP(w, r)
+}

--- a/pkg/orchestrator/handler/network.go
+++ b/pkg/orchestrator/handler/network.go
@@ -1,0 +1,90 @@
+package handler
+
+import (
+	"crypto/tls"
+	"golang.org/x/net/http2"
+	"net"
+	"net/http"
+	"time"
+)
+
+const (
+	// DefaultConnTimeout specifies a short default connection timeout
+	// to avoid hitting the issue fixed in
+	// https://github.com/kubernetes/kubernetes/pull/72534 but only
+	// avalailable after Kubernetes 1.14.
+	//
+	// Our connections are usually between pods in the same cluster
+	// like activator <-> queue-proxy, or even between containers
+	// within the same pod queue-proxy <-> user-container, so a
+	// smaller connect timeout would be justifiable.
+	//
+	// We should consider exposing this as a configuration.
+	DefaultConnTimeout = 200 * time.Millisecond
+)
+
+// RoundTripperFunc implementation roundtrips a request.
+type RoundTripperFunc func(*http.Request) (*http.Response, error)
+
+// RoundTrip implements http.RoundTripper.
+func (rt RoundTripperFunc) RoundTrip(r *http.Request) (*http.Response, error) {
+	return rt(r)
+}
+
+func newAutoTransport(v1 http.RoundTripper, v2 http.RoundTripper) http.RoundTripper {
+	return RoundTripperFunc(func(r *http.Request) (*http.Response, error) {
+		t := v1
+		if r.ProtoMajor == 2 {
+			t = v2
+		}
+		return t.RoundTrip(r)
+	})
+}
+
+// NewH2CTransport constructs a new H2C transport.
+// That transport will reroute all HTTPS traffic to HTTP. This is
+// to explicitly allow h2c (http2 without TLS) transport.
+// See https://github.com/golang/go/issues/14141 for more details.
+func NewH2CTransport() http.RoundTripper {
+	return &http2.Transport{
+		AllowHTTP: true,
+		DialTLS: func(netw, addr string, cfg *tls.Config) (net.Conn, error) {
+			d := &net.Dialer{
+				Timeout:   DefaultConnTimeout,
+				KeepAlive: 5 * time.Second,
+				DualStack: true,
+			}
+			return d.Dial(netw, addr)
+		},
+	}
+}
+
+// DefaultH2CTransport is a singleton instance of H2C transport.
+var DefaultH2CTransport http.RoundTripper = NewH2CTransport()
+
+func newHTTPTransport(connTimeout time.Duration) http.RoundTripper {
+	return &http.Transport{
+		// Those match net/http/transport.go
+		Proxy:                 http.ProxyFromEnvironment,
+		MaxIdleConns:          100,
+		IdleConnTimeout:       5 * time.Second,
+		TLSHandshakeTimeout:   10 * time.Second,
+		ExpectContinueTimeout: 1 * time.Second,
+
+		// This is bespoke.
+		DialContext: (&net.Dialer{
+			Timeout:   connTimeout,
+			KeepAlive: 5 * time.Second,
+			DualStack: true,
+		}).DialContext,
+	}
+}
+
+// NewAutoTransport creates a RoundTripper that can use appropriate transport
+// based on the request's HTTP version.
+func NewAutoTransport() http.RoundTripper {
+	return newAutoTransport(newHTTPTransport(DefaultConnTimeout), NewH2CTransport())
+}
+
+// AutoTransport uses h2c for HTTP2 requests and falls back to `http.DefaultTransport` for all others
+var AutoTransport = NewAutoTransport()

--- a/pkg/reconciler/ksvc/resources/knative_service.go
+++ b/pkg/reconciler/ksvc/resources/knative_service.go
@@ -1,0 +1,70 @@
+package resources
+
+import (
+	"fmt"
+	"github.com/knative/serving/pkg/apis/autoscaling"
+	knservingv1alpha1 "github.com/knative/serving/pkg/apis/serving/v1alpha1"
+	"github.com/knative/serving/pkg/apis/serving/v1beta1"
+	"github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha1"
+	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+func CreateKnativeService(name string, metadata metav1.ObjectMeta, modelSpec *v1alpha1.ModelSpec) *knservingv1alpha1.Service {
+	if modelSpec == nil {
+		return nil
+	}
+	annotations := make(map[string]string)
+	if modelSpec.MinReplicas != 0 {
+		annotations[autoscaling.MinScaleAnnotationKey] = fmt.Sprint(modelSpec.MinReplicas)
+	}
+	if modelSpec.MaxReplicas != 0 {
+		annotations[autoscaling.MaxScaleAnnotationKey] = fmt.Sprint(modelSpec.MaxReplicas)
+	}
+
+	// User can pass down scaling target annotation to overwrite the target default 1
+	if _, ok := metadata.Annotations[autoscaling.TargetAnnotationKey]; !ok {
+		annotations[autoscaling.TargetAnnotationKey] = constants.DefaultScalingTarget
+	}
+	// User can pass down scaling class annotation to overwrite the default scaling KPA
+	if _, ok := metadata.Annotations[autoscaling.ClassAnnotationKey]; !ok {
+		annotations[autoscaling.ClassAnnotationKey] = autoscaling.KPA
+	}
+
+	kfsvcAnnotations := utils.Filter(metadata.Annotations, configurationAnnotationFilter)
+
+	configuration := &knservingv1alpha1.Service{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: metadata.Namespace,
+			Labels:    metadata.Labels,
+		},
+		Spec: knservingv1alpha1.ServiceSpec{
+			RunLatest: &knservingv1alpha1.RunLatestType{
+				Configuration: knservingv1alpha1.ConfigurationSpec{
+					RevisionTemplate: &knservingv1alpha1.RevisionTemplateSpec{
+						ObjectMeta: metav1.ObjectMeta{
+							Labels: utils.Union(metadata.Labels, map[string]string{
+								constants.KFServicePodLabelKey: metadata.Name,
+							}),
+							Annotations: utils.Union(kfsvcAnnotations, annotations),
+						},
+						Spec: knservingv1alpha1.RevisionSpec{
+							RevisionSpec: v1beta1.RevisionSpec{
+								// Defaulting here since this always shows a diff with nil vs 300s(knative default)
+								// we may need to expose this field in future
+								TimeoutSeconds: &constants.DefaultTimeout,
+								PodSpec: v1beta1.PodSpec{
+									ServiceAccountName: modelSpec.ServiceAccountName,
+								},
+							},
+							Container: modelSpec.CreateModelServingContainer(metadata.Name),
+						},
+					},
+				},
+			},
+		},
+	}
+	return configuration
+}

--- a/pkg/reconciler/ksvc/service_account_credentials.go
+++ b/pkg/reconciler/ksvc/service_account_credentials.go
@@ -37,7 +37,7 @@ func NewCredentialBulder(client client.Client) *CredentialBuilder {
 }
 
 func (c *CredentialBuilder) CreateSecretVolumeAndEnv(ctx context.Context, namespace string, serviceAccountName string,
-	configuration *knservingv1alpha1.Configuration) error {
+	configuration *knservingv1alpha1.ConfigurationSpec) error {
 	if serviceAccountName == "" {
 		serviceAccountName = "default"
 	}
@@ -59,15 +59,15 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(ctx context.Context, namesp
 		if _, ok := secret.Data[s3.AWSSecretAccessKeyName]; ok {
 			log.Info("Setting secret envs for s3", "S3Secret", secret.Name)
 			envs := s3.BuildSecretEnvs(secret)
-			configuration.Spec.RevisionTemplate.Spec.Container.Env = append(configuration.Spec.RevisionTemplate.Spec.Container.Env, envs...)
+			configuration.RevisionTemplate.Spec.Container.Env = append(configuration.RevisionTemplate.Spec.Container.Env, envs...)
 		} else if _, ok := secret.Data[gcs.GCSCredentialFileName]; ok {
 			log.Info("Setting secret volume for gcs", "GCSSecret", secret.Name)
 			volume, volumeMount := gcs.BuildSecretVolume(secret)
-			configuration.Spec.RevisionTemplate.Spec.Volumes =
-				append(configuration.Spec.RevisionTemplate.Spec.Volumes, volume)
-			configuration.Spec.RevisionTemplate.Spec.Container.VolumeMounts =
-				append(configuration.Spec.RevisionTemplate.Spec.Container.VolumeMounts, volumeMount)
-			configuration.Spec.RevisionTemplate.Spec.Container.Env = append(configuration.Spec.RevisionTemplate.Spec.Container.Env,
+			configuration.RevisionTemplate.Spec.Volumes =
+				append(configuration.RevisionTemplate.Spec.Volumes, volume)
+			configuration.RevisionTemplate.Spec.Container.VolumeMounts =
+				append(configuration.RevisionTemplate.Spec.Container.VolumeMounts, volumeMount)
+			configuration.RevisionTemplate.Spec.Container.Env = append(configuration.RevisionTemplate.Spec.Container.Env,
 				v1.EnvVar{
 					Name:  gcs.GCSCredentialEnvKey,
 					Value: gcs.GCSCredentialVolumeMountPath,

--- a/pkg/reconciler/ksvc/service_account_credentials_test.go
+++ b/pkg/reconciler/ksvc/service_account_credentials_test.go
@@ -125,7 +125,7 @@ func TestS3CredentialBuilder(t *testing.T) {
 		g.Expect(c.Create(context.TODO(), existingS3Secret)).NotTo(gomega.HaveOccurred())
 
 		err := builder.CreateSecretVolumeAndEnv(context.TODO(), scenario.serviceAccount.Namespace, scenario.serviceAccount.Name,
-			scenario.inputConfiguration)
+			&scenario.inputConfiguration.Spec)
 		if scenario.shouldFail && err == nil {
 			t.Errorf("Test %q failed: returned success but expected error", name)
 		}
@@ -231,7 +231,7 @@ func TestGCSCredentialBuilder(t *testing.T) {
 		g.Expect(c.Create(context.TODO(), existingGCSSecret)).NotTo(gomega.HaveOccurred())
 
 		err := builder.CreateSecretVolumeAndEnv(context.TODO(), scenario.serviceAccount.Namespace, scenario.serviceAccount.Name,
-			scenario.inputConfiguration)
+			&scenario.inputConfiguration.Spec)
 		if scenario.shouldFail && err == nil {
 			t.Errorf("Test %q failed: returned success but expected error", name)
 		}

--- a/test/crds/knative_service.yaml
+++ b/test/crds/knative_service.yaml
@@ -1,0 +1,55 @@
+# Copyright 2018 The Knative Authors
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     https://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+apiVersion: apiextensions.k8s.io/v1beta1
+kind: CustomResourceDefinition
+metadata:
+  name: services.serving.knative.dev
+  labels:
+    serving.knative.dev/release: devel
+    knative.dev/crd-install: "true"
+spec:
+  group: serving.knative.dev
+  version: v1alpha1
+  names:
+    kind: Service
+    plural: services
+    singular: service
+    categories:
+    - all
+    - knative
+    - serving
+    shortNames:
+    - kservice
+    - ksvc
+  scope: Namespaced
+  subresources:
+    status: {}
+  additionalPrinterColumns:
+  - name: URL
+    type: string
+    JSONPath: .status.url
+  - name: LatestCreated
+    type: string
+    JSONPath: .status.latestCreatedRevisionName
+  - name: LatestReady
+    type: string
+    JSONPath: .status.latestReadyRevisionName
+  - name: Ready
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].status"
+  - name: Reason
+    type: string
+    JSONPath: ".status.conditions[?(@.type=='Ready')].reason"
+


### PR DESCRIPTION

**What this PR does / why we need it**:

Adds the orchestrator. This will proxy the request and combine results from explainers, outlier detectors etc.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #19 

**Special notes for your reviewer**:

First brush strawman orchestrator implementation.

  * Adds an orchestrator cmd. This is inspired by the [knative serving activator](https://github.com/knative/serving/blob/master/cmd/activator/main.go)
      * Uses a similar chain of http handlers. The ones added at present at examples and might be removed.
      * At present it takes a single argument of the service to proxy and runs a reverse proxy. In future it would also call other services and combine the responses in the main proxy response.
  * It changes the controller to create a `knative configuration` for the orchestrator in the default configuration and creates the model in a normal `knative service`. In future explainers, outliers could be created as other knative services.
      * Did not do Canary changes as wanted to have a review discussion before proceeding.

Open questions

   *  The change to orchestrator being top level controlled configuration behind the Route and other lower level items models, explainers being standalone knative services.
   * Not looked at possibility of in future bypassing orchestrator and running original existing spec. We can discuss but it might be complex for garbage collection if a users keeps switching between two (i.e. adds an explainer then removes it)
   
To test you will need to:

```release-note
dep ensure
```
Updated knative pkg to gain access to latest activator code.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/125)
<!-- Reviewable:end -->
