### PR TITLE
Fix the link to how to install kubebuilder on test/README.md

### DIFF
--- a/test/README.md
+++ b/test/README.md
@@ -9,7 +9,7 @@ This directory contains tests and testing docs for `KFServing`:
 
 ## Prerequisite
 `kfserving-controller-manager` has a few integration tests which requires mock apiserver
-and etcd, they get installed along with [`kubebuilder`](https://book.kubebuilder.io/getting_started/installation_and_setup.html).
+and etcd, they get installed along with [`kubebuilder`](https://book.kubebuilder.io/quick-start.html#installation).
 
 ## Running unit/integration tests
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Fix the link to how to install kubebuilder on test/README.md because the current link is not found.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/367)
<!-- Reviewable:end -->
