### PR TITLE
Remove install from Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,10 +23,6 @@ executor: fmt vet
 run: generate fmt vet lint
 	go run ./cmd/manager/main.go
 
-# Install CRDs into a cluster
-install: manifests
-	kubectl apply -f config/default/crds
-
 # Deploy controller in the configured Kubernetes cluster in ~/.kube/config
 deploy: manifests
 	kustomize build config/default | kubectl apply -f -


### PR DESCRIPTION

`make install` fails as needs kustomize.
`make deploy` already installs the CRD and is referenced in developer docs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/232)
<!-- Reviewable:end -->
