### PR TITLE
Specify kfserving-related WebhookConfigName

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -47,12 +47,14 @@ var (
 
 // Webhook Constants
 var (
-	WebhookServerName              = KFServingName + "-webhook-server"
-	WebhookServerServiceName       = WebhookServerName + "-service"
-	WebhookServerSecretName        = WebhookServerName + "-secret"
-	KFServiceValidatingWebhookName = strings.Join([]string{KFServiceName, WebhookServerName, "validator"}, ".")
-	KFServiceDefaultingWebhookName = strings.Join([]string{KFServiceName, WebhookServerName, "defaulter"}, ".")
-	WebhookFailurePolicy           = v1beta1.Fail
+	WebhookServerName                    = KFServingName + "-webhook-server"
+	WebhookServerServiceName             = WebhookServerName + "-service"
+	WebhookServerSecretName              = WebhookServerName + "-secret"
+	KFServiceValidatingWebhookName       = strings.Join([]string{KFServiceName, WebhookServerName, "validator"}, ".")
+	KFServiceDefaultingWebhookName       = strings.Join([]string{KFServiceName, WebhookServerName, "defaulter"}, ".")
+	WebhookFailurePolicy                 = v1beta1.Fail
+	KFServiceValidatingWebhookConfigName = strings.Join([]string{KFServiceName, KFServingAPIGroupName}, ".")
+	KFServiceMutatingWebhookConfigName   = strings.Join([]string{KFServiceName, KFServingAPIGroupName}, ".")
 )
 
 func getEnvOrDefault(key string, fallback string) string {

--- a/pkg/webhook/webhook.go
+++ b/pkg/webhook/webhook.go
@@ -52,6 +52,8 @@ func AddToManager(manager manager.Manager) error {
 					"control-plane": constants.ControllerLabelName,
 				},
 			},
+			ValidatingWebhookConfigName: constants.KFServiceValidatingWebhookConfigName,
+			MutatingWebhookConfigName:   constants.KFServiceMutatingWebhookConfigName,
 		},
 	})
 	if err != nil {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Before this PR, kfserving webhookconfigurations names are used by default value `mutating-webhook-configuration` and `validating-webhook-configuration` as below

```
# kubectl get mutatingwebhookconfigurations 
NAME                                 CREATED AT
istio-sidecar-injector               2019-05-14T12:11:23Z
mutating-webhook-configuration       2019-06-10T01:37:34Z
webhook.serving.knative.dev          2019-05-14T23:55:01Z
# kubectl get validatingwebhookconfigurations 
NAME                                   CREATED AT
istio-galley                           2019-05-14T12:12:07Z
validating-webhook-configuration       2019-05-31T00:49:14Z
```

After this PR, it looks like below
```
# kubectl get mutatingwebhookconfigurations 
NAME                                 CREATED AT
istio-sidecar-injector               2019-05-14T12:11:23Z
kfservice.serving.kubeflow.org       2019-06-10T02:48:10Z
webhook.serving.knative.dev          2019-05-14T23:55:01Z
# kubectl get validatingwebhookconfigurations 
NAME                                   CREATED AT
istio-galley                           2019-05-14T12:12:07Z
kfservice.serving.kubeflow.org         2019-06-10T02:48:10Z
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/149)
<!-- Reviewable:end -->
