### PR TITLE
add rollout api for SDK

### DIFF
--- a/docs/samples/client/kfserving_sdk_sample.ipynb
+++ b/docs/samples/client/kfserving_sdk_sample.ipynb
@@ -13,7 +13,7 @@
    "source": [
     "This is a sample for KFServing SDK. \n",
     "\n",
-    "The notebook shows how to use KFServing SDK to create, get, patch and delete KFService."
+    "The notebook shows how to use KFServing SDK to create, get, rollout_canary, promote and delete KFService."
    ]
   },
   {
@@ -45,7 +45,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Firstly define the model spec for default model spec, and then define the kfservice basic on the model spec."
+    "Firstly define default endpoint spec, and then define the kfservice basic on the endpoint spec."
    ]
   },
   {
@@ -121,7 +121,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Patch the KFService to add canary model."
+    "Firstly define canary endpoint spec, and then rollout 10% traffic to the canary version, watch the rollout process."
    ]
   },
   {
@@ -138,15 +138,22 @@
     "                                 requests={'cpu':'100m','memory':'1Gi'},\n",
     "                                 limits={'cpu':'100m', 'memory':'1Gi'}))))\n",
     "\n",
-    "kfsvc = V1alpha2KFService(api_version=api_version,\n",
-    "                          kind=constants.KFSERVING_KIND,\n",
-    "                          metadata=client.V1ObjectMeta(\n",
-    "                              name='flower-sample', namespace='kubeflow'),\n",
-    "                          spec=V1alpha2KFServiceSpec(default=default_endpoint_spec,\n",
-    "                                                     canary=canary_endpoint_spec,\n",
-    "                                                     canary_traffic_percent=10))\n",
-    "\n",
-    "KFServing.patch('flower-sample', kfsvc)"
+    "KFServing.rollout_canary('flower-sample', canary=canary_endpoint_spec, percent=10,\n",
+    "                         namespace='kubeflow', watch=True, timeout_seconds=120)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Rollout more traffic to canary of the KFService"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Rollout traffice percent to 50% to canary version."
    ]
   },
   {
@@ -155,7 +162,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "KFServing.get('flower-sample', namespace='kubeflow', watch=True, timeout_seconds=120)"
+    "KFServing.rollout_canary('flower-sample', percent=50, namespace='kubeflow',\n",
+    "                         watch=True, timeout_seconds=120)"
    ]
   },
   {
@@ -171,16 +179,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "KFServing.promote('flower-sample', namespace='kubeflow')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "KFServing.get('flower-sample', namespace='kubeflow', watch=True, timeout_seconds=120)"
+    "KFServing.promote('flower-sample', namespace='kubeflow', watch=True, timeout_seconds=120)"
    ]
   },
   {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Discussed with @ellis-bigelow and @yuzisun in the PR https://github.com/kubeflow/kfserving/pull/357#discussion_r328163284, adding rollout API to let user easily update the canary traffic percent.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/370)
<!-- Reviewable:end -->
