### PR TITLE
WIP: Internal models for Tf2openapi tool

### DIFF
--- a/tools/tf2openapi/README.md
+++ b/tools/tf2openapi/README.md
@@ -1,2 +1,21 @@
+# Tf2OpenAPI
 The main purpose of this tool is to enable automatically generating OpenAPI 3.0 specifications for prediction HTTP requests from TensorFlow SavedModel files containing signature definitions (SignatureDefs) for models. One use case for the OpenAPI specification involves generating sample payloads in a UI.
 
+## Overview
+###Use Cases for OpenAPI
+This project is motivated by the following uses of an OpenAPI specification:
+* <b> Validate HTTP requests </b> (i.e. prediction requests) so the user can be notified of malformed inputs and correct them before running comparatively expensive computations on the model 
+* <b> Automatically generate user-friendly documentation </b> or UI with the API and display sample payloads for users so that they can format inputs properly
+* <b> Generate payloads </b> for benchmarking purposes, such as recording the response times of queries to an ML model
+
+###Project: TensorFlow-to-OpenAPI Transformer
+The outcome of this project is a TensorFlow-to-OpenAPI transformer which takes SavedModel protobuf binary files and generates an OpenAPI specification for prediction requests.
+
+###TensorFlow Compatibility
+TBD
+
+## Example
+TBD. Consider the TensorFlow sample in [docs/samples/tensorflow](https://github.com/kubeflow/kfserving/tree/master/docs/samples/tensorflow). The idea is that an OpenAPI specification can be generated from the model in Google Cloud Storage (gs://kfserving-samples/models/tensorflow/flowers) and be used to validate and/or generate the [sample input](https://github.com/kubeflow/kfserving/blob/master/docs/samples/tensorflow/input.json).   
+
+## Caveats
+* There is a dependency on protobufs defined by TensorFlow, e.g. [tensorflow/core/protobuf](https://github.com/tensorflow/tensorflow/tree/master/tensorflow/core/protobuf). When compiling proto source files from the TensorFlow repository, ensure that the field `option go_package` is defined; otherwise, there will be missing Go files, causing problems with Go imports.

--- a/tools/tf2openapi/README.md
+++ b/tools/tf2openapi/README.md
@@ -1,0 +1,2 @@
+The main purpose of this tool is to enable automatically generating OpenAPI 3.0 specifications for prediction HTTP requests from TensorFlow SavedModel files containing signature definitions (SignatureDefs) for models. One use case for the OpenAPI specification involves generating sample payloads in a UI.
+

--- a/tools/tf2openapi/tfmodel/generate.go
+++ b/tools/tf2openapi/tfmodel/generate.go
@@ -1,0 +1,55 @@
+package tfmodel
+
+import (
+	"github.com/golang/protobuf/proto"
+	pb "github.com/tensorflow/tensorflow/tensorflow/go/core/protobuf"
+	"log"
+)
+
+func UnmarshalSavedModelPb(in []byte) pb.SavedModel {
+	model := &pb.SavedModel{}
+	if err := proto.Unmarshal(in, model); err != nil {
+		log.Fatalln("SavedModel not in expected format. May be corrupted.")
+	}
+	return *model
+}
+
+func generateTFSigDef(sigDefMapping map[string]*pb.TensorInfo, sigDefArr *[]*TFTensor) {
+	for key := range sigDefMapping {
+		tfTensor := &TFTensor{}
+		tfTensor.SetKey(key)
+		tfTensor.SetShape(append(ShapeInternal{}, 1))
+		tfTensor.SetDType(DTypeInternal(2))
+		//TODO *tensorPtr.Dtype
+		//TODO *tensorPtr.TensorShape.Dim
+		//> unknown rank
+		//> otherwise
+		*sigDefArr = append(*sigDefArr, tfTensor)
+	}
+}
+
+func GenerateTFModel(model pb.SavedModel) *TFSavedModel {
+	tfSavedModel := &TFSavedModel{}
+	tfMetaGraphs := &[]*TFMetaGraph{}
+	for _, mPtr := range model.MetaGraphs {
+		metaGraph := *mPtr
+		tfMetaGraph := &TFMetaGraph{}
+		tfSigDefs := &[]*TFSignatureDef{}
+		for sigDefKey, sigDefPtr := range metaGraph.SignatureDef {
+			tfSigDef := &TFSignatureDef{}
+			tfSigDef.SetName(sigDefKey)
+			tfSigDefInputs := &[]*TFTensor{}
+			tfSigDefOutputs := &[]*TFTensor{}
+			sigDef := *sigDefPtr
+			generateTFSigDef(sigDef.Inputs, tfSigDefInputs)
+			generateTFSigDef(sigDef.Outputs, tfSigDefOutputs)
+			tfSigDef.SetInputs(*tfSigDefInputs)
+			tfSigDef.SetOutputs(*tfSigDefOutputs)
+			*tfSigDefs = append(*tfSigDefs, tfSigDef)
+		}
+		tfMetaGraph.SetSignatureDefs(*tfSigDefs)
+		*tfMetaGraphs = append(*tfMetaGraphs, tfMetaGraph)
+	}
+	tfSavedModel.SetMetaGraphs(*tfMetaGraphs)
+	return tfSavedModel
+}

--- a/tools/tf2openapi/tfmodel/generate.go
+++ b/tools/tf2openapi/tfmodel/generate.go
@@ -23,37 +23,37 @@ func GenerateTFModel(model pb.SavedModel) *TFSavedModel {
 		tfSigDefs := &[]*TFSignatureDef{}
 		for sigDefKey, sigDefPtr := range metaGraph.SignatureDef {
 			tfSigDef := &TFSignatureDef{}
-			tfSigDef.SetName(sigDefKey)
+			tfSigDef.Name = sigDefKey
 			tfSigDefInputs := &[]*TFTensor{}
 			tfSigDefOutputs := &[]*TFTensor{}
 			sigDef := *sigDefPtr
 			generateTFSigDef(sigDef.Inputs, tfSigDefInputs)
 			generateTFSigDef(sigDef.Outputs, tfSigDefOutputs)
-			tfSigDef.SetInputs(*tfSigDefInputs)
-			tfSigDef.SetOutputs(*tfSigDefOutputs)
+			tfSigDef.Inputs = *tfSigDefInputs
+			tfSigDef.Outputs = *tfSigDefOutputs
 			*tfSigDefs = append(*tfSigDefs, tfSigDef)
 		}
-		tfMetaGraph.SetSignatureDefs(*tfSigDefs)
+		tfMetaGraph.SignatureDefs = *tfSigDefs
 		*tfMetaGraphs = append(*tfMetaGraphs, tfMetaGraph)
 	}
-	tfSavedModel.SetMetaGraphs(*tfMetaGraphs)
+	tfSavedModel.MetaGraphs = *tfMetaGraphs
 	return tfSavedModel
 }
 
 func generateTFSigDef(sigDefMapping map[string]*pb.TensorInfo, sigDefArr *[]*TFTensor) {
 	for key, tensorInfo := range sigDefMapping {
 		tfTensor := &TFTensor{}
-		tfTensor.SetKey(key)
+		tfTensor.Key = key
 		tfShape := TFShape{}
 		if tensorInfo.TensorShape.UnknownRank {
-			tfTensor.SetRank(-1)
+			tfTensor.Rank = -1
 		} else {
 			for _, d := range tensorInfo.TensorShape.Dim {
 				tfShape = append(tfShape, d.Size)
 			}
-			tfTensor.SetRank(int64(len(tfShape)))
+			tfTensor.Rank = int64(len(tfShape))
 		}
-		tfTensor.SetShape(tfShape)
+		tfTensor.Shape = tfShape
 		generateTFDType(tensorInfo.Dtype.String(), tfTensor)
 		*sigDefArr = append(*sigDefArr, tfTensor)
 	}
@@ -62,27 +62,27 @@ func generateTFSigDef(sigDefMapping map[string]*pb.TensorInfo, sigDefArr *[]*TFT
 func generateTFDType(tensorInfoDType string, tfTensor *TFTensor) {
 	switch tensorInfoDType {
 	case "DT_BOOL":
-		tfTensor.SetDType(DT_BOOL)
+		tfTensor.DType = DT_BOOL
 	case "DT_STRING":
-		tfTensor.SetDType(DT_STRING)
+		tfTensor.DType = DT_STRING
 	case "DT_INT8":
-		tfTensor.SetDType(DT_INT8)
+		tfTensor.DType = DT_INT8
 	case "DT_UINT8":
-		tfTensor.SetDType(DT_UINT8)
+		tfTensor.DType = DT_UINT8
 	case "DT_INT16":
-		tfTensor.SetDType(DT_INT16)
+		tfTensor.DType = DT_INT16
 	case "DT_INT32":
-		tfTensor.SetDType(DT_INT32)
+		tfTensor.DType = DT_INT32
 	case "DT_UINT32":
-		tfTensor.SetDType(DT_UINT32)
+		tfTensor.DType = DT_UINT32
 	case "DT_INT64":
-		tfTensor.SetDType(DT_INT64)
+		tfTensor.DType = DT_INT64
 	case "DT_UINT64":
-		tfTensor.SetDType(DT_UINT64)
+		tfTensor.DType = DT_UINT64
 	case "DT_FLOAT":
-		tfTensor.SetDType(DT_FLOAT)
+		tfTensor.DType = DT_FLOAT
 	case "DT_DOUBLE":
-		tfTensor.SetDType(DT_DOUBLE)
+		tfTensor.DType = DT_DOUBLE
 	default:
 		panic("Unsupported data type for generating payloads")
 	}

--- a/tools/tf2openapi/tfmodel/node.go
+++ b/tools/tf2openapi/tfmodel/node.go
@@ -1,0 +1,5 @@
+package tfmodel
+
+type Node interface {
+	Accept(w Visitor)
+}

--- a/tools/tf2openapi/tfmodel/node.go
+++ b/tools/tf2openapi/tfmodel/node.go
@@ -1,5 +1,6 @@
 package tfmodel
 
+/** Node to be visited by the Visitor in the Visitor Design Pattern **/
 type Node interface {
 	Accept(w Visitor)
 }

--- a/tools/tf2openapi/tfmodel/openapivisitor.go
+++ b/tools/tf2openapi/tfmodel/openapivisitor.go
@@ -2,6 +2,7 @@ package tfmodel
 
 import "fmt"
 
+/** Implements the Visitor interface **/
 type OpenAPIVisitor struct {
 }
 

--- a/tools/tf2openapi/tfmodel/openapivisitor.go
+++ b/tools/tf2openapi/tfmodel/openapivisitor.go
@@ -1,0 +1,11 @@
+package tfmodel
+
+import "fmt"
+
+type OpenAPIVisitor struct {
+}
+
+func (w *OpenAPIVisitor) VisitSavedModel(node *TFSavedModel)     { fmt.Println("Saved Model") }
+func (w *OpenAPIVisitor) VisitMetaGraph(node *TFMetaGraph)       { fmt.Println("Meta Graph") }
+func (w *OpenAPIVisitor) VisitSignatureDef(node *TFSignatureDef) { fmt.Println("Sig Def") }
+func (w *OpenAPIVisitor) VisitTensor(node *TFTensor)             { fmt.Println("Tensor") }

--- a/tools/tf2openapi/tfmodel/tfmetagraph.go
+++ b/tools/tf2openapi/tfmodel/tfmetagraph.go
@@ -1,0 +1,20 @@
+package tfmodel
+
+type TFMetaGraph struct {
+	signatureDefs [] *TFSignatureDef
+}
+
+func (m *TFMetaGraph) SignatureDefs() [] *TFSignatureDef {
+	return m.signatureDefs
+}
+
+func (m *TFMetaGraph) SetSignatureDefs(signatureDefs [] *TFSignatureDef) {
+	m.signatureDefs = signatureDefs
+}
+
+func (m *TFMetaGraph) Accept(w Visitor) {
+	w.VisitMetaGraph(m)
+	for _, x := range m.SignatureDefs() {
+		x.Accept(w)
+	}
+}

--- a/tools/tf2openapi/tfmodel/tfmetagraph.go
+++ b/tools/tf2openapi/tfmodel/tfmetagraph.go
@@ -1,20 +1,16 @@
 package tfmodel
 
+/** TFMetaGraph contains meta information about the TensorFlow graph, i.e. the signature definitions of the graph.
+It is the internal model representation for the MetaGraph defined in the TensorFlow repository
+[tensorflow/core/protobuf/meta_graph.proto]
+*/
 type TFMetaGraph struct {
-	signatureDefs [] *TFSignatureDef
-}
-
-func (m *TFMetaGraph) SignatureDefs() [] *TFSignatureDef {
-	return m.signatureDefs
-}
-
-func (m *TFMetaGraph) SetSignatureDefs(signatureDefs [] *TFSignatureDef) {
-	m.signatureDefs = signatureDefs
+	SignatureDefs [] *TFSignatureDef
 }
 
 func (m *TFMetaGraph) Accept(w Visitor) {
 	w.VisitMetaGraph(m)
-	for _, x := range m.SignatureDefs() {
+	for _, x := range m.SignatureDefs {
 		x.Accept(w)
 	}
 }

--- a/tools/tf2openapi/tfmodel/tfmetagraph.go
+++ b/tools/tf2openapi/tfmodel/tfmetagraph.go
@@ -1,11 +1,12 @@
 package tfmodel
 
-/** TFMetaGraph contains meta information about the TensorFlow graph, i.e. the signature definitions of the graph.
+/**
+TFMetaGraph contains meta information about the TensorFlow graph, i.e. the signature definitions of the graph.
 It is the internal model representation for the MetaGraph defined in the TensorFlow repository
 [tensorflow/core/protobuf/meta_graph.proto]
 */
 type TFMetaGraph struct {
-	SignatureDefs [] *TFSignatureDef
+	SignatureDefs [] TFSignatureDef
 }
 
 func (m *TFMetaGraph) Accept(w Visitor) {

--- a/tools/tf2openapi/tfmodel/tfsavedmodel.go
+++ b/tools/tf2openapi/tfmodel/tfsavedmodel.go
@@ -1,11 +1,12 @@
 package tfmodel
 
-/** TFSavedModel is the high level serialization format for TensorFlow saved models.
+/**
+TFSavedModel is the high level serialization format for TensorFlow saved models.
 It is the internal model representation for the SavedModel defined in the TensorFlow repository
 [tensorflow/core/protobuf/saved_model.proto]
 */
 type TFSavedModel struct {
-	MetaGraphs [] *TFMetaGraph
+	MetaGraphs [] TFMetaGraph
 }
 
 func (m *TFSavedModel) Accept(w Visitor) {

--- a/tools/tf2openapi/tfmodel/tfsavedmodel.go
+++ b/tools/tf2openapi/tfmodel/tfsavedmodel.go
@@ -1,20 +1,16 @@
 package tfmodel
 
+/** TFSavedModel is the high level serialization format for TensorFlow saved models.
+It is the internal model representation for the SavedModel defined in the TensorFlow repository
+[tensorflow/core/protobuf/saved_model.proto]
+*/
 type TFSavedModel struct {
-	metaGraphs [] *TFMetaGraph
-}
-
-func (m *TFSavedModel) MetaGraphs() [] *TFMetaGraph {
-	return m.metaGraphs
-}
-
-func (m *TFSavedModel) SetMetaGraphs(metaGraphs [] *TFMetaGraph) {
-	m.metaGraphs = metaGraphs
+	MetaGraphs [] *TFMetaGraph
 }
 
 func (m *TFSavedModel) Accept(w Visitor) {
 	w.VisitSavedModel(m)
-	for _, x := range m.MetaGraphs() {
+	for _, x := range m.MetaGraphs {
 		x.Accept(w)
 	}
 }

--- a/tools/tf2openapi/tfmodel/tfsavedmodel.go
+++ b/tools/tf2openapi/tfmodel/tfsavedmodel.go
@@ -1,0 +1,20 @@
+package tfmodel
+
+type TFSavedModel struct {
+	metaGraphs [] *TFMetaGraph
+}
+
+func (m *TFSavedModel) MetaGraphs() [] *TFMetaGraph {
+	return m.metaGraphs
+}
+
+func (m *TFSavedModel) SetMetaGraphs(metaGraphs [] *TFMetaGraph) {
+	m.metaGraphs = metaGraphs
+}
+
+func (m *TFSavedModel) Accept(w Visitor) {
+	w.VisitSavedModel(m)
+	for _, x := range m.MetaGraphs() {
+		x.Accept(w)
+	}
+}

--- a/tools/tf2openapi/tfmodel/tfsignaturedef.go
+++ b/tools/tf2openapi/tfmodel/tfsignaturedef.go
@@ -1,13 +1,14 @@
 package tfmodel
 
-/** TFSignatureDef defines the signature of supported computations in the TensorFlow graph, including their inputs and
+/**
+TFSignatureDef defines the signature of supported computations in the TensorFlow graph, including their inputs and
 outputs. It is the internal model representation for the SignatureDef defined in the TensorFlow repository
 [tensorflow/core/protobuf/meta_graph.proto]
 */
 type TFSignatureDef struct {
 	Name    string
-	Inputs  [] *TFTensor
-	Outputs [] *TFTensor
+	Inputs  [] TFTensor
+	Outputs [] TFTensor
 }
 
 func (m *TFSignatureDef) Accept(w Visitor) {

--- a/tools/tf2openapi/tfmodel/tfsignaturedef.go
+++ b/tools/tf2openapi/tfmodel/tfsignaturedef.go
@@ -1,41 +1,21 @@
 package tfmodel
 
+/** TFSignatureDef defines the signature of supported computations in the TensorFlow graph, including their inputs and
+outputs. It is the internal model representation for the SignatureDef defined in the TensorFlow repository
+[tensorflow/core/protobuf/meta_graph.proto]
+*/
 type TFSignatureDef struct {
-	name    string
-	inputs  [] *TFTensor
-	outputs [] *TFTensor
-}
-
-func (m *TFSignatureDef) Name() string {
-	return m.name
-}
-
-func (m *TFSignatureDef) SetName(name string) {
-	m.name = name
-}
-
-func (m *TFSignatureDef) Outputs() []*TFTensor {
-	return m.outputs
-}
-
-func (m *TFSignatureDef) SetOutputs(outputs []*TFTensor) {
-	m.outputs = outputs
-}
-
-func (m *TFSignatureDef) Inputs() []*TFTensor {
-	return m.inputs
-}
-
-func (m *TFSignatureDef) SetInputs(inputs []*TFTensor) {
-	m.inputs = inputs
+	Name    string
+	Inputs  [] *TFTensor
+	Outputs [] *TFTensor
 }
 
 func (m *TFSignatureDef) Accept(w Visitor) {
 	w.VisitSignatureDef(m)
-	for _, x := range m.Inputs() {
+	for _, x := range m.Inputs {
 		x.Accept(w)
 	}
-	for _, x := range m.Outputs() {
+	for _, x := range m.Outputs {
 		x.Accept(w)
 	}
 }

--- a/tools/tf2openapi/tfmodel/tfsignaturedef.go
+++ b/tools/tf2openapi/tfmodel/tfsignaturedef.go
@@ -1,0 +1,41 @@
+package tfmodel
+
+type TFSignatureDef struct {
+	name    string
+	inputs  [] *TFTensor
+	outputs [] *TFTensor
+}
+
+func (m *TFSignatureDef) Name() string {
+	return m.name
+}
+
+func (m *TFSignatureDef) SetName(name string) {
+	m.name = name
+}
+
+func (m *TFSignatureDef) Outputs() []*TFTensor {
+	return m.outputs
+}
+
+func (m *TFSignatureDef) SetOutputs(outputs []*TFTensor) {
+	m.outputs = outputs
+}
+
+func (m *TFSignatureDef) Inputs() []*TFTensor {
+	return m.inputs
+}
+
+func (m *TFSignatureDef) SetInputs(inputs []*TFTensor) {
+	m.inputs = inputs
+}
+
+func (m *TFSignatureDef) Accept(w Visitor) {
+	w.VisitSignatureDef(m)
+	for _, x := range m.Inputs() {
+		x.Accept(w)
+	}
+	for _, x := range m.Outputs() {
+		x.Accept(w)
+	}
+}

--- a/tools/tf2openapi/tfmodel/tftensor.go
+++ b/tools/tf2openapi/tfmodel/tftensor.go
@@ -1,0 +1,55 @@
+package tfmodel
+
+type TFTensor struct {
+	dType DTypeInternal
+	shape ShapeInternal
+	key   string
+}
+
+func (m *TFTensor) Key() string {
+	return m.key
+}
+
+func (m *TFTensor) SetKey(key string) {
+	m.key = key
+}
+
+func (m *TFTensor) DType() DTypeInternal {
+	return m.dType
+}
+
+func (m *TFTensor) SetDType(dType DTypeInternal) {
+	m.dType = dType
+}
+
+func (m *TFTensor) Shape() ShapeInternal {
+	return m.shape
+}
+
+func (m *TFTensor) SetShape(shape ShapeInternal) {
+	m.shape = shape
+}
+
+func (m *TFTensor) Accept(w Visitor) {
+	w.VisitTensor(m)
+}
+
+type ShapeInternal []int
+
+type DTypeInternal int
+
+const (
+	// all the possible constants that can be JSON-ified according to
+	// https://www.tensorflow.org/tfx/serving/api_rest#json_mapping
+	DT_BOOL DTypeInternal = iota + 1
+	DT_STRING
+	DT_INT8
+	DT_UINT8
+	DTI_INT16
+	DT_INT32
+	DT_UINT32
+	DT_INT64
+	DT_UINT64
+	DT_FLOAT
+	DT_DOUBLE
+)

--- a/tools/tf2openapi/tfmodel/tftensor.go
+++ b/tools/tf2openapi/tfmodel/tftensor.go
@@ -1,46 +1,20 @@
 package tfmodel
 
+/**
+TFTensor represents a logical tensor. It contains fields from TensorInfo in the TensorFlow repository
+[tensorflow/core/protobuf/meta_graph.proto] but is named after the user-facing input/output (hence being a logical
+tensor and not an actual tensor).
+ */
 type TFTensor struct {
-	dType TFDType
+	//Name of the logical tensor
+	Key   string
+	DType TFDType
 
 	// Length of the shape is 0 when rank <= 0
-	shape TFShape
+	Shape TFShape
 
 	// If rank = -1, the shape is unknown. Otherwise, rank corresponds to the number of dimensions in this tensor
-	rank  int64
-	key   string
-}
-
-func (m *TFTensor) Rank() int64 {
-	return m.rank
-}
-
-func (m *TFTensor) SetRank(rank int64) {
-	m.rank = rank
-}
-
-func (m *TFTensor) Key() string {
-	return m.key
-}
-
-func (m *TFTensor) SetKey(key string) {
-	m.key = key
-}
-
-func (m *TFTensor) DType() TFDType {
-	return m.dType
-}
-
-func (m *TFTensor) SetDType(dType TFDType) {
-	m.dType = dType
-}
-
-func (m *TFTensor) Shape() TFShape {
-	return m.shape
-}
-
-func (m *TFTensor) SetShape(shape TFShape) {
-	m.shape = shape
+	Rank int64
 }
 
 func (m *TFTensor) Accept(w Visitor) {

--- a/tools/tf2openapi/tfmodel/tftensor.go
+++ b/tools/tf2openapi/tfmodel/tftensor.go
@@ -1,9 +1,22 @@
 package tfmodel
 
 type TFTensor struct {
-	dType DTypeInternal
-	shape ShapeInternal
+	dType TFDType
+
+	// Length of the shape is 0 when rank <= 0
+	shape TFShape
+
+	// If rank = -1, the shape is unknown. Otherwise, rank corresponds to the number of dimensions in this tensor
+	rank  int64
 	key   string
+}
+
+func (m *TFTensor) Rank() int64 {
+	return m.rank
+}
+
+func (m *TFTensor) SetRank(rank int64) {
+	m.rank = rank
 }
 
 func (m *TFTensor) Key() string {
@@ -14,19 +27,19 @@ func (m *TFTensor) SetKey(key string) {
 	m.key = key
 }
 
-func (m *TFTensor) DType() DTypeInternal {
+func (m *TFTensor) DType() TFDType {
 	return m.dType
 }
 
-func (m *TFTensor) SetDType(dType DTypeInternal) {
+func (m *TFTensor) SetDType(dType TFDType) {
 	m.dType = dType
 }
 
-func (m *TFTensor) Shape() ShapeInternal {
+func (m *TFTensor) Shape() TFShape {
 	return m.shape
 }
 
-func (m *TFTensor) SetShape(shape ShapeInternal) {
+func (m *TFTensor) SetShape(shape TFShape) {
 	m.shape = shape
 }
 
@@ -34,18 +47,18 @@ func (m *TFTensor) Accept(w Visitor) {
 	w.VisitTensor(m)
 }
 
-type ShapeInternal []int
+type TFShape []int64
 
-type DTypeInternal int
+type TFDType int
 
 const (
 	// all the possible constants that can be JSON-ified according to
 	// https://www.tensorflow.org/tfx/serving/api_rest#json_mapping
-	DT_BOOL DTypeInternal = iota + 1
+	DT_BOOL TFDType = iota
 	DT_STRING
 	DT_INT8
 	DT_UINT8
-	DTI_INT16
+	DT_INT16
 	DT_INT32
 	DT_UINT32
 	DT_INT64

--- a/tools/tf2openapi/tfmodel/tftensor.go
+++ b/tools/tf2openapi/tfmodel/tftensor.go
@@ -1,13 +1,15 @@
 package tfmodel
 
 /**
-TFTensor represents a logical tensor. It contains fields from TensorInfo in the TensorFlow repository
+TFTensor represents a logical tensor. It contains the information from TensorInfo in the TensorFlow repository
 [tensorflow/core/protobuf/meta_graph.proto] but is named after the user-facing input/output (hence being a logical
 tensor and not an actual tensor).
  */
 type TFTensor struct {
 	//Name of the logical tensor
 	Key   string
+
+	// Data type contained in this tensor
 	DType TFDType
 
 	// Length of the shape is 0 when rank <= 0
@@ -29,6 +31,7 @@ const (
 	// all the possible constants that can be JSON-ified according to
 	// https://www.tensorflow.org/tfx/serving/api_rest#json_mapping
 	DT_BOOL TFDType = iota
+	DT_B64_STRING
 	DT_STRING
 	DT_INT8
 	DT_UINT8

--- a/tools/tf2openapi/tfmodel/visitor.go
+++ b/tools/tf2openapi/tfmodel/visitor.go
@@ -1,0 +1,8 @@
+package tfmodel
+
+type Visitor interface {
+	VisitSavedModel(node *TFSavedModel)
+	VisitMetaGraph(node *TFMetaGraph)
+	VisitSignatureDef(node *TFSignatureDef)
+	VisitTensor(node *TFTensor)
+}

--- a/tools/tf2openapi/tfmodel/visitor.go
+++ b/tools/tf2openapi/tfmodel/visitor.go
@@ -1,5 +1,7 @@
 package tfmodel
 
+/** Interface for the Visitor Pattern [https://en.wikipedia.org/wiki/Visitor_pattern]
+**/
 type Visitor interface {
 	VisitSavedModel(node *TFSavedModel)
 	VisitMetaGraph(node *TFMetaGraph)

--- a/tools/tf2openapi/tfmodel/visitor.go
+++ b/tools/tf2openapi/tfmodel/visitor.go
@@ -1,7 +1,8 @@
 package tfmodel
 
-/** Interface for the Visitor Pattern [https://en.wikipedia.org/wiki/Visitor_pattern]
-**/
+/**
+Interface for the Visitor Pattern [https://en.wikipedia.org/wiki/Visitor_pattern]
+*/
 type Visitor interface {
 	VisitSavedModel(node *TFSavedModel)
 	VisitMetaGraph(node *TFMetaGraph)


### PR DESCRIPTION
**What this PR does / why we need it**: See README for the purpose of the Tf2openapi tool. This PR adds internal models to store information from SavedModel Go structures created from unmarshalling SavedModel protobuf files.

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
```NONE

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/155)
<!-- Reviewable:end -->
