### PR TITLE
support loading model from pvc

### DIFF
--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -139,7 +139,7 @@ Conditions provide realtime feedback to users on the underlying state of their d
 ### ModelSpec
 | Field       | Value       | Description |
 | ----------- | ----------- | ----------- |
-| modelUri       | String                                                                                             | URI pointing to Saved Model assets |
+| modelUri       | String                                                                                             | URI pointing to Saved Model assets. KFService supports loading Saved Model assets from [PersistentVolumeClaim (PVC)](https://kubernetes.io/docs/concepts/storage/persistent-volumes/#persistentvolumeclaims). To mount the PVC with containers, user needs to define PVC name as `pvcName` and mount path as `pvcMountPath` in [metadata.annotations](#Metadata).|
 | runtimeVersion | String                                                                                             | Defaults to latest the version of Tensorflow. |
 | resources      | [Resources](https://kubernetes.io/docs/concepts/configuration/manage-compute-resources-container/) | Defaults to requests and limits of 1CPU, 2Gb MEM. |
 

--- a/docs/samples/pvc/tensorflow.yaml
+++ b/docs/samples/pvc/tensorflow.yaml
@@ -1,0 +1,11 @@
+apiVersion: "serving.kubeflow.org/v1alpha1"
+kind: "KFService"
+metadata:
+  name: "flowers-sample"
+  annotations:
+    pvcName: "test-pvc"
+    pvcMountPath: "/mnt"
+spec:
+  default:
+    tensorflow:
+      modelUri: "/mnt/models/tensorflow/flowers"

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -47,14 +47,23 @@ var (
 
 // Webhook Constants
 var (
-	WebhookServerName                    = KFServingName + "-webhook-server"
-	WebhookServerServiceName             = WebhookServerName + "-service"
-	WebhookServerSecretName              = WebhookServerName + "-secret"
-	KFServiceValidatingWebhookName       = strings.Join([]string{KFServiceName, WebhookServerName, "validator"}, ".")
-	KFServiceDefaultingWebhookName       = strings.Join([]string{KFServiceName, WebhookServerName, "defaulter"}, ".")
-	WebhookFailurePolicy                 = v1beta1.Fail
-	KFServiceValidatingWebhookConfigName = strings.Join([]string{KFServiceName, KFServingAPIGroupName}, ".")
-	KFServiceMutatingWebhookConfigName   = strings.Join([]string{KFServiceName, KFServingAPIGroupName}, ".")
+	WebhookServerName               = KFServingName + "-webhook-server"
+	WebhookServerServiceName        = WebhookServerName + "-service"
+	WebhookServerSecretName         = WebhookServerName + "-secret"
+	KFServiceValidatingWebhookName  = strings.Join([]string{KFServiceName, WebhookServerName, "validator"}, ".")
+	KFServiceDefaultingWebhookName  = strings.Join([]string{KFServiceName, WebhookServerName, "defaulter"}, ".")
+	KFServiceMountingPvcWebhookName = strings.Join([]string{KFServiceName, WebhookServerName, "mountor"}, ".")
+	WebhookFailurePolicy            = v1beta1.Fail
+        KFServiceValidatingWebhookConfigName = strings.Join([]string{KFServiceName, KFServingAPIGroupName}, ".")
+        KFServiceMutatingWebhookConfigName   = strings.Join([]string{KFServiceName, KFServingAPIGroupName}, ".")
+)
+
+// PersistentVolumeClaim Constants
+var (
+	PvcNameAnnotation      = "pvcName"
+	PvcMountPathAnnotation = "pvcMountPath"	
+	PvcMountingName        = "kfserving-local-storage"
+	PvcDefaultMountPath    = "/mnt"
 )
 
 func getEnvOrDefault(key string, fallback string) string {

--- a/pkg/reconciler/knative/resources/knative_configuration.go
+++ b/pkg/reconciler/knative/resources/knative_configuration.go
@@ -110,6 +110,10 @@ func configurationAnnotationFilter(annotationKey string) bool {
 		return true
 	case autoscaling.ClassAnnotationKey:
 		return true
+	case constants.PvcNameAnnotation:
+		return true
+	case constants.PvcMountPathAnnotation:
+		return true
 	default:
 		return false
 	}

--- a/pkg/webhook/admission/kfservice/kfservice_mounter.go
+++ b/pkg/webhook/admission/kfservice/kfservice_mounter.go
@@ -1,0 +1,111 @@
+/*
+Copyright 2019 kubeflow.org.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package kfservice
+
+import (
+	"context"
+	"encoding/json"
+	"github.com/kubeflow/kfserving/pkg/constants"
+	"net/http"
+	appsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission"
+	"sigs.k8s.io/controller-runtime/pkg/webhook/admission/types"
+)
+
+// Mounting a PVC for containers.
+type Mounter struct {
+	Client  client.Client
+	Decoder types.Decoder
+}
+
+const (
+	PvcNameAnnotation = "pvcName"
+	PvcMountPathAnnotation = "pvcMountPath"	
+	pvcMountingName  = "kfserving-local-storage"
+	defaultMountPath = "/mnt"
+)
+
+// Handle decodes the incoming deployment and executes mounting logic.
+func (mounter *Mounter) Handle(ctx context.Context, req types.Request) types.Response {	
+	deployment := &appsv1.Deployment{}
+
+	if err := mounter.Decoder.Decode(req, deployment); err != nil {
+		return admission.ErrorResponse(http.StatusBadRequest, err)
+	}
+
+	if err := pvcMounting(deployment); err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+
+	patch, err := json.Marshal(deployment)
+	if err != nil {
+		return admission.ErrorResponse(http.StatusInternalServerError, err)
+	}
+
+	return patchResponseFromRaw(req.AdmissionRequest.Object.Raw, patch)
+}
+
+// Mount PVC to kfserving user container.
+func pvcMounting(deployment *appsv1.Deployment) error {
+
+	var claimName, mountPath string
+
+	annotations := deployment.Spec.Template.ObjectMeta.Annotations
+	podSpec     := &deployment.Spec.Template.Spec
+
+	if _, ok := annotations[constants.PvcNameAnnotation]; ok {
+		claimName = annotations[constants.PvcNameAnnotation]
+	} else {
+		return nil
+	}
+
+	if _, ok := annotations[constants.PvcMountPathAnnotation]; ok {
+		mountPath = annotations[constants.PvcMountPathAnnotation]
+	} else {
+		mountPath = constants.PvcDefaultMountPath
+	}
+
+	volume, volumeMount := buildPersistentVolume(claimName, mountPath)
+
+	podSpec.Volumes = append(podSpec.Volumes, volume)
+	//TBD @jinchihe Any better way to get the user container?
+	podSpec.Containers[0].VolumeMounts = append(podSpec.Containers[0].VolumeMounts, volumeMount)
+
+	return nil
+}
+
+// Generate Volume and VolumeMount
+func buildPersistentVolume(claimName string, mountPath string) (v1.Volume, v1.VolumeMount) {
+	volume := v1.Volume{
+		Name: constants.PvcMountingName,
+		VolumeSource: v1.VolumeSource{
+			PersistentVolumeClaim: &v1.PersistentVolumeClaimVolumeSource{
+				ClaimName: claimName,
+			},
+		},
+	}
+
+	volumeMount := v1.VolumeMount{
+		Name: constants.PvcMountingName,
+		MountPath: mountPath,
+		ReadOnly:  true,
+	}
+	return volume, volumeMount
+}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`kfserving` should support loading model from local PVC storage since there are some user case that models are trained by on-premise cluster, and models cannot be uploaded to clound. For example, if user used kubeflow Pipeline trained model and user want use kfservice as a steps in the Pipeline, that's good way.

**Which issue(s) this PR fixes**:
Fixes #129 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support loading model from PersistentVolumeClaim (PVC) 
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/151)
<!-- Reviewable:end -->
