### PR TITLE
fix pytouch build timeout issue in presubmit

### DIFF
--- a/test/scripts/build-python-image.sh
+++ b/test/scripts/build-python-image.sh
@@ -38,5 +38,5 @@ echo "Activating service-account"
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
 
 cp $1 Dockerfile
-gcloud builds submit . --tag=${REGISTRY}/${REPO_NAME}/$2:${VERSION} --project=${PROJECT}
+gcloud builds submit . --tag=${REGISTRY}/${REPO_NAME}/$2:${VERSION} --project=${PROJECT} --timeout=20m
 gcloud container images add-tag --quiet ${REGISTRY}/${REPO_NAME}/$2:${VERSION} ${REGISTRY}/${REPO_NAME}/$2:latest --verbosity=info


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
I always hit some presubmit timeout problem for while pytorchserver building as below.
```
Removing intermediate container 6cb3f3f8be8b
---> 1a3a8eb6797a
Step 11/11 : ENTRYPOINT ["python", "-m", "pytorchserver"]
Your build timed out. Use the [--timeout=DURATION] flag to change the timeout threshold.
ERROR: (gcloud.builds.submit) build f9314385-826e-4dcf-913f-24abf06f9fce completed with status "TIMEOUT"
---> Running in 4d7ec527356e
```
Checked,  If timeout is not set, a default timeout of 10 minutes will apply to the build. Seems the build may be cannot finished in the 10 minutes, we should extend the time.
**Which issue(s) this PR fixes** :
Fixes #303

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/304)
<!-- Reviewable:end -->
