### PR TITLE
Remove a workaround in the update-openapigen.sh to run 'make test' on macOS

### DIFF
--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -26,8 +26,8 @@ fi
 go run vendor/k8s.io/code-generator/cmd/openapi-gen/main.go --input-dirs github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2,knative.dev/pkg/apis --output-package github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2/ --go-header-file hack/boilerplate.go.txt
 
 # Workaroud error "spec redeclared in this block" in unit test.
-sed -i 's%spec "github.com/go-openapi/spec"%openapispec "github.com/go-openapi/spec"%g' pkg/apis/serving/v1alpha2/openapi_generated.go
-sed -i 's/spec\./openapispec\./g' pkg/apis/serving/v1alpha2/openapi_generated.go
+sed -i '' -e 's%spec "github.com/go-openapi/spec"%openapispec "github.com/go-openapi/spec"%g' pkg/apis/serving/v1alpha2/openapi_generated.go
+sed -i '' -e 's/spec\./openapispec\./g' pkg/apis/serving/v1alpha2/openapi_generated.go
 
 # Generating swagger file
 go run cmd/spec-gen/main.go 0.1 > pkg/apis/serving/v1alpha2/swagger.json

--- a/hack/update-openapigen.sh
+++ b/hack/update-openapigen.sh
@@ -25,9 +25,5 @@ fi
 # Generating OpenAPI specification
 go run vendor/k8s.io/code-generator/cmd/openapi-gen/main.go --input-dirs github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2,knative.dev/pkg/apis --output-package github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2/ --go-header-file hack/boilerplate.go.txt
 
-# Workaroud error "spec redeclared in this block" in unit test.
-sed -i '' -e 's%spec "github.com/go-openapi/spec"%openapispec "github.com/go-openapi/spec"%g' pkg/apis/serving/v1alpha2/openapi_generated.go
-sed -i '' -e 's/spec\./openapispec\./g' pkg/apis/serving/v1alpha2/openapi_generated.go
-
 # Generating swagger file
 go run cmd/spec-gen/main.go 0.1 > pkg/apis/serving/v1alpha2/swagger.json

--- a/pkg/apis/serving/v1alpha2/kfservice_framework_tensorrt_test.go
+++ b/pkg/apis/serving/v1alpha2/kfservice_framework_tensorrt_test.go
@@ -25,27 +25,25 @@ import (
 	v1 "k8s.io/api/core/v1"
 )
 
-var requestedResource = v1.ResourceRequirements{
-	Limits: v1.ResourceList{
-		"cpu": resource.Quantity{
-			Format: "100",
-		},
-	},
-	Requests: v1.ResourceList{
-		"cpu": resource.Quantity{
-			Format: "90",
-		},
-	},
-}
-
-var config = FrameworksConfig{
-	TensorRT: FrameworkConfig{
-		ContainerImage: "someOtherImage",
-	},
-}
-
 func TestCreateModelServingContainer(t *testing.T) {
 
+	var requestedResource = v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			"cpu": resource.Quantity{
+				Format: "100",
+			},
+		},
+		Requests: v1.ResourceList{
+			"cpu": resource.Quantity{
+				Format: "90",
+			},
+		},
+	}
+	var config = FrameworksConfig{
+		TensorRT: FrameworkConfig{
+			ContainerImage: "someOtherImage",
+		},
+	}
 	var spec = TensorRTSpec{
 		StorageURI:     "gs://someUri",
 		Resources:      requestedResource,

--- a/pkg/apis/serving/v1alpha2/kfservice_framework_tensorrt_test.go
+++ b/pkg/apis/serving/v1alpha2/kfservice_framework_tensorrt_test.go
@@ -38,12 +38,6 @@ var requestedResource = v1.ResourceRequirements{
 	},
 }
 
-var spec = TensorRTSpec{
-	StorageURI:     "gs://someUri",
-	Resources:      requestedResource,
-	RuntimeVersion: "19.05-py3",
-}
-
 var config = FrameworksConfig{
 	TensorRT: FrameworkConfig{
 		ContainerImage: "someOtherImage",
@@ -52,6 +46,11 @@ var config = FrameworksConfig{
 
 func TestCreateModelServingContainer(t *testing.T) {
 
+	var spec = TensorRTSpec{
+		StorageURI:     "gs://someUri",
+		Resources:      requestedResource,
+		RuntimeVersion: "19.05-py3",
+	}
 	g := gomega.NewGomegaWithT(t)
 
 	expectedContainer := &v1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

* Modify sed options in the update-openapigen.sh to run 'make test' on macOS
* I failed to run `make test` on macOS (v10.13.6, High Sierra) with the following error message:

```
$ make test
go generate ./pkg/... ./cmd/...
hack/update-codegen.sh
Generating deepcopy funcs
Generating clientset for serving:v1alpha2 at github.com/kubeflow/kfserving/pkg/client/clientset
Generating listers for serving:v1alpha2 at github.com/kubeflow/kfserving/pkg/client/listers
Generating informers for serving:v1alpha2 at github.com/kubeflow/kfserving/pkg/client/informers
hack/update-openapigen.sh
sed: 1: "pkg/apis/serving/v1alph ...": extra characters at the end of p command
make: *** [generate] Error 1
```

**Special notes for your reviewer**:

1. I'd appreciate checking if this change would work with GNU sed

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/365)
<!-- Reviewable:end -->
