### PR TITLE
Use klog for kfserving

### DIFF
--- a/pkg/apis/serving/v1alpha1/kfservice_framework.go
+++ b/pkg/apis/serving/v1alpha1/kfservice_framework.go
@@ -15,8 +15,8 @@ package v1alpha1
 
 import (
 	"fmt"
-	"log"
 
+	"k8s.io/klog"
 	v1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
 )
@@ -68,7 +68,7 @@ func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
 func getHandler(modelSpec *ModelSpec) interface{ FrameworkHandler } {
 	handler, err := makeHandler(modelSpec)
 	if err != nil {
-		log.Fatal(err)
+		klog.Fatal(err)
 	}
 
 	return handler

--- a/pkg/apis/serving/v1alpha1/v1alpha1_suite_test.go
+++ b/pkg/apis/serving/v1alpha1/v1alpha1_suite_test.go
@@ -17,13 +17,13 @@ limitations under the License.
 package v1alpha1
 
 import (
-	"log"
 	"os"
 	"path/filepath"
 	"testing"
 
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
+	"k8s.io/klog"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/envtest"
 )
@@ -39,15 +39,15 @@ func TestMain(m *testing.M) {
 	err := SchemeBuilder.AddToScheme(scheme.Scheme)
 
 	if err != nil {
-		log.Fatal(err)
+		klog.Fatal(err)
 	}
 
 	if cfg, err = t.Start(); err != nil {
-		log.Fatal(err)
+		klog.Fatal(err)
 	}
 
 	if c, err = client.New(cfg, client.Options{Scheme: scheme.Scheme}); err != nil {
-		log.Fatal(err)
+		klog.Fatal(err)
 	}
 
 	code := m.Run()

--- a/pkg/controller/kfservice/kfservice_controller_suite_test.go
+++ b/pkg/controller/kfservice/kfservice_controller_suite_test.go
@@ -20,7 +20,7 @@ import (
 	pkgtest "github.com/kubeflow/kfserving/pkg/testing"
 	"github.com/onsi/gomega"
 	"k8s.io/client-go/rest"
-	stdlog "log"
+	"k8s.io/klog"
 	"os"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
@@ -34,7 +34,7 @@ func TestMain(m *testing.M) {
 	t := pkgtest.SetupEnvTest()
 	var err error
 	if cfg, err = t.Start(); err != nil {
-		stdlog.Fatal(err)
+		klog.Fatal(err)
 	}
 
 	code := m.Run()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Use klog for kfserving. As most of the Kubernetes projects are using klog, it is better for kfserving migrate to this as well.

**Which issue(s) this PR fixes** :
fixes #89 

**Special notes for your reviewer**:

The PR is to use klog (replacing log) for kfserving.

The PR does not update `sigs.k8s.io/controller-runtime/pkg/runtime/log` that's used in the kfserving,  since the issue for klog at https://github.com/kubernetes/klog/issues/22, the klog cannot handle the case of some sort with a predefined set of variables which are used as suffix for each log line.  Leave the part for now as katib repo in https://github.com/kubeflow/katib/issues/506, may be updated later. Thanks.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Used klog for kfserving.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/128)
<!-- Reviewable:end -->
