### PR TITLE
Remove NVCR.io workaround

### DIFF
--- a/docs/samples/tensorrt/README.md
+++ b/docs/samples/tensorrt/README.md
@@ -5,9 +5,6 @@
 2. Your cluster's Istio Ingress gateway must be network accessible.
 3. Your cluster's Istio Egresss gateway must [allow Google Cloud Storage](https://knative.dev/docs/serving/outbound-network-access/)
 
-
-> Knative is not able to resolve containers from the NVIDIA container registry.
-To work around this you need to skip resolution for nvcr.io by editing knative config-deployment.yaml. See details here: https://github.com/knative/serving/issues/4355
 ## Create the KFService
 Apply the CRD
 ```


### PR DESCRIPTION
Now that we have knative 0.7 the workaround is no longer needed!

Fixes #165

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/254)
<!-- Reviewable:end -->
