### PR TITLE
Adding ClearCondition fix

### DIFF
--- a/pkg/apis/serving/v1alpha1/kfservice_status.go
+++ b/pkg/apis/serving/v1alpha1/kfservice_status.go
@@ -76,7 +76,7 @@ func (ss *KFServiceStatus) PropagateCanaryConfigurationStatus(canaryConfiguratio
 	// reset status if canaryConfigurationStatus is nil
 	if canaryConfigurationStatus == nil {
 		ss.Canary = StatusConfigurationSpec{}
-		conditionSet.Manage(ss).MarkUnknown(CanaryPredictorReady, "CanarySpecUnavailable", "Canary spec unavailable")
+		conditionSet.Manage(ss).ClearCondition(CanaryPredictorReady)
 		return
 	}
 	ss.Canary.Name = canaryConfigurationStatus.LatestCreatedRevisionName

--- a/pkg/controller/kfservice/kfservice_controller_test.go
+++ b/pkg/controller/kfservice/kfservice_controller_test.go
@@ -233,13 +233,6 @@ func TestReconcile(t *testing.T) {
 		Status: duckv1beta1.Status{
 			Conditions: duckv1beta1.Conditions{
 				{
-					Type:     servingv1alpha1.CanaryPredictorReady,
-					Status:   "Unknown",
-					Severity: "Info",
-					Reason:   "CanarySpecUnavailable",
-					Message:  "Canary spec unavailable",
-				},
-				{
 					Type:   servingv1alpha1.DefaultPredictorReady,
 					Status: "True",
 				},
@@ -584,13 +577,6 @@ func TestCanaryDelete(t *testing.T) {
 	expectedKfsvcStatus = servingv1alpha1.KFServiceStatus{
 		Status: duckv1beta1.Status{
 			Conditions: duckv1beta1.Conditions{
-				{
-					Type:     servingv1alpha1.CanaryPredictorReady,
-					Status:   "Unknown",
-					Severity: "Info",
-					Reason:   "CanarySpecUnavailable",
-					Message:  "Canary spec unavailable",
-				},
 				{
 					Type:   servingv1alpha1.DefaultPredictorReady,
 					Status: "True",


### PR DESCRIPTION
ClearCondition function is implemented in ConditionSet which clears a non-terminal condition. CanaryPredictorReady is cleared when canary spec is empty.

Fixes: #276

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/285)
<!-- Reviewable:end -->
