### PR TITLE
Temporarily point to custom location for storage-initializer

### DIFF
--- a/config/default/configmap/kfservice.yaml
+++ b/config/default/configmap/kfservice.yaml
@@ -27,7 +27,7 @@ data:
     }
   storageInitializer: |-
     {
-        "image" : "gcr.io/kfserving/storage-initializer:latest"
+        "image" : "kcorer/storage-initializer:latest"
     }
   credentials: |-
     {


### PR DESCRIPTION
#327 changed the image name for the initializer. However the new one is not available in GCR. Point to a custom one for now. Have opened an issue to revert this..

Fixed commits from #330

/assign @yuzisun

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/333)
<!-- Reviewable:end -->
