### PR TITLE
Add correct URLs for sklearn and xgboost

### DIFF
--- a/docs/samples/sklearn/sklearn.yaml
+++ b/docs/samples/sklearn/sklearn.yaml
@@ -5,6 +5,4 @@ metadata:
 spec:
   default:
     sklearn:
-#     Fos testing purposes, using a local embedded model until S3/GCS gets implemented
-#     modelUri: "gs://kfserving-samples/models/sklearn/joblib"
-      modelUri: "/tmp/models"
+      modelUri: "gs://kfserving-samples/models/sklearn/iris/"

--- a/docs/samples/xgboost/xgboost.yaml
+++ b/docs/samples/xgboost/xgboost.yaml
@@ -5,6 +5,4 @@ metadata:
 spec:
   default:
     xgboost:
-#     Fos testing purposes, using a local embedded model until S3/GCS gets implemented
-#     modelUri: "gs://kfserving-samples/models/xgboost/iris"
-      modelUri: "/tmp/models"
+      modelUri: "gs://kfserving-samples/models/xgboost/iris/"

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -3,5 +3,4 @@ FROM python:3.7-slim
 COPY . .
 RUN pip install --upgrade pip && pip install -e ./kfserving
 RUN pip install -e ./sklearnserver
-COPY sklearnserver/model.joblib /tmp/models/model.joblib
 ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -4,5 +4,4 @@ RUN apt-get update && apt-get install libgomp1
 COPY . .
 RUN pip install --upgrade pip && pip install -e ./kfserving
 RUN pip install -e ./xgbserver
-COPY xgbserver/model.bst /tmp/models/model.bst
 ENTRYPOINT ["python", "-m", "xgbserver"]


### PR DESCRIPTION
Corrects the storage location for sklearn and xgboost, and removes copying of models in docker containers.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/131)
<!-- Reviewable:end -->
