### PR TITLE
adding repalce and promote APIs for kfserving sdk

### DIFF
--- a/docs/samples/client/kfserving_sdk_sample.ipynb
+++ b/docs/samples/client/kfserving_sdk_sample.ipynb
@@ -171,15 +171,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "kfsvc = V1alpha2KFService(api_version=api_version,\n",
-    "                          kind=constants.KFSERVING_KIND,\n",
-    "                          metadata=client.V1ObjectMeta(\n",
-    "                              name='flower-sample', namespace='kubeflow'),\n",
-    "                          spec=V1alpha2KFServiceSpec(default=canary_endpoint_spec,\n",
-    "                                                     canary=None,\n",
-    "                                                     canary_traffic_percent=0))\n",
-    "\n",
-    "KFServing.patch('flower-sample', kfsvc)"
+    "KFServing.promote('flower-sample', namespace='kubeflow')"
    ]
   },
   {

--- a/python/kfserving/docs/KFServingClient.md
+++ b/python/kfserving/docs/KFServingClient.md
@@ -20,6 +20,7 @@ KFServingClient | [set_credentials](#set_credentials) | Set Credentials|
 KFServingClient | [create](#create) | Create KFService|
 KFServingClient | [get](#get)    | Get or watch the specified KFService or all KFServices in the namespace |
 KFServingClient | [patch](#patch)  | Patch the specified KFService|
+KFServingClient | [promote](#promote) | Promote the specified KFService|
 KFServingClient | [delete](#delete) | Delete the specified KFService |
 
 ## set_credentials
@@ -216,6 +217,34 @@ Name | Type |  Description | Notes
 kfservice  | [V1alpha2KFService](V1alpha2KFService.md) | KFService defination| Required |
 namespace | str | The KFService's namespace for patching. If the `namespace` is not defined, will align with KFService definition, or use current or default namespace if namespace is not specified in KFService definition. | Optional|
 watch | bool | Watch the patched KFService if `True`, otherwise will return the patched KFService object. Stop watching if KFService reaches the optional specified `timeout_seconds` or once the KFService overall status `READY` is `True`. | Optional |
+timeout_seconds | int | Timeout seconds for watching. Defaults to 600. | Optional |
+
+### Return type
+object
+
+
+## promote
+> promote(name, namespace=None, watch=False, timeout_seconds=600)
+
+Promote the `Canary KFServiceSpec` to `Default KFServiceSpec` for the created KFService in the specified namespace.
+
+### Example
+
+```python
+
+KFServing = KFServingClient()
+KFServing.promote('flower-sample', namespace='kubeflow')
+
+# The API also supports watching the promoted KFService status till it's READY.
+# KFServing.promote('flower-sample', namespace='kubeflow', watch=True)
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+Name  | str | The KFService name for promoting.| |
+namespace | str | The KFService's namespace. If the `namespace` is not defined, will align with KFService definition, or use current or default namespace if namespace is not specified in KFService definition. | Optional|
+watch | bool | Watch the promoted KFService if `True`, otherwise will return the promoted KFService object. Stop watching if KFService reaches the optional specified `timeout_seconds` or once the KFService overall status `READY` is `True`. | Optional |
 timeout_seconds | int | Timeout seconds for watching. Defaults to 600. | Optional |
 
 ### Return type

--- a/python/kfserving/docs/KFServingClient.md
+++ b/python/kfserving/docs/KFServingClient.md
@@ -20,7 +20,8 @@ KFServingClient | [set_credentials](#set_credentials) | Set Credentials|
 KFServingClient | [create](#create) | Create KFService|
 KFServingClient | [get](#get)    | Get or watch the specified KFService or all KFServices in the namespace |
 KFServingClient | [patch](#patch)  | Patch the specified KFService|
-KFServingClient | [promote](#promote) | Promote the specified KFService|
+KFServingClient | [replace](#replace) | Replace the specified KFService|
+KFServingClient | [promote](#promote) | Promote the `canary` version of the KFService to `default`|
 KFServingClient | [delete](#delete) | Delete the specified KFService |
 
 ## set_credentials
@@ -178,7 +179,9 @@ object
 ## patch
 > patch(name, kfservice, namespace=None, watch=False, timeout_seconds=600)
 
-Patch the created KFService in the specified namespace
+Patch the created KFService in the specified namespace.
+
+Note that if you want to set the field from existing value to `None`, `patch` API may not work, you need to use [replace](#replace) API to remove the field value.
 
 ### Example
 
@@ -217,6 +220,58 @@ Name | Type |  Description | Notes
 kfservice  | [V1alpha2KFService](V1alpha2KFService.md) | KFService defination| Required |
 namespace | str | The KFService's namespace for patching. If the `namespace` is not defined, will align with KFService definition, or use current or default namespace if namespace is not specified in KFService definition. | Optional|
 watch | bool | Watch the patched KFService if `True`, otherwise will return the patched KFService object. Stop watching if KFService reaches the optional specified `timeout_seconds` or once the KFService overall status `READY` is `True`. | Optional |
+timeout_seconds | int | Timeout seconds for watching. Defaults to 600. | Optional |
+
+### Return type
+object
+
+## replace
+> replace(name, kfservice, namespace=None, watch=False, timeout_seconds=600)
+
+Replace the created KFService in the specified namespace. Generally use the `replace` API to update whole KFService or remove a field such as canary or other components of the KFService.
+
+### Example
+
+```python
+from kubernetes import client
+from kfserving import constants
+from kfserving import V1alpha2EndpointSpec
+from kfserving import V1alpha2PredictorSpec
+from kfserving import V1alpha2TensorflowSpec
+from kfserving import V1alpha2KFServiceSpec
+from kfserving import V1alpha2KFService
+from kfserving import KFServingClient
+
+default_endpoint_spec = V1alpha2EndpointSpec(
+                          predictor=V1alpha2PredictorSpec(
+                            tensorflow=V1alpha2TensorflowSpec(
+                              storage_uri='gs://kfserving-samples/models/tensorflow/flowers',
+                              resources=None)))
+
+kfsvc = V1alpha2KFService(api_version=api_version,
+                          kind=constants.KFSERVING_KIND,
+                          metadata=client.V1ObjectMeta(
+                            name='flower-sample',
+                            namespace='kubeflow',
+                            resource_version=resource_version),
+                          spec=V1alpha2KFServiceSpec(default=default_endpoint_spec,
+                                                     canary=None,
+                                                     canary_traffic_percent=0))
+
+
+KFServing = KFServingClient()
+KFServing.replace('flower-sample', kfsvc)
+
+# The API also supports watching the replaced KFService status till it's READY.
+# KFServing.replace('flower-sample', kfsvc, watch=True)
+```
+
+### Parameters
+Name | Type |  Description | Notes
+------------ | ------------- | ------------- | -------------
+kfservice  | [V1alpha2KFService](V1alpha2KFService.md) | KFService defination| Required |
+namespace | str | The KFService's namespace. If the `namespace` is not defined, will align with KFService definition, or use current or default namespace if namespace is not specified in KFService definition. | Optional|
+watch | bool | Watch the patched KFService if `True`, otherwise will return the replaced KFService object. Stop watching if KFService reaches the optional specified `timeout_seconds` or once the KFService overall status `READY` is `True`. | Optional |
 timeout_seconds | int | Timeout seconds for watching. Defaults to 600. | Optional |
 
 ### Return type

--- a/python/kfserving/kfserving/api/kf_serving_client.py
+++ b/python/kfserving/kfserving/api/kf_serving_client.py
@@ -169,32 +169,16 @@ class KFServingClient(object):
         else:
             return outputs
 
-    def promote(self, name, namespace=None, watch=False, timeout_seconds=600): # pylint:disable=too-many-arguments,inconsistent-return-statements
-        """Promote the created KFService in the specified namespace"""
+    def replace(self, name, kfservice, namespace=None, watch=False, timeout_seconds=600): # pylint:disable=too-many-arguments,inconsistent-return-statements
+        """Replace the created KFService in the specified namespace"""
 
         if namespace is None:
-            namespace = utils.get_default_target_namespace()
+            namespace = utils.set_kfsvc_namespace(kfservice)
 
-        current_kfsvc = self.get(name, namespace=namespace)
-        api_version = current_kfsvc['apiVersion']
-        resource_version = current_kfsvc['metadata']['resourceVersion']
-
-        try:
-            current_canary_spec = current_kfsvc['spec']['canary']
-        except KeyError as e:
-            raise RuntimeError("Cannot promote a KFService that has no Canary Spec.")
-
-        kfservice = V1alpha2KFService(
-            api_version=api_version,
-            kind=constants.KFSERVING_KIND,
-            metadata=client.V1ObjectMeta(
-                name=name,
-                namespace=namespace,
-                resource_version=resource_version),
-            spec=V1alpha2KFServiceSpec(
-                default=current_canary_spec,
-                canary=None,
-                canary_traffic_percent=0))
+        if kfservice.metadata.resource_version is None:
+            current_kfsvc = self.get(name, namespace=namespace)
+            current_resource_version = current_kfsvc['metadata']['resourceVersion']
+            kfservice.metadata.resource_version = current_resource_version
 
         try:
             outputs = self.api_instance.replace_namespaced_custom_object(
@@ -216,6 +200,36 @@ class KFServingClient(object):
                 timeout_seconds=timeout_seconds)
         else:
             return outputs
+
+
+    def promote(self, name, namespace=None, watch=False, timeout_seconds=600): # pylint:disable=too-many-arguments,inconsistent-return-statements
+        """Promote the created KFService in the specified namespace"""
+
+        if namespace is None:
+            namespace = utils.get_default_target_namespace()
+
+        current_kfsvc = self.get(name, namespace=namespace)
+        api_version = current_kfsvc['apiVersion']
+
+        try:
+            current_canary_spec = current_kfsvc['spec']['canary']
+        except KeyError:
+            raise RuntimeError("Cannot promote a KFService that has no Canary Spec.")
+
+        kfservice = V1alpha2KFService(
+            api_version=api_version,
+            kind=constants.KFSERVING_KIND,
+            metadata=client.V1ObjectMeta(
+                name=name,
+                namespace=namespace),
+            spec=V1alpha2KFServiceSpec(
+                default=current_canary_spec,
+                canary=None,
+                canary_traffic_percent=0))
+
+        return self.replace(name=name, kfservice=kfservice, namespace=namespace,
+                            watch=watch, timeout_seconds=timeout_seconds)
+
 
     def delete(self, name, namespace=None):
         """Delete the provided KFService in the specified namespace"""

--- a/python/kfserving/test/test_kfservice_client.py
+++ b/python/kfserving/test/test_kfservice_client.py
@@ -90,12 +90,18 @@ def test_kfservice_client_patch():
         kfsvc = generate_kfservice()
         assert mocked_unit_result == KFServing.patch('flower-sample', kfsvc, namespace='kubeflow')
 
-def test_kfservice_client_premote():
-    '''Unit test for kfserving premote api'''
-    with patch('kfserving.api.kf_serving_client.KFServingClient.premote',
+def test_kfservice_client_promote():
+    '''Unit test for kfserving promote api'''
+    with patch('kfserving.api.kf_serving_client.KFServingClient.promote',
+               return_value=mocked_unit_result):
+        assert mocked_unit_result == KFServing.promote('flower-sample', namespace='kubeflow')
+
+def test_kfservice_client_replace():
+    '''Unit test for kfserving replace api'''
+    with patch('kfserving.api.kf_serving_client.KFServingClient.replace',
                return_value=mocked_unit_result):
         kfsvc = generate_kfservice()
-        assert mocked_unit_result == KFServing.patch('flower-sample', kfsvc, namespace='kubeflow')
+        assert mocked_unit_result == KFServing.replace('flower-sample', kfsvc, namespace='kubeflow')
 
 def test_kfservice_client_delete():
     '''Unit test for kfserving delete api'''

--- a/python/kfserving/test/test_kfservice_client.py
+++ b/python/kfserving/test/test_kfservice_client.py
@@ -90,6 +90,12 @@ def test_kfservice_client_patch():
         kfsvc = generate_kfservice()
         assert mocked_unit_result == KFServing.patch('flower-sample', kfsvc, namespace='kubeflow')
 
+def test_kfservice_client_premote():
+    '''Unit test for kfserving premote api'''
+    with patch('kfserving.api.kf_serving_client.KFServingClient.premote',
+               return_value=mocked_unit_result):
+        kfsvc = generate_kfservice()
+        assert mocked_unit_result == KFServing.patch('flower-sample', kfsvc, namespace='kubeflow')
 
 def test_kfservice_client_delete():
     '''Unit test for kfserving delete api'''


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The PR is going to add two new APIs:
1. API `promote` to handle promote Canary to Default case.
2. API `Replace` to handle cases that user cannot set the field from existing value to `None` by `patch` API (@yuzisun met that while want to set Canary Spec to None).

The `Replace` called kubernetes API [replace_namespaced_custom_object](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CustomObjectsApi.md#replace_namespaced_custom_object), instead of  [patch_namespaced_custom_object](https://github.com/kubernetes-client/python/blob/master/kubernetes/docs/CustomObjectsApi.md#patch_namespaced_custom_object) which is called by `patch` API. The reason is that there is a problem for `patch_namespaced_custom_object` api of kfserving python SDK while set the Canary to None, after patching, the Canary are not removed, keep old value as below.

```
 'spec': {'canary': {'predictor': {'tensorflow': {'resources': {'limits': {'cpu': '100m',
       'memory': '1Gi'},
      'requests': {'cpu': '100m', 'memory': '1Gi'}},
     'runtimeVersion': 'latest',
     'storageUri': 'gs://kfserving-samples/models/tensorflow/flowers-2'}}},
```

Checked the kubernetes API `patch_namespaced_custom_object` which is called by `patch` API of kfserving SDK, if we set to `None`, the api will take this as "no input/update", so the Canary will not be updated. For this scene, I think we should call `replace_namespaced_custom_object` of k8s python client.

The `promote` called `replace` API for user easily promote from Canary to Default Spec.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Added `promote` API for kfserving python SDK Client
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/357)
<!-- Reviewable:end -->
