### PR TITLE
Filter directory keys when downloading models from S3 storage

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -71,10 +71,12 @@ class Storage(object): # pylint: disable=too-few-public-methods
         for obj in objects:
             # Replace any prefix from the object key with temp_dir
             subdir_object_key = obj.object_name.replace(bucket_path, "", 1).strip("/")
-            if subdir_object_key == "":
-                subdir_object_key = obj.object_name.split("/")[-1]
-            client.fget_object(bucket_name, obj.object_name,
-                               os.path.join(temp_dir, subdir_object_key))
+            # fget_object handles directory creation if does not exist
+            if not obj.is_dir:
+                if subdir_object_key == "":
+                    subdir_object_key = obj.object_name
+                client.fget_object(bucket_name, obj.object_name,
+                                   os.path.join(temp_dir, subdir_object_key))
 
     @staticmethod
     def _download_gcs(uri, temp_dir: str):

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -15,15 +15,19 @@
 import unittest.mock as mock
 import kfserving
 
+
 def create_mock_obj(path):
     mock_obj = mock.MagicMock()
     mock_obj.object_name = path
+    mock_obj.is_dir = False
     return mock_obj
+
 
 def create_mock_minio_client(mock_storage, paths):
     mock_minio_client = mock_storage.return_value
     mock_minio_client.list_objects.return_value = [create_mock_obj(p) for p in paths]
     return mock_minio_client
+
 
 def get_call_args(call_args_list):
     arg_list = []
@@ -32,11 +36,13 @@ def get_call_args(call_args_list):
         arg_list.append(args)
     return arg_list
 
+
 def expected_call_args_list(bucket_name, parent_key, dest, paths):
     return [(bucket_name, f'{parent_key}/{p}'.strip('/'), f'{dest}/{p}'.strip('/'))
             for p in paths]
 
 # pylint: disable=protected-access
+
 
 @mock.patch('kfserving.storage.Minio')
 def test_parent_key(mock_storage):
@@ -56,6 +62,7 @@ def test_parent_key(mock_storage):
 
     mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='bar', recursive=True)
 
+
 @mock.patch('kfserving.storage.Minio')
 def test_no_key(mock_storage):
 
@@ -73,6 +80,7 @@ def test_no_key(mock_storage):
 
     mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='', recursive=True)
 
+
 @mock.patch('kfserving.storage.Minio')
 def test_full_name_key(mock_storage):
 
@@ -86,8 +94,8 @@ def test_full_name_key(mock_storage):
 
     # then
     arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
-    assert arg_list == expected_call_args_list(bucket_name, 'path/to/model', 'dest_path',
-                                               ['name.pt'])
+    assert arg_list == expected_call_args_list(bucket_name, '', 'dest_path',
+                                               [object_key])
 
     mock_minio_client.list_objects.assert_called_with(bucket_name, prefix=object_key,
                                                       recursive=True)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Bug fix in storage initializer for downloading tensorflow model from s3 storage.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubeflow/kfserving/issues/379

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/380)
<!-- Reviewable:end -->
