### PR TITLE
make connection to minio configurable

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -193,8 +193,8 @@ class Storage(object): # pylint: disable=too-few-public-methods
     @staticmethod
     def _create_minio_client():
         # Remove possible http scheme for Minio
-        url = urlparse(os.getenv("S3_ENDPOINT", ""))
-        use_ssl = url.scheme=='https' if url.scheme else bool(os.getenv("USE_SSL", True))
+        url = urlparse(os.getenv("AWS_ENDPOINT_URL", ""))
+        use_ssl = url.scheme=='https' if url.scheme else bool(os.getenv("S3_USE_HTTPS", True))
         minioClient = Minio(url.netloc,
                             access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),
                             secret_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -17,6 +17,7 @@ import logging
 import tempfile
 import os
 import re
+from urllib.parse import urlparse
 from azure.common import AzureMissingResourceHttpError
 from azure.storage.blob import BlockBlobService
 from google.auth import exceptions
@@ -194,9 +195,8 @@ class Storage(object): # pylint: disable=too-few-public-methods
     def _create_minio_client():
         # Remove possible http scheme for Minio
         url = urlparse(os.getenv("AWS_ENDPOINT_URL", ""))
-        use_ssl = url.scheme=='https' if url.scheme else bool(os.getenv("S3_USE_HTTPS", True))
-        minioClient = Minio(url.netloc,
-                            access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),
-                            secret_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-                            secure=use_ssl)
-        return minioClient
+        use_ssl = url.scheme == 'https' if url.scheme else bool(os.getenv("S3_USE_HTTPS", "true"))
+        return Minio(url.netloc,
+                     access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),
+                     secret_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
+                     secure=use_ssl)

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -193,9 +193,10 @@ class Storage(object): # pylint: disable=too-few-public-methods
     @staticmethod
     def _create_minio_client():
         # Remove possible http scheme for Minio
-        url = re.compile(r"https?://")
-        minioClient = Minio(url.sub("", os.getenv("S3_ENDPOINT", "")),
+        url = urlparse(os.getenv("S3_ENDPOINT", ""))
+        use_ssl = url.scheme=='https' if url.scheme else bool(os.getenv("USE_SSL", True))
+        minioClient = Minio(url.netloc,
                             access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),
                             secret_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-                            secure=True)
+                            secure=use_ssl)
         return minioClient


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allows using insecure minio storage backend by specifying http as scheme in S3_ENDPOINT environment variable or explicitly by setting USE_SSL to False. Default setting remains secure.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #361 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Allow use of insecure minio storage backend for local development/testing.
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/362)
<!-- Reviewable:end -->
