### PR TITLE
fix one problem in new kustomize 3.0.0

### DIFF
--- a/hack/image_patch_dev.sh
+++ b/hack/image_patch_dev.sh
@@ -6,6 +6,7 @@ apiVersion: apps/v1
 kind: StatefulSet 
 metadata:
   name: kfserving-controller-manager
+  namespace: kfserving-system
 spec:
   template:
     spec:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

fix one problem in new kustomize, see more #223 

**Which issue(s) this PR fixes**:
Fixes #223 

**Special notes for your reviewer**:

Before the PR with kustomize 3.0.0:
```
(python36) [root@jinchi1 kfserving]# kustomize version
Version: {KustomizeVersion:3.0.0 GitCommit:e0bac6ad192f33d993f11206e24f6cda1d04c4ec BuildDate:2019-07-03T18:21:24Z GoOs:linux GoArch:amd64}
(python36) [root@jinchi1 kfserving]#
(python36) [root@jinchi1 kfserving]# kustomize build config/overlays/development
Error: no matches for OriginalId apps_v1_StatefulSet|~X|kfserving-controller-manager; no matches for CurrentId apps_v1_StatefulSet|~X|kfserving-controller-manager; failed to find unique target for patch apps_v1_StatefulSet|kfserving-controller-manager
```

With the PR with kustomize 3.0.0, that works fine
```
(python36) [root@jinchi1 kfserving]# make deploy-dev
go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd --output-dir=config/default/crds
.....
RBAC manifests generated under 'config/default/rbac' directory
./hack/image_patch_dev.sh
2019/07/08 02:53:13 Building github.com/kubeflow/kfserving/cmd/manager
2019/07/08 02:53:25 Using base gcr.io/distroless/static:latest for github.com/kubeflow/kfserving/cmd/manager
.....
service/kfserving-controller-manager-service created
statefulset.apps/kfserving-controller-manager created
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/224)
<!-- Reviewable:end -->
