### PR TITLE
add available images to configmap

### DIFF
--- a/pkg/apis/serving/v1alpha2/framework_scikit.go
+++ b/pkg/apis/serving/v1alpha2/framework_scikit.go
@@ -26,6 +26,7 @@ import (
 var (
 	AllowedSKLearnRuntimeVersions = []string{
 		"latest",
+		"v0.1.2",
 	}
 	InvalidSKLearnRuntimeVersionError = "RuntimeVersion must be one of " + strings.Join(AllowedSKLearnRuntimeVersions, ", ")
 	SKLearnServerImageName            = "gcr.io/kfserving/sklearnserver"

--- a/pkg/apis/serving/v1alpha2/framework_xgboost.go
+++ b/pkg/apis/serving/v1alpha2/framework_xgboost.go
@@ -26,6 +26,7 @@ import (
 var (
 	AllowedXGBoostRuntimeVersions = []string{
 		"latest",
+		"v0.1.2",
 	}
 	InvalidXGBoostRuntimeVersionError = "RuntimeVersion must be one of " + strings.Join(AllowedXGBoostRuntimeVersions, ", ")
 	XGBoostServerImageName            = "gcr.io/kfserving/xgbserver"

--- a/pkg/apis/serving/v1alpha2/kfservice_framework_pytorch.go
+++ b/pkg/apis/serving/v1alpha2/kfservice_framework_pytorch.go
@@ -26,6 +26,7 @@ import (
 var (
 	AllowedPyTorchRuntimeVersions = []string{
 		"latest",
+		"v0.1.2",
 	}
 	InvalidPyTorchRuntimeVersionError = "RuntimeVersion must be one of " + strings.Join(AllowedPyTorchRuntimeVersions, ", ")
 	PyTorchServerImageName            = "gcr.io/kfserving/pytorchserver"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Today I investigated the issue #296 , seems that works for last docker image, but the user cannot input the last docker image as `RuntimeVersion must be one of latest`, and `latest` image is not last one.

```
(python36) [root@jinchi1 kfserving]# kubectl create -f /opt/kubeflow/shared/kfserving/docs/samples/pytorch/pytorch.yaml
Error from server: error when creating "/opt/kubeflow/shared/kfserving/docs/samples/pytorch/pytorch.yaml": admission webhook "kfservice.kfserving-webhook-server.validator" denied the request: RuntimeVersion must be one of latest
```
We should add more available images so that user can configure the docker image tag while define the kfservice. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/319)
<!-- Reviewable:end -->
