### PR TITLE
make tensorflow protocol default

### DIFF
--- a/python/kfserving/kfserving/server.py
+++ b/python/kfserving/kfserving/server.py
@@ -43,6 +43,7 @@ parser.add_argument('--http_port', default=DEFAULT_HTTP_PORT, type=int,
 parser.add_argument('--grpc_port', default=DEFAULT_GRPC_PORT, type=int,
                     help='The GRPC Port listened to by the model server.')
 parser.add_argument('--protocol', type=Protocol, choices=list(Protocol),
+                    default="tensorflow.http",
                     help='The protocol served by the model server')
 args, _ = parser.parse_known_args()
 


### PR DESCRIPTION
Tensorflow protocol was not default in latest python changes. This fixes this.
Current samples won't work until this is merged.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/176)
<!-- Reviewable:end -->
