### PR TITLE
fix bad link and typo in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ KFServing encapsulates the complexity of autoscaling, networking, health checkin
 
 ### Learn More
 * [Read the Docs](/docs)
-* [Roadmap]()
+* [Roadmap](/ROADMAP.md)
 * [KFServing 101 Slides](https://drive.google.com/file/d/16oqz6dhY5BR0u74pi9mDThU97Np__AFb/view)
 * [KFServing 101 Tech Talk](https://www.youtube.com/watch?v=hGIvlFADMhU)
 * This project is an evolution of the [original proposal in the Kubeflow repo](https://github.com/kubeflow/kubeflow/issues/2306). 

--- a/python/sklearnserver/README.md
+++ b/python/sklearnserver/README.md
@@ -105,7 +105,7 @@ mypy --ignore-missing-imports sklearnserver
 ```
 An empty result will indicate success.
 
-## Building your own Scikit-Learn erver Docker Image
+## Building your own Scikit-Learn Server Docker Image
 
 You can build and publish your own image for development needs. Please ensure that you modify the kfservice files for XGBoost in the api directory to point to your own image.
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

During viewing the docs, found one bad link in overall README file and a typo in sklearnserver/README.md. The PR is to fix the simple problems. Thanks.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/154)
<!-- Reviewable:end -->
