### PR TITLE
update from v1alpha1 to v1alpha2 for some docs and samples

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -14,6 +14,7 @@
     - [Deploy KFServing with your own version](#deploy-kfserving-with-your-own-version)
     - [Smoke test after deployment](#smoke-test-after-deployment)
   - [Iterating](#iterating)
+    - [Knative CLI (knctl):](#knative-cli-knctl)
   - [Troubleshooting](#troubleshooting)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
@@ -178,7 +179,7 @@ of:
   `make manifests`. Inputs include:
 
   - API type definitions in
-    [pkg/apis/serving/v1alpha1/](../pkg/apis/serving/v1alpha2/.),
+    [pkg/apis/serving/v1alpha2/](../pkg/apis/serving/v1alpha2/.),
   - Manifests or kustomize patches stored in [config](../config).
 
 - **If you change a package's deps** (including adding external dep), then you

--- a/docs/control-plane.md
+++ b/docs/control-plane.md
@@ -9,7 +9,7 @@ This top level resource definition is shared by all Kubernetes Custom Resources.
 | Field       |  Value      | Description |
 | ----------- | ----------- | ----------- |
 | kind       | KFService                     | [Read the Docs](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#types-kinds) |
-| apiVersion | serving.kubeflow.org/v1alpha1 | [Read the Docs](https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning) |
+| apiVersion | serving.kubeflow.org/v1alpha2 | [Read the Docs](https://kubernetes.io/docs/reference/using-api/api-overview/#api-versioning) |
 | metadata   | [Metadata](#Metadata)         | [Read the Docs](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#metadata) |
 | spec       | [Spec](#Spec)                 | [Read the Docs](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status) |
 | status     | [Status](#Status)             | [Read the Docs](https://github.com/kubernetes/community/blob/master/contributors/devel/sig-architecture/api-conventions.md#spec-and-status) |

--- a/docs/samples/accelerators/tensorflow-gpu.yaml
+++ b/docs/samples/accelerators/tensorflow-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "tensorflow-gpu"

--- a/docs/samples/accelerators/xgboost-gpu.yaml
+++ b/docs/samples/accelerators/xgboost-gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "xgboost-gpu"

--- a/docs/samples/autoscaling/README.md
+++ b/docs/samples/autoscaling/README.md
@@ -212,7 +212,7 @@ is pretty easy and effective!
 ### Create the KFService with GPU resource
 Apply the tensorflow gpu example CR
 ```
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "flowers-sample-gpu"
@@ -289,7 +289,7 @@ Status code distribution:
 You can also customize the target concurrency by adding annotation `autoscaling.knative.dev/target: "10"` on `KFService` CR.
 
 ```yaml
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "flowers-sample"

--- a/docs/samples/autoscaling/autoscale.yaml
+++ b/docs/samples/autoscaling/autoscale.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "flowers-sample"

--- a/docs/samples/autoscaling/autoscale_custom.yaml
+++ b/docs/samples/autoscaling/autoscale_custom.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "flowers-sample"

--- a/docs/samples/autoscaling/autoscale_gpu.yaml
+++ b/docs/samples/autoscaling/autoscale_gpu.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "flowers-sample-gpu"

--- a/docs/samples/custom/custom.yaml
+++ b/docs/samples/custom/custom.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.kubeflow.org/v1alpha1
+apiVersion: serving.kubeflow.org/v1alpha2
 kind: KFService
 metadata:
   labels:

--- a/docs/samples/pytorch/pytorch.yaml
+++ b/docs/samples/pytorch/pytorch.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "pytorch-cifar10"

--- a/docs/samples/rollouts/canary.yaml
+++ b/docs/samples/rollouts/canary.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "my-model"

--- a/docs/samples/rollouts/pinned.yaml
+++ b/docs/samples/rollouts/pinned.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "my-model"

--- a/docs/samples/s3/tensorflow_s3.yaml
+++ b/docs/samples/s3/tensorflow_s3.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "mnist-s3"

--- a/docs/samples/sklearn/sklearn.yaml
+++ b/docs/samples/sklearn/sklearn.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "sklearn-iris"

--- a/docs/samples/tensorflow/tensorflow-canary.yaml
+++ b/docs/samples/tensorflow/tensorflow-canary.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "flowers-sample"

--- a/docs/samples/tensorflow/tensorflow.yaml
+++ b/docs/samples/tensorflow/tensorflow.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "flowers-sample"

--- a/docs/samples/tensorrt/tensorrt.yaml
+++ b/docs/samples/tensorrt/tensorrt.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "tensorrt-simple-string"

--- a/docs/samples/xgboost/xgboost.yaml
+++ b/docs/samples/xgboost/xgboost.yaml
@@ -1,4 +1,4 @@
-apiVersion: "serving.kubeflow.org/v1alpha1"
+apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "KFService"
 metadata:
   name: "xgboost-iris"

--- a/python/kfserving/test/test_kfservice_client.py
+++ b/python/kfserving/test/test_kfservice_client.py
@@ -13,7 +13,7 @@ KFServing = KFServingClient()
 mocked_unit_result = \
 '''
 {
-    "api_version": "serving.kubeflow.org/v1alpha1",
+    "api_version": "serving.kubeflow.org/v1alpha2",
     "kind": "KFService",
     "metadata": {
         "name": "flower-sample",
@@ -33,7 +33,7 @@ def generate_kfservice():
     default_model_spec = V1alpha2ModelSpec(tensorflow=V1alpha2TensorflowSpec(
         model_uri='gs://kfserving-samples/models/tensorflow/flowers'))
 
-    kfsvc = V1alpha2KFService(api_version='serving.kubeflow.org/v1alpha1',
+    kfsvc = V1alpha2KFService(api_version='serving.kubeflow.org/v1alpha2',
                               kind='KFService',
                               metadata=client.V1ObjectMeta(name='flower-sample'),
                               spec=V1alpha2KFServiceSpec(default=default_model_spec))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
After I installed the last KFServing, and try to deploy KFService using sample, but failed due to the mismatched version. The PR is to update from v1alpha1 to v1alpha2 for some docs and samples.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/308)
<!-- Reviewable:end -->
