### PR TITLE
Update the Knative installation guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,7 @@ KFServing encapsulates the complexity of autoscaling, networking, health checkin
 KNative Serving and Istio should be available on Kubernetes Cluster.
 - Istio Version: v1.1.7 + 
 - Knative Version: v0.8.0 +
+
 You may find this [installation instruction](https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#install-knative-on-a-kubernetes-cluster) useful.
 
 ### Install ###

--- a/README.md
+++ b/README.md
@@ -13,9 +13,10 @@ KFServing encapsulates the complexity of autoscaling, networking, health checkin
 * This project is an evolution of the [original proposal in the Kubeflow repo](https://github.com/kubeflow/kubeflow/issues/2306). 
 
 ### Prerequisits
-KNative Serving and Istio should be available on Kubernetes Cluster
+KNative Serving and Istio should be available on Kubernetes Cluster.
 - Istio Version: v1.1.7 + 
 - Knative Version: v0.8.0 +
+You may find this [installation instruction](https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#install-knative-on-a-kubernetes-cluster) useful.
 
 ### Install ###
 ```

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -57,8 +57,8 @@ KFServing currently requires `Knative Serving` for auto-scaling, canary rollout,
 * You can follow the instructions on [Set up a kubernetes cluster and install Knative Serving](https://knative.dev/docs/install/) or
 [Custom Install](https://knative.dev/docs/install/knative-custom-install) to install `Istio` and `Knative Serving`. Observability plug-ins are good to have for monitoring.
 
-* If you already have `Istio` (e.g. from a Kubeflow install) then simply skip the `Istio` steps. For Kubeflow install, you can install Knative serving via
-the following commands after downloading repository [kubeflow/manifest](https://github.com/kubeflow/manifests).
+* If you already have `Istio` (e.g. from a Kubeflow install) then simply skip the `Istio` steps. For Kubeflow install, you can install `Knative Serving` via
+the following commands after downloading repository [kubeflow/manifests](https://github.com/kubeflow/manifests).
 
   ``` kubeflow/manifests/knative/knative-serving-crd/base$ kustomize build . | kubectl apply -f -```
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -57,7 +57,7 @@ KFServing currently requires `Knative Serving` for auto-scaling, canary rollout,
 * You can follow the instructions on [Set up a kubernetes cluster and install Knative Serving](https://knative.dev/docs/install/) or
 [Custom Install](https://knative.dev/docs/install/knative-custom-install) to install `Istio` and `Knative Serving`. Observability plug-ins are good to have for monitoring.
 
-* If you already have `Istio` (e.g. from a Kubeflow install) then simply skip the `Istio` steps. For Kubeflow install, you can install `Knative Serving` via
+* If you already have `Istio` (e.g. from a Kubeflow install) then simply skip the `Istio` steps. For Kubeflow install, you can install `Knative Serving` v0.8 via
 the following commands after downloading repository [kubeflow/manifests](https://github.com/kubeflow/manifests).
 
   ``` kubeflow/manifests/knative/knative-serving-crd/base$ kustomize build . | kubectl apply -f -```

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -52,12 +52,17 @@ You must install these tools:
 
 ### Install Knative on a Kubernetes cluster
 
-1. [Set up a kubernetes cluster and install Knative Serving](https://knative.dev/docs/install/)
+KFServing currently requires `Knative Serving` for auto-scaling, canary rollout, `Istio` for traffic routing and ingress.
 
-- **Note**: KFServing currently only requires `Knative Serving` for auto-scaling, canary rollout,
- `Istio` for traffic routing and ingress. You can follow instructions on
- [Custom Install](https://knative.dev/docs/install/knative-custom-install) to install `Istio` and `Knative Serving`,
- observability plug-ins are good to have for monitoring. If you already have `Istio` (e.g. from a kubeflow install) then simply skip the `Istio` steps.
+* You can follow the instructions on [Set up a kubernetes cluster and install Knative Serving](https://knative.dev/docs/install/) or
+[Custom Install](https://knative.dev/docs/install/knative-custom-install) to install `Istio` and `Knative Serving`. Observability plug-ins are good to have for monitoring.
+
+* If you already have `Istio` (e.g. from a Kubeflow install) then simply skip the `Istio` steps. For Kubeflow install, you can install Knative serving via
+the following commands after downloading repository [kubeflow/manifest](https://github.com/kubeflow/manifests).
+
+  ``` kubeflow/manifests/knative/knative-serving-crd/base$ kustomize build . | kubectl apply -f -```
+
+  ``` kubeflow/manifests/knative/knative-serving-install/base$ kustomize build . | kubectl apply -f -```
 
 ### Setup your environment
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -60,7 +60,7 @@ KFServing currently requires `Knative Serving` for auto-scaling, canary rollout,
 * If you already have `Istio` (e.g. from a Kubeflow install) then simply skip the `Istio` steps. For Kubeflow install, you can install `Knative Serving` v0.8 via
 the following commands after downloading repository [kubeflow/manifests](https://github.com/kubeflow/manifests).
 
-  ``` kubeflow/manifests/knative/knative-serving-crd/base$ kustomize build . | kubectl apply -f -```
+  ``` kubeflow/manifests/knative/knative-serving-crds/base$ kustomize build . | kubectl apply -f -```
 
   ``` kubeflow/manifests/knative/knative-serving-install/base$ kustomize build . | kubectl apply -f -```
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add instructions on how to install Knative Serving via kubeflow/manifests. The original guide on installing knative v0.9 doesn't work with Kubeflow v0.6.2.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/359)
<!-- Reviewable:end -->
