### PR TITLE
allow user can set kube_config in sdk client

### DIFF
--- a/sdk/docs/KFServingClient.md
+++ b/sdk/docs/KFServingClient.md
@@ -1,5 +1,19 @@
 # KFServingClient
 
+> KFServingClient(config_file=None, context=None, client_configuration=None, persist_config=True)
+
+User can loads authentication and cluster information from kube-config file and stores them in kubernetes.client.configuration. Parameters are as following:
+
+parameter |  Description
+------------ | -------------
+config_file | Name of the kube-config file. Defaults to `~/.kube/config`. |
+context |Set the active context. If is set to None, current_context from config file will be used.|
+client_configuration | The kubernetes.client.Configuration to set configs to.|
+persist_config | If True, config file will be updated when changed (e.g GCP token refresh).|
+
+
+The APIs for KFServingClient are as following:
+
 Class | Method |  Description
 ------------ | ------------- | -------------
 KFServingClient | [create](#create) | Create KFService|

--- a/sdk/kfserving/api/kf_serving_client.py
+++ b/sdk/kfserving/api/kf_serving_client.py
@@ -22,11 +22,16 @@ from ..utils import utils
 class KFServingClient(object):
     """KFServing Apis."""
 
-    def __init__(self):
+    def __init__(self, config_file=None, context=None,
+                 client_configuration=None, persist_config=True):
         if utils.is_running_in_k8s():
             config.load_incluster_config()
         else:
-            config.load_kube_config()
+            config.load_kube_config(
+                config_file=config_file,
+                context=context,
+                client_configuration=client_configuration,
+                persist_config=persist_config)
 
         self.api_instance = client.CustomObjectsApi()
     


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Alllow user can set the `kube_config` to loads authentication and cluster information from `kube_config` file.

**Which issue(s) this PR fixes** :
Fixes item 1 in the #263 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/279)
<!-- Reviewable:end -->
