### PR TITLE
valication failed if the minReplicas greater than maxReplicas

### DIFF
--- a/pkg/apis/serving/v1alpha1/kfservice_validation.go
+++ b/pkg/apis/serving/v1alpha1/kfservice_validation.go
@@ -96,7 +96,7 @@ func validateReplicas(minReplicas int, maxReplicas int) error {
 	if maxReplicas < 0 {
 		return fmt.Errorf(MaxReplicasLowerBoundExceededError)
 	}
-	if minReplicas > maxReplicas && maxReplicas != 0 {
+	if minReplicas > maxReplicas {
 		return fmt.Errorf(MinReplicasShouldBeLessThanMaxError)
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

During my tests, unintentionally I set the `minReplicas` to `1` and `maxReplicas` to `0`, but the kfservice applied sucussfully, the validation does not work, as below:

```bash
[root@jinchi1 kfserving]# cat mytest.yaml |grep -i Replicas
    minReplicas: 1
    maxReplicas: 0
[root@jinchi1 kfserving]# kubectl create -f mytest.yaml
kfservice.serving.kubeflow.org/my-model created
```
I think the `maxReplicas` should be always greater than `minReplicas`, seems there is a logic problem? The PR is to fix this. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/140)
<!-- Reviewable:end -->
