### PR TITLE
Set default resource limits for KFService

### DIFF
--- a/pkg/apis/serving/v1alpha2/framework.go
+++ b/pkg/apis/serving/v1alpha2/framework.go
@@ -37,10 +37,8 @@ const (
 )
 
 var (
-	DefaultMemoryRequests = resource.MustParse("2Gi")
-	DefaultCPURequests    = resource.MustParse("1")
-	DefaultMemoryLimits   = resource.MustParse("2Gi")
-	DefaultCPULimits      = resource.MustParse("1")
+	DefaultMemory = resource.MustParse("2Gi")
+	DefaultCPU    = resource.MustParse("1")
 )
 
 // Returns a URI to the model. This URI is passed to the model-initializer via the ModelInitializerSourceUriInternalAnnotationKey
@@ -83,10 +81,10 @@ func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
 	}
 
 	if _, ok := requirements.Requests[v1.ResourceCPU]; !ok {
-		requirements.Requests[v1.ResourceCPU] = DefaultCPURequests
+		requirements.Requests[v1.ResourceCPU] = DefaultCPU
 	}
 	if _, ok := requirements.Requests[v1.ResourceMemory]; !ok {
-		requirements.Requests[v1.ResourceMemory] = DefaultMemoryRequests
+		requirements.Requests[v1.ResourceMemory] = DefaultMemory
 	}
 
 	if requirements.Limits == nil {
@@ -94,10 +92,10 @@ func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
 	}
 
 	if _, ok := requirements.Limits[v1.ResourceCPU]; !ok {
-		requirements.Limits[v1.ResourceCPU] = DefaultCPULimits
+		requirements.Limits[v1.ResourceCPU] = DefaultCPU
 	}
 	if _, ok := requirements.Limits[v1.ResourceMemory]; !ok {
-		requirements.Limits[v1.ResourceMemory] = DefaultMemoryLimits
+		requirements.Limits[v1.ResourceMemory] = DefaultMemory
 	}
 }
 

--- a/pkg/apis/serving/v1alpha2/framework.go
+++ b/pkg/apis/serving/v1alpha2/framework.go
@@ -39,6 +39,8 @@ const (
 var (
 	DefaultMemoryRequests = resource.MustParse("2Gi")
 	DefaultCPURequests    = resource.MustParse("1")
+	DefaultMemoryLimits   = resource.MustParse("2Gi")
+	DefaultCPULimits      = resource.MustParse("1")
 )
 
 // Returns a URI to the model. This URI is passed to the model-initializer via the ModelInitializerSourceUriInternalAnnotationKey
@@ -85,6 +87,17 @@ func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
 	}
 	if _, ok := requirements.Requests[v1.ResourceMemory]; !ok {
 		requirements.Requests[v1.ResourceMemory] = DefaultMemoryRequests
+	}
+
+	if requirements.Limits == nil {
+		requirements.Limits = v1.ResourceList{}
+	}
+
+	if _, ok := requirements.Limits[v1.ResourceCPU]; !ok {
+		requirements.Limits[v1.ResourceCPU] = DefaultCPULimits
+	}
+	if _, ok := requirements.Limits[v1.ResourceMemory]; !ok {
+		requirements.Limits[v1.ResourceMemory] = DefaultMemoryLimits
 	}
 }
 

--- a/pkg/apis/serving/v1alpha2/kfservice_defaults_test.go
+++ b/pkg/apis/serving/v1alpha2/kfservice_defaults_test.go
@@ -46,6 +46,8 @@ func TestTensorflowDefaults(t *testing.T) {
 	g.Expect(kfsvc.Spec.Default.Tensorflow.RuntimeVersion).To(gomega.Equal(DefaultTensorflowRuntimeVersion))
 	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPURequests))
 	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemoryRequests))
+	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPULimits))
+	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemoryLimits))
 	g.Expect(kfsvc.Spec.Canary.Tensorflow.RuntimeVersion).To(gomega.Equal("1.11"))
 	g.Expect(kfsvc.Spec.Canary.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPURequests))
 	g.Expect(kfsvc.Spec.Canary.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))

--- a/pkg/apis/serving/v1alpha2/kfservice_defaults_test.go
+++ b/pkg/apis/serving/v1alpha2/kfservice_defaults_test.go
@@ -44,11 +44,11 @@ func TestTensorflowDefaults(t *testing.T) {
 	kfsvc.Default()
 
 	g.Expect(kfsvc.Spec.Default.Tensorflow.RuntimeVersion).To(gomega.Equal(DefaultTensorflowRuntimeVersion))
-	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPURequests))
-	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemoryRequests))
-	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPULimits))
-	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemoryLimits))
+	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(kfsvc.Spec.Default.Tensorflow.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
 	g.Expect(kfsvc.Spec.Canary.Tensorflow.RuntimeVersion).To(gomega.Equal("1.11"))
-	g.Expect(kfsvc.Spec.Canary.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPURequests))
+	g.Expect(kfsvc.Spec.Canary.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
 	g.Expect(kfsvc.Spec.Canary.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix the bug that resources limits are not defaulted when it is not specified on KFService spec and knative's default limit is smaller than KFService's default requests.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubeflow/kfserving/issues/291

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/293)
<!-- Reviewable:end -->
