### PR TITLE
Fix gcs secret volume mount path

### DIFF
--- a/pkg/controller/kfservice/resources/credentials/gcs/gcs_secret.go
+++ b/pkg/controller/kfservice/resources/credentials/gcs/gcs_secret.go
@@ -21,17 +21,17 @@ import (
 )
 
 const (
-	GCSCredentialFileName              = "gcloud-application-credentials.json"
-	GCSCredentialVolumeName            = "user-gcp-sa"
-	GCSCredentialVolumeMountPathPrefix = "/var/secrets/"
-	GCSCredentialEnvKey                = "GOOGLE_APPLICATION_CREDENTIALS"
+	GCSCredentialFileName        = "gcloud-application-credentials.json"
+	GCSCredentialVolumeName      = "user-gcp-sa"
+	GCSCredentialVolumeMountPath = "/var/secrets/"
+	GCSCredentialEnvKey          = "GOOGLE_APPLICATION_CREDENTIALS"
 )
 
 type GCSConfig struct {
 	GCSCredentialFileName string `json:"gcsCredentialFileName,omitempty"`
 }
 
-func BuildSecretVolume(secret *v1.Secret, gcsCredentialFileName string) (v1.Volume, v1.VolumeMount) {
+func BuildSecretVolume(secret *v1.Secret) (v1.Volume, v1.VolumeMount) {
 	volume := v1.Volume{
 		Name: GCSCredentialVolumeName,
 		VolumeSource: v1.VolumeSource{
@@ -41,7 +41,7 @@ func BuildSecretVolume(secret *v1.Secret, gcsCredentialFileName string) (v1.Volu
 		},
 	}
 	volumeMount := v1.VolumeMount{
-		MountPath: GCSCredentialVolumeMountPathPrefix + gcsCredentialFileName,
+		MountPath: GCSCredentialVolumeMountPath,
 		Name:      GCSCredentialVolumeName,
 		ReadOnly:  true,
 	}

--- a/pkg/controller/kfservice/resources/credentials/gcs/gcs_secret_test.go
+++ b/pkg/controller/kfservice/resources/credentials/gcs/gcs_secret_test.go
@@ -41,7 +41,7 @@ func TestGcsSecret(t *testing.T) {
 			expectedVolumeMount: v1.VolumeMount{
 				Name:      GCSCredentialVolumeName,
 				ReadOnly:  true,
-				MountPath: GCSCredentialVolumeMountPathPrefix + GCSCredentialFileName,
+				MountPath: GCSCredentialVolumeMountPath,
 			},
 			expectedVolume: v1.Volume{
 				Name: GCSCredentialVolumeName,
@@ -55,7 +55,7 @@ func TestGcsSecret(t *testing.T) {
 	}
 
 	for name, scenario := range scenarios {
-		volume, volumeMount := BuildSecretVolume(scenario.secret, GCSCredentialFileName)
+		volume, volumeMount := BuildSecretVolume(scenario.secret)
 
 		if diff := cmp.Diff(scenario.expectedVolume, volume); diff != "" {
 			t.Errorf("Test %q unexpected volume (-want +got): %v", name, diff)

--- a/pkg/controller/kfservice/resources/credentials/service_account_credentials.go
+++ b/pkg/controller/kfservice/resources/credentials/service_account_credentials.go
@@ -97,7 +97,7 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 			configuration.Spec.RevisionTemplate.Spec.Container.Env = append(configuration.Spec.RevisionTemplate.Spec.Container.Env, envs...)
 		} else if _, ok := secret.Data[gcsCredentialFileName]; ok {
 			log.Info("Setting secret volume for gcs", "GCSSecret", secret.Name)
-			volume, volumeMount := gcs.BuildSecretVolume(secret, gcsCredentialFileName)
+			volume, volumeMount := gcs.BuildSecretVolume(secret)
 			configuration.Spec.RevisionTemplate.Spec.Volumes =
 				append(configuration.Spec.RevisionTemplate.Spec.Volumes, volume)
 			configuration.Spec.RevisionTemplate.Spec.Container.VolumeMounts =
@@ -105,7 +105,7 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 			configuration.Spec.RevisionTemplate.Spec.Container.Env = append(configuration.Spec.RevisionTemplate.Spec.Container.Env,
 				v1.EnvVar{
 					Name:  gcs.GCSCredentialEnvKey,
-					Value: gcs.GCSCredentialVolumeMountPathPrefix + gcsCredentialFileName,
+					Value: gcs.GCSCredentialVolumeMountPath + gcsCredentialFileName,
 				})
 		} else {
 			log.V(5).Info("Skipping non gcs/s3 secret", "Secret", secret.Name)

--- a/pkg/controller/kfservice/resources/credentials/service_account_credentials_test.go
+++ b/pkg/controller/kfservice/resources/credentials/service_account_credentials_test.go
@@ -206,13 +206,13 @@ func TestGCSCredentialBuilder(t *testing.T) {
 									{
 										Name:      gcs.GCSCredentialVolumeName,
 										ReadOnly:  true,
-										MountPath: gcs.GCSCredentialVolumeMountPathPrefix + "gcloud-application-credentials.json",
+										MountPath: gcs.GCSCredentialVolumeMountPath,
 									},
 								},
 								Env: []v1.EnvVar{
 									{
 										Name:  gcs.GCSCredentialEnvKey,
-										Value: gcs.GCSCredentialVolumeMountPathPrefix + "gcloud-application-credentials.json",
+										Value: gcs.GCSCredentialVolumeMountPath + "gcloud-application-credentials.json",
 									},
 								},
 							},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix the gcs secret volume mount path, the path should not be included on the mount path since key-value pair in the data field of the secret will be projected into the volume as a file whose name is the key and content is the value.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:
Create the following secret, the key of the secret is `application_default_credentials.json` and value is the content of the file. 
```
kubectl create secret generic dsun-gcs --from-file=/Users/dsun20/.config/gcloud/application_default_credentials.json
```
when you create volume mount we only need to specify the mount path, the secret key-value pair will be projected under the mount path with secret key as file name and value as file content.
```
GCSCredentialVolumeMountPath = "/var/secrets/"
volumeMount := v1.VolumeMount{
	MountPath: GCSCredentialVolumeMountPath,
	Name:      GCSCredentialVolumeName,
	ReadOnly:  true,
}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/171)
<!-- Reviewable:end -->
