### PR TITLE
storage: Allow get s3 object with fully specified path

### DIFF
--- a/python/.pylintrc
+++ b/python/.pylintrc
@@ -11,7 +11,7 @@ ignore=CVS
 
 # Add files or directories matching the regex patterns to the blacklist. The
 # regex matches against base names, not paths.
-ignore-patterns=server.py,anchor_tabular.py,explainer.py,model.py,api_client.py,rest.py,configuration.py,v1alpha2_*,v1_time.py,knative_*,test_knative_*,test_v1alpha2_*
+ignore-patterns=server.py,anchor_tabular.py,explainer.py,model.py,api_client.py,rest.py,configuration.py,v1alpha2_*,v1_time.py,knative_*,test_knative_*,test_v1alpha2_*,test_s3_storage.py
 
 # Python code to execute, usually for sys.path manipulation such as
 # pygtk.require().

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -70,6 +70,8 @@ class Storage(object): # pylint: disable=too-few-public-methods
         for obj in objects:
             # Replace any prefix from the object key with temp_dir
             subdir_object_key = obj.object_name.replace(bucket_path, "", 1).strip("/")
+            if subdir_object_key == "":
+                subdir_object_key = obj.object_name.split("/")[-1]
             client.fget_object(bucket_name, obj.object_name,
                                os.path.join(temp_dir, subdir_object_key))
 

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -13,8 +13,6 @@
 # limitations under the License.
 
 import unittest.mock as mock
-import pytest
-from azure.common import AzureMissingResourceHttpError
 import kfserving
 
 def create_mock_obj(path):

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -34,7 +34,7 @@ def get_call_args(call_args_list):
 
 def expected_call_args_list(bucket_name, parent_key, dest, paths):
     return [(bucket_name, f'{parent_key}/{p}'.strip('/'), f'{dest}/{p}'.strip('/'))
-            for p in paths] # pylint: disable=syntax-error
+            for p in paths]
 
 # pylint: disable=protected-access
 
@@ -48,8 +48,7 @@ def test_parent_key(mock_storage):
 
     # when
     mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
-    kfserving.Storage._download_s3(f's3://{bucket_name}/bar', 'dest_path') # pylint: disable=syntax-error
-
+    kfserving.Storage._download_s3(f's3://{bucket_name}/bar', 'dest_path')
 
     # then
     arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
@@ -66,7 +65,7 @@ def test_no_key(mock_storage):
 
     # when
     mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
-    kfserving.Storage._download_s3(f's3://{bucket_name}/', 'dest_path') # pylint: disable=syntax-error
+    kfserving.Storage._download_s3(f's3://{bucket_name}/', 'dest_path')
 
     # then
     arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
@@ -83,7 +82,7 @@ def test_full_name_key(mock_storage):
 
     # when
     mock_minio_client = create_mock_minio_client(mock_storage, [object_key])
-    kfserving.Storage._download_s3(f's3://{bucket_name}/{object_key}', 'dest_path') # pylint: disable=syntax-error
+    kfserving.Storage._download_s3(f's3://{bucket_name}/{object_key}', 'dest_path')
 
     # then
     arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -1,0 +1,95 @@
+# Copyright 2019 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import unittest.mock as mock
+import pytest
+from azure.common import AzureMissingResourceHttpError
+import kfserving
+
+def create_mock_obj(path):
+    mock_obj = mock.MagicMock()
+    mock_obj.object_name = path
+    return mock_obj
+
+def create_mock_minio_client(mock_storage, paths):
+    mock_minio_client = mock_storage.return_value
+    mock_minio_client.list_objects.return_value = [create_mock_obj(p) for p in paths]
+    return mock_minio_client
+
+def get_call_args(call_args_list):
+    arg_list = []
+    for call in call_args_list:
+        args, _ = call
+        arg_list.append(args)
+    return arg_list
+
+def expected_call_args_list(bucket_name, parent_key, dest, paths):
+    return [(bucket_name, f'{parent_key}/{p}'.strip('/'), f'{dest}/{p}'.strip('/'))
+            for p in paths]
+
+# pylint: disable=protected-access
+
+@mock.patch('kfserving.storage.Minio')
+def test_parent_key(mock_storage): # pylint: disable=unused-argument
+
+    # given
+    bucket_name = 'foo'
+    paths = ['models/weights.pt', '0002.h5', 'a/very/long/path/config.json']
+    object_paths = ['bar/' + p for p in paths]
+
+    # when
+    mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
+    kfserving.Storage._download_s3(f's3://{bucket_name}/bar', 'dest_path')
+
+    # then
+    arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
+    assert arg_list == expected_call_args_list(bucket_name, 'bar', 'dest_path', paths)
+
+    mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='bar', recursive=True)
+
+@mock.patch('kfserving.storage.Minio')
+def test_no_key(mock_storage): # pylint: disable=unused-argument
+
+    # given
+    bucket_name = 'foo'
+    object_paths = ['models/weights.pt', '0002.h5', 'a/very/long/path/config.json']
+
+    # when
+    mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
+    kfserving.Storage._download_s3(f's3://{bucket_name}/', 'dest_path')
+
+    # then
+    arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
+    assert arg_list == expected_call_args_list(bucket_name, '', 'dest_path', object_paths)
+
+    mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='', recursive=True)
+
+@mock.patch('kfserving.storage.Minio')
+def test_full_name_key(mock_storage): # pylint: disable=unused-argument
+
+    # given
+    bucket_name = 'foo'
+    object_key = 'path/to/model/name.pt'
+
+    # when
+    mock_minio_client = create_mock_minio_client(mock_storage, [object_key])
+    kfserving.Storage._download_s3(f's3://{bucket_name}/{object_key}', 'dest_path')
+
+    # then
+    arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
+    assert arg_list == expected_call_args_list(bucket_name, 'path/to/model', 'dest_path',
+                                               ['name.pt'])
+
+    mock_minio_client.list_objects.assert_called_with(bucket_name, prefix=object_key,
+                                                      recursive=True)

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -32,6 +32,8 @@ def get_call_args(call_args_list):
         arg_list.append(args)
     return arg_list
 
