### PR TITLE
fix testing problem in building image steps

### DIFF
--- a/test/scripts/build-python-image.sh
+++ b/test/scripts/build-python-image.sh
@@ -20,11 +20,16 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-cd python
 if [ ! $# -eq 2 ]; then
   echo "build-python-image.sh dockerFile imageName"
   exit -1
 fi
+
+# Avoid conflicts due to multipe components parallel executing in same folder.
+mkdir -p build_for_$2
+cp -rf python/* build_for_$2
+cd build_for_$2
+
 if [ ! -f $1 ]; then
   echo "dockerFile $1 doesn't exist"
   exit -1


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The CI/CD testing always failed due to #342, logs are as following:
```
Activating service-account
Activated service account credentials for: [kubeflow-testing@kubeflow-ci.iam.gserviceaccount.com]
cp: cannot create regular file ‘Dockerfile’: File exists
```

The problem should be cuased by file conflicts due to multipe components parallel executing in same folder. See details in #342 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #342 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/349)
<!-- Reviewable:end -->
