### PR TITLE
Fix reconcile logic for canary spec 

### DIFF
--- a/pkg/apis/serving/v1alpha1/kfservice_status.go
+++ b/pkg/apis/serving/v1alpha1/kfservice_status.go
@@ -73,6 +73,12 @@ func (ss *KFServiceStatus) PropagateDefaultConfigurationStatus(defaultConfigurat
 // PropagateCanaryConfigurationStatus propagates the canary Configuration status and applies its values
 // to the Service status.
 func (ss *KFServiceStatus) PropagateCanaryConfigurationStatus(canaryConfigurationStatus *knservingv1alpha1.ConfigurationStatus) {
+	// reset status if canaryConfigurationStatus is nil
+	if canaryConfigurationStatus == nil {
+		ss.Canary = StatusConfigurationSpec{}
+		conditionSet.Manage(ss).MarkUnknown(CanaryPredictorReady, "CanarySpecUnavailable", "Canary spec unavailable")
+		return
+	}
 	ss.Canary.Name = canaryConfigurationStatus.LatestCreatedRevisionName
 	configurationCondition := canaryConfigurationStatus.GetCondition(knservingv1alpha1.ConfigurationConditionReady)
 

--- a/pkg/controller/kfservice/kfservice_controller.go
+++ b/pkg/controller/kfservice/kfservice_controller.go
@@ -151,7 +151,6 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 		knative.NewRouteReconciler(r.Client, r.scheme),
 	}
 
-	kfsvc.Status = v1alpha1.KFServiceStatus{}
 	for _, reconciler := range reconcilers {
 		if err := reconciler.Reconcile(kfsvc); err != nil {
 			log.Error(err, "Failed to reconcile")

--- a/pkg/controller/kfservice/kfservice_controller.go
+++ b/pkg/controller/kfservice/kfservice_controller.go
@@ -151,6 +151,7 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 		knative.NewRouteReconciler(r.Client, r.scheme),
 	}
 
+	kfsvc.Status = v1alpha1.KFServiceStatus{}
 	for _, reconciler := range reconcilers {
 		if err := reconciler.Reconcile(kfsvc); err != nil {
 			log.Error(err, "Failed to reconcile")

--- a/pkg/controller/kfservice/kfservice_controller_test.go
+++ b/pkg/controller/kfservice/kfservice_controller_test.go
@@ -33,6 +33,7 @@ import (
 	servingv1alpha1 "github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha1"
 	"github.com/onsi/gomega"
 	"golang.org/x/net/context"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -560,8 +561,10 @@ func TestCanaryDelete(t *testing.T) {
 		Should(gomega.Succeed())
 
 	canaryConfiguration = &knservingv1alpha1.Configuration{}
-	g.Eventually(func() error { return c.Get(context.TODO(), canaryConfigurationKey, canaryConfiguration) }, timeout).
-		Should(gomega.MatchError("Configuration.serving.knative.dev \"bar-canary\" not found"))
+	g.Eventually(func() bool {
+		err := c.Get(context.TODO(), canaryConfigurationKey, canaryConfiguration)
+		return errors.IsNotFound(err)
+	}, timeout).Should(gomega.BeTrue())
 
 	// Verify if KFService status is updated with right status
 	// Canary status should be removed with condition set to unknown

--- a/pkg/controller/kfservice/kfservice_controller_test.go
+++ b/pkg/controller/kfservice/kfservice_controller_test.go
@@ -42,7 +42,7 @@ import (
 
 var c client.Client
 
-const timeout = time.Second * 5
+const timeout = time.Second * 10
 
 var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: "foo", Namespace: "default"}}
 var serviceKey = expectedRequest.NamespacedName
@@ -149,10 +149,11 @@ func TestReconcile(t *testing.T) {
 	defer c.Delete(context.TODO(), configMap)
 
 	// Create the KFService object and expect the Reconcile and Knative configuration/routes to be created
-	g.Expect(c.Create(context.TODO(), instance)).NotTo(gomega.HaveOccurred())
+	defaultInstance := instance.DeepCopy()
+	g.Expect(c.Create(context.TODO(), defaultInstance)).NotTo(gomega.HaveOccurred())
 
 	g.Expect(err).NotTo(gomega.HaveOccurred())
-	defer c.Delete(context.TODO(), instance)
+	defer c.Delete(context.TODO(), defaultInstance)
 	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
 
 	configuration := &knservingv1alpha1.Configuration{}
@@ -160,8 +161,8 @@ func TestReconcile(t *testing.T) {
 		Should(gomega.Succeed())
 	expectedConfiguration := &knservingv1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      constants.DefaultConfigurationName(instance.Name),
-			Namespace: instance.Namespace,
+			Name:      constants.DefaultConfigurationName(defaultInstance.Name),
+			Namespace: defaultInstance.Namespace,
 		},
 		Spec: knservingv1alpha1.ConfigurationSpec{
 			Template: &knservingv1alpha1.RevisionTemplateSpec{
@@ -172,7 +173,7 @@ func TestReconcile(t *testing.T) {
 						"autoscaling.knative.dev/class":                          "kpa.autoscaling.knative.dev",
 						"autoscaling.knative.dev/maxScale":                       "3",
 						"autoscaling.knative.dev/minScale":                       "1",
-						constants.ModelInitializerSourceUriInternalAnnotationKey: instance.Spec.Default.Tensorflow.ModelURI,
+						constants.ModelInitializerSourceUriInternalAnnotationKey: defaultInstance.Spec.Default.Tensorflow.ModelURI,
 					},
 				},
 				Spec: knservingv1alpha1.RevisionSpec{
@@ -182,12 +183,12 @@ func TestReconcile(t *testing.T) {
 							Containers: []v1.Container{
 								{
 									Image: servingv1alpha1.TensorflowServingImageName + ":" +
-										instance.Spec.Default.Tensorflow.RuntimeVersion,
+										defaultInstance.Spec.Default.Tensorflow.RuntimeVersion,
 									Command: []string{servingv1alpha1.TensorflowEntrypointCommand},
 									Args: []string{
 										"--port=" + servingv1alpha1.TensorflowServingGRPCPort,
 										"--rest_api_port=" + servingv1alpha1.TensorflowServingRestPort,
-										"--model_name=" + instance.Name,
+										"--model_name=" + defaultInstance.Name,
 										"--model_base_path=" + constants.DefaultModelLocalMountPath,
 									},
 								},
@@ -230,6 +231,13 @@ func TestReconcile(t *testing.T) {
 	expectedKfsvcStatus := servingv1alpha1.KFServiceStatus{
 		Status: duckv1beta1.Status{
 			Conditions: duckv1beta1.Conditions{
+				{
+					Type:     servingv1alpha1.CanaryPredictorReady,
+					Status:   "Unknown",
+					Severity: "Info",
+					Reason:   "CanarySpecUnavailable",
+					Message:  "Canary spec unavailable",
+				},
 				{
 					Type:   servingv1alpha1.DefaultPredictorReady,
 					Status: "True",
@@ -288,8 +296,9 @@ func TestCanaryReconcile(t *testing.T) {
 	defer c.Delete(context.TODO(), configMap)
 
 	// Create the KFService object and expect the Reconcile and knative service to be created
-	g.Expect(c.Create(context.TODO(), canary)).NotTo(gomega.HaveOccurred())
-	defer c.Delete(context.TODO(), canary)
+	canaryInstance := canary.DeepCopy()
+	g.Expect(c.Create(context.TODO(), canaryInstance)).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), canaryInstance)
 	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedCanaryRequest)))
 
 	defaultConfiguration := &knservingv1alpha1.Configuration{}
@@ -301,8 +310,8 @@ func TestCanaryReconcile(t *testing.T) {
 		Should(gomega.Succeed())
 	expectedCanaryConfiguration := &knservingv1alpha1.Configuration{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      canary.Name,
-			Namespace: canary.Namespace,
+			Name:      canaryInstance.Name,
+			Namespace: canaryInstance.Namespace,
 		},
 		Spec: knservingv1alpha1.ConfigurationSpec{
 			Template: &knservingv1alpha1.RevisionTemplateSpec{
@@ -345,8 +354,8 @@ func TestCanaryReconcile(t *testing.T) {
 		Should(gomega.Succeed())
 	expectedRoute := knservingv1alpha1.Route{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      canary.Name,
-			Namespace: canary.Namespace,
+			Name:      canaryInstance.Name,
+			Namespace: canaryInstance.Namespace,
 		},
 		Spec: knservingv1alpha1.RouteSpec{
 			Traffic: []knservingv1alpha1.TrafficTarget{
@@ -451,4 +460,159 @@ func TestCanaryReconcile(t *testing.T) {
 		}
 		return cmp.Diff(&expectedKfsvcStatus, &kfsvc.Status, cmpopts.IgnoreTypes(apis.VolatileTime{}))
 	}, timeout).Should(gomega.BeEmpty())
+}
+
+func TestCanaryDelete(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+
+	mgr, err := manager.New(cfg, manager.Options{})
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	c = mgr.GetClient()
+
+	recFn, requests := SetupTestReconcile(newReconciler(mgr))
+	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
+
+	stopMgr, mgrStopped := StartTestManager(mgr, g)
+
+	defer func() {
+		close(stopMgr)
+		mgrStopped.Wait()
+	}()
+
+	// Create configmap
+	var configMap = &v1.ConfigMap{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      constants.KFServiceConfigMapName,
+			Namespace: constants.KFServingNamespace,
+		},
+		Data: configs,
+	}
+	g.Expect(c.Create(context.TODO(), configMap)).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), configMap)
+
+	// Create the KFService object and expect the Reconcile
+	// Default and Canary configuration should be present
+	canaryInstance := canary.DeepCopy()
+	g.Expect(c.Create(context.TODO(), canaryInstance)).NotTo(gomega.HaveOccurred())
+	defer c.Delete(context.TODO(), canaryInstance)
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedCanaryRequest)))
+
+	defaultConfiguration := &knservingv1alpha1.Configuration{}
+	g.Eventually(func() error { return c.Get(context.TODO(), defaultConfigurationKey, defaultConfiguration) }, timeout).
+		Should(gomega.Succeed())
+
+	canaryConfiguration := &knservingv1alpha1.Configuration{}
+	g.Eventually(func() error { return c.Get(context.TODO(), canaryConfigurationKey, canaryConfiguration) }, timeout).
+		Should(gomega.Succeed())
+
+	// Verify if KFService status is updated
+	routeUrl := &apis.URL{Scheme: "http", Host: canaryServiceKey.Name + ".svc.cluster.local"}
+	expectedKfsvcStatus := servingv1alpha1.KFServiceStatus{
+		Status: duckv1beta1.Status{
+			Conditions: duckv1beta1.Conditions{
+				{
+					Type:     servingv1alpha1.CanaryPredictorReady,
+					Severity: "Info",
+					Status:   "True",
+				},
+				{
+					Type:   servingv1alpha1.DefaultPredictorReady,
+					Status: "True",
+				},
+				{
+					Type:   apis.ConditionReady,
+					Status: "True",
+				},
+				{
+					Type:   servingv1alpha1.RoutesReady,
+					Status: "True",
+				},
+			},
+		},
+		URL: routeUrl,
+		Default: servingv1alpha1.StatusConfigurationSpec{
+			Name:    "revision-v1",
+			Traffic: 80,
+		},
+		Canary: servingv1alpha1.StatusConfigurationSpec{
+			Name:    "revision-v2",
+			Traffic: 20,
+		},
+	}
+	g.Eventually(func() string {
+		if err := c.Get(context.TODO(), canaryServiceKey, canaryInstance); err != nil {
+			return err.Error()
+		}
+		return cmp.Diff(&expectedKfsvcStatus, &canaryInstance.Status, cmpopts.IgnoreTypes(apis.VolatileTime{}))
+	}, timeout).Should(gomega.BeEmpty())
+
+	// Update instance to remove Canary Spec
+	// Canary configuration should be removed during reconcile
+	canaryInstance.Spec.Canary = nil
+	canaryInstance.Spec.CanaryTrafficPercent = 0
+	g.Expect(c.Update(context.TODO(), canaryInstance)).NotTo(gomega.HaveOccurred())
+
+	g.Expect(err).NotTo(gomega.HaveOccurred())
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedCanaryRequest)))
+
+	defaultConfiguration = &knservingv1alpha1.Configuration{}
+	g.Eventually(func() error { return c.Get(context.TODO(), defaultConfigurationKey, defaultConfiguration) }, timeout).
+		Should(gomega.Succeed())
+
+	canaryConfiguration = &knservingv1alpha1.Configuration{}
+	g.Eventually(func() error { return c.Get(context.TODO(), canaryConfigurationKey, canaryConfiguration) }, timeout).
+		Should(gomega.MatchError("Configuration.serving.knative.dev \"bar-canary\" not found"))
+
+	// Verify if KFService status is updated with right status
+	// Canary status should be removed with condition set to unknown
+	route := &knservingv1alpha1.Route{}
+	g.Eventually(func() error { return c.Get(context.TODO(), canaryServiceKey, route) }, timeout).
+		Should(gomega.Succeed())
+
+	updatedRoute := route.DeepCopy()
+	updatedRoute.Status.Traffic = []knservingv1alpha1.TrafficTarget{
+		{
+			TrafficTarget: v1beta1.TrafficTarget{RevisionName: "revision-v1"},
+		},
+	}
+	g.Expect(c.Status().Update(context.TODO(), updatedRoute)).NotTo(gomega.HaveOccurred())
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedCanaryRequest)))
+
+	expectedKfsvcStatus = servingv1alpha1.KFServiceStatus{
+		Status: duckv1beta1.Status{
+			Conditions: duckv1beta1.Conditions{
+				{
+					Type:     servingv1alpha1.CanaryPredictorReady,
+					Status:   "Unknown",
+					Severity: "Info",
+					Reason:   "CanarySpecUnavailable",
+					Message:  "Canary spec unavailable",
+				},
+				{
+					Type:   servingv1alpha1.DefaultPredictorReady,
+					Status: "True",
+				},
+				{
+					Type:   apis.ConditionReady,
+					Status: "True",
+				},
+				{
+					Type:   servingv1alpha1.RoutesReady,
+					Status: "True",
+				},
+			},
+		},
+		URL: routeUrl,
+		Default: servingv1alpha1.StatusConfigurationSpec{
+			Name: "revision-v1",
+		},
+	}
+	g.Eventually(func() *servingv1alpha1.KFServiceStatus {
+		kfsvc := &servingv1alpha1.KFService{}
+		err := c.Get(context.TODO(), canaryServiceKey, kfsvc)
+		if err != nil {
+			return nil
+		}
+		return &kfsvc.Status
+	}, timeout).Should(testutils.BeSematicEqual(&expectedKfsvcStatus))
 }

--- a/pkg/controller/kfservice/reconcilers/knative/configuration_reconciler.go
+++ b/pkg/controller/kfservice/reconcilers/knative/configuration_reconciler.go
@@ -29,6 +29,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -82,12 +84,17 @@ func (r *ConfigurationReconciler) reconcileDefault(kfsvc *v1alpha1.KFService) er
 }
 
 func (r *ConfigurationReconciler) reconcileCanary(kfsvc *v1alpha1.KFService) error {
+	canaryConfigurationName := constants.CanaryConfigurationName(kfsvc.Name)
 	if kfsvc.Spec.Canary == nil {
+		if err := r.finalizeConfiguration(kfsvc); err != nil {
+			return err
+		}
+		kfsvc.Status.PropagateCanaryConfigurationStatus(nil)
 		return nil
 	}
 
 	canaryConfiguration, err := r.configurationBuilder.CreateKnativeConfiguration(
-		constants.CanaryConfigurationName(kfsvc.Name),
+		canaryConfigurationName,
 		kfsvc.ObjectMeta,
 		kfsvc.Spec.Canary,
 	)
@@ -101,6 +108,26 @@ func (r *ConfigurationReconciler) reconcileCanary(kfsvc *v1alpha1.KFService) err
 	}
 
 	kfsvc.Status.PropagateCanaryConfigurationStatus(status)
+	return nil
+}
+
+func (r *ConfigurationReconciler) finalizeConfiguration(kfsvc *v1alpha1.KFService) error {
+	canaryConfigurationName := constants.CanaryConfigurationName(kfsvc.Name)
+	existing := &knservingv1alpha1.Configuration{}
+	err := r.client.Get(context.TODO(), types.NamespacedName{Name: canaryConfigurationName, Namespace: kfsvc.Namespace}, existing)
+	if err != nil {
+		if !errors.IsNotFound(err) {
+			return err
+		}
+	} else {
+		log.Info("Deleting Knative Serving configuration", "namespace", kfsvc.Namespace, "name", canaryConfigurationName)
+		err := r.client.Delete(context.TODO(), existing, client.PropagationPolicy(metav1.DeletePropagationBackground))
+		if err != nil {
+			if !errors.IsNotFound(err) {
+				return err
+			}
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
**What this PR does / why we need it**:
Status has to be initialized before reconcile.  Else Status will have stale values. This is a safe option as all required status fields are recomputed during reconcile.  

How to reproduce

`kubectl apply -f  docs/samples/tensorflow/tensorflow.yaml `

`kubectl apply -f  docs/samples/tensorflow/tensorflow-canary.yaml `<-Canary status is updated

`kubectl apply -f  docs/samples/tensorflow/tensorflow.yaml ` <- Canary status still remains though new spec doesn't have canary block. 




**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/253)
<!-- Reviewable:end -->