+# pylint: disable=syntax-error
+
 def expected_call_args_list(bucket_name, parent_key, dest, paths):
     return [(bucket_name, f'{parent_key}/{p}'.strip('/'), f'{dest}/{p}'.strip('/'))
             for p in paths]
@@ -39,7 +41,7 @@ def expected_call_args_list(bucket_name, parent_key, dest, paths):
 # pylint: disable=protected-access
 
 @mock.patch('kfserving.storage.Minio')
-def test_parent_key(mock_storage): # pylint: disable=unused-argument
+def test_parent_key(mock_storage):
 
     # given
     bucket_name = 'foo'
@@ -57,7 +59,7 @@ def test_parent_key(mock_storage): # pylint: disable=unused-argument
     mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='bar', recursive=True)
 
 @mock.patch('kfserving.storage.Minio')
-def test_no_key(mock_storage): # pylint: disable=unused-argument
+def test_no_key(mock_storage):
 
     # given
     bucket_name = 'foo'
@@ -74,7 +76,7 @@ def test_no_key(mock_storage): # pylint: disable=unused-argument
     mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='', recursive=True)
 
 @mock.patch('kfserving.storage.Minio')
-def test_full_name_key(mock_storage): # pylint: disable=unused-argument
+def test_full_name_key(mock_storage):
 
     # given
     bucket_name = 'foo'

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -32,11 +32,9 @@ def get_call_args(call_args_list):
         arg_list.append(args)
     return arg_list
 
-# pylint: disable=syntax-error
-
 def expected_call_args_list(bucket_name, parent_key, dest, paths):
     return [(bucket_name, f'{parent_key}/{p}'.strip('/'), f'{dest}/{p}'.strip('/'))
-            for p in paths]
+            for p in paths] # pylint: disable=syntax-error
 
 # pylint: disable=protected-access
 
@@ -50,7 +48,8 @@ def test_parent_key(mock_storage):
 
     # when
     mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
-    kfserving.Storage._download_s3(f's3://{bucket_name}/bar', 'dest_path')
+    kfserving.Storage._download_s3(f's3://{bucket_name}/bar', 'dest_path') # pylint: disable=syntax-error
+
 
     # then
     arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
@@ -67,7 +66,7 @@ def test_no_key(mock_storage):
 
     # when
     mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
-    kfserving.Storage._download_s3(f's3://{bucket_name}/', 'dest_path')
+    kfserving.Storage._download_s3(f's3://{bucket_name}/', 'dest_path') # pylint: disable=syntax-error
 
     # then
     arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
@@ -84,7 +83,7 @@ def test_full_name_key(mock_storage):
 
     # when
     mock_minio_client = create_mock_minio_client(mock_storage, [object_key])
-    kfserving.Storage._download_s3(f's3://{bucket_name}/{object_key}', 'dest_path')
+    kfserving.Storage._download_s3(f's3://{bucket_name}/{object_key}', 'dest_path') # pylint: disable=syntax-error
 
     # then
     arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Previously using storage to download s3 objects, we have to specify the parent key, with this patch it can download files with full path.

**Release note**:
```release-note
None
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/302)
<!-- Reviewable:end -->
