### PR TITLE
Adding E2E test for KFServing

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,6 +31,9 @@ deploy-dev: manifests
 	./hack/image_patch_dev.sh
 	kustomize build config/overlays/development | kubectl apply -f -
 
+deploy-ci: manifests
+	kustomize build config/overlays/test | kubectl apply -f -
+
 undeploy:
 	kustomize build config/default | kubectl delete -f -
 	kubectl delete validatingwebhookconfigurations.admissionregistration.k8s.io inferenceservice.serving.kubeflow.org

--- a/config/overlays/test/kustomization.yaml
+++ b/config/overlays/test/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../default
+
+patches:
+  - manager_image_patch.yaml

--- a/config/overlays/test/manager_image_patch.yaml
+++ b/config/overlays/test/manager_image_patch.yaml
@@ -1,0 +1,12 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kfserving-controller-manager
+  namespace: kfserving-system
+spec:
+  template:
+    spec:
+      containers:
+        - name: manager
+          command:
+          image: gcr.io/kubeflow-ci/kfserving/kfserving-controller:latest

--- a/python/kfserving/requirements.txt
+++ b/python/kfserving/requirements.txt
@@ -8,7 +8,6 @@ tornado >= 1.4.1
 argparse >= 1.4.0
 minio >= 4.0.9
 google-cloud-storage >= 1.16.0
-azure-storage-blob >= 2.1.0
 adal >= 1.2.2
 table_logger >= 0.3.5
 numpy

--- a/test/e2e/test_tensorflow_inference_service.py
+++ b/test/e2e/test_tensorflow_inference_service.py
@@ -1,0 +1,49 @@
+# Copyright 2019 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import time
+from kubernetes import client
+
+from kfserving import KFServingClient
+from kfserving import constants
+from kfserving import V1alpha2EndpointSpec
+from kfserving import V1alpha2PredictorSpec
+from kfserving import V1alpha2TensorflowSpec
+from kfserving import V1alpha2InferenceServiceSpec
+from kfserving import V1alpha2InferenceService
+from kubernetes.client import V1ResourceRequirements
+
+from utils import wait_for_kfservice_ready
+
+api_version = constants.KFSERVING_GROUP + '/' + constants.KFSERVING_VERSION
+KFServing = KFServingClient(load_kube_config=True)
+
+
+def test_tensorflow_kfserving():
+    default_endpoint_spec = V1alpha2EndpointSpec(
+        predictor=V1alpha2PredictorSpec(
+            tensorflow=V1alpha2TensorflowSpec(
+                storage_uri='gs://kfserving-samples/models/tensorflow/flowers',
+                resources=V1ResourceRequirements(
+                    requests={'cpu': '100m', 'memory': '256Mi'},
+                    limits={'cpu': '100m', 'memory': '256Mi'}))))
+
+    isvc = V1alpha2InferenceService(api_version=api_version,
+                                    kind=constants.KFSERVING_KIND,
+                                    metadata=client.V1ObjectMeta(
+                                        name='isvc-tensorflow-test', namespace='kfserving-ci-e2e-test'),
+                                    spec=V1alpha2InferenceServiceSpec(default=default_endpoint_spec))
+
+    KFServing.create(isvc)
+    wait_for_kfservice_ready('isvc-tensorflow-test')

--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -1,0 +1,28 @@
+# Copyright 2019 kubeflow.org.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import time
+from kfserving import KFServingClient
+
+KFServing = KFServingClient(load_kube_config=True)
+
+def wait_for_kfservice_ready(name, namespace='kfserving-ci-e2e-test', Timeout_seconds=600):
+    for _ in range(round(Timeout_seconds/10)):
+        time.sleep(10)
+        kfsvc_status = KFServing.get(name, namespace=namespace)
+        for condition in kfsvc_status['status'].get('conditions', {}):
+            if condition.get('type', '') == 'Ready':
+                status = condition.get('status', 'Unknown')
+        if status == 'True':
+            return
+    raise RuntimeError("Timeout to start the KFService.")

--- a/test/scripts/create-cluster.sh
+++ b/test/scripts/create-cluster.sh
@@ -1,0 +1,45 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This shell script is used to build a cluster and create a namespace.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME}"
+ZONE="${GCP_ZONE}"
+PROJECT="${GCP_PROJECT}"
+NAMESPACE="${DEPLOY_NAMESPACE}"
+
+echo "Activating service-account ..."
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+echo "Creating cluster ${CLUSTER_NAME} ... "
+gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
+    --addons=HorizontalPodAutoscaling,HttpLoadBalancing \
+    --machine-type=n1-standard-4 \
+    --cluster-version 1.13 --zone ${ZONE} \
+    --enable-stackdriver-kubernetes --enable-ip-alias \
+    --enable-autoscaling --min-nodes=3 --max-nodes=10 \
+    --enable-autorepair \
+    --scopes cloud-platform
+
+echo "Configuring kubectl ..."
+gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} --zone ${ZONE}
+
+echo "Creating namespace ${NAMESPACE} ..."
+kubectl create namespace ${NAMESPACE}

--- a/test/scripts/delete-cluster.sh
+++ b/test/scripts/delete-cluster.sh
@@ -14,10 +14,18 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This shell script is used to build an image from our argo workflow
+# This shell script is used to delete a cluster.
 
 set -o errexit
 set -o nounset
 set -o pipefail
 
-# TODO: deploy kfserving and run e2e use test cases
+CLUSTER_NAME="${CLUSTER_NAME}"
+ZONE="${GCP_ZONE}"
+PROJECT="${GCP_PROJECT}"
+
+echo "Activating service-account"
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+echo "Tearing down the cluster"
+gcloud container clusters delete ${CLUSTER_NAME} --zone=${ZONE} --project=${PROJECT} --async

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -1,0 +1,126 @@
+#!/bin/bash
+
+# Copyright 2019 The Kubeflow Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# The script is used to deploy knative and kfserving, and run e2e tests.
+
+set -o errexit
+set -o nounset
+set -o pipefail
+
+CLUSTER_NAME="${CLUSTER_NAME}"
+ZONE="${GCP_ZONE}"
+PROJECT="${GCP_PROJECT}"
+NAMESPACE="${DEPLOY_NAMESPACE}"
+REGISTRY="${GCP_REGISTRY}"
+KNATIVE_VERSION="v0.9.0"
+
+# Check and wait for istio/knative/kfserving pod started normally.
+waiting_pod_running(){
+    namespace=$1
+    TIMEOUT=120
+    PODNUM=$(kubectl get pods -n ${namespace} | grep -v NAME | wc -l)
+    until kubectl get pods -n ${namespace} | grep -E "Running|Completed" | [[ $(wc -l) -eq $PODNUM ]]; do
+        echo Pod Status $(kubectl get pods -n ${namespace} | grep -E "Running|Completed" | wc -l)/$PODNUM
+
+        sleep 10
+        TIMEOUT=$(( TIMEOUT - 1 ))
+        if [[ $TIMEOUT -eq 0 ]];then
+            echo "Timeout to waiting for pod start."
+            kubectl get pods -n ${namespace}
+            exit 1
+        fi
+    done
+}
+
+echo "Activating service-account ..."
+gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+echo "Configuring kubectl ..."
+gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} --zone ${ZONE}
+kubectl config set-context $(kubectl config current-context) --namespace=default
+
+echo "Grant cluster-admin permissions to the current user ..."
+kubectl create clusterrolebinding cluster-admin-binding \
+  --clusterrole=cluster-admin \
+  --user=$(gcloud config get-value core/account)
+
+echo "Install istio ..."
+mkdir istio_tmp
+pushd istio_tmp >/dev/null
+  curl -L https://git.io/getLatestIstio | sh -
+  cd istio-*
+  export PATH=$PWD/bin:$PATH
+  kubectl create namespace istio-system
+  helm template install/kubernetes/helm/istio-init \
+  --name istio-init --namespace istio-system | kubectl apply -f -
+  sleep 30
+  helm template install/kubernetes/helm/istio \
+  --name istio --namespace istio-system | kubectl apply -f -
+popd
+
+echo "Waiting for istio started ..."
+sleep 15
+waiting_pod_running "istio-system"
+
+echo "Installing knative serving ..."
+kubectl apply --selector knative.dev/crd-install=true --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
+sleep 2
+kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
+
+echo "Waiting for knative started ..."
+waiting_pod_running "knative-serving"
+
+echo "Install KFServing ..."
+export GOPATH="$HOME/go"
+export PATH="${PATH}:${GOPATH}/bin"
+mkdir -p ${GOPATH}/src/github.com/kubeflow
+cp -rf ../kfserving ${GOPATH}/src/github.com/kubeflow
+cd ${GOPATH}/src/github.com/kubeflow/kfserving
+make deploy-ci
+
+echo "Waiting for KFServing started ..."
+sleep 20
+waiting_pod_running "kfserving-system"
+sleep 60  # Wait for webhook install finished totally.
+
+echo "Creating a namespace kfserving-ci-test ..."
+kubectl create namespace kfserving-ci-e2e-test
+
+echo "Istio, Knative and KFServing have been installed and started."
+
+echo "Upgrading Python to 3.6 to install KFServing SDK ..."
+apt-get update -yqq
+apt-get install -yqq --no-install-recommends software-properties-common
+add-apt-repository -y ppa:jonathonf/python-3.6
+apt-get update -yqq
+apt-get install -yqq --no-install-recommends  python3.6 python3-pip
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
+update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.6 2
+
+echo "Installing KFServing Python SDK ..."
+python3 -m pip install --upgrade pip
+pip3 install --upgrade pytest
+pip3 install --upgrade pytest-tornasync
+pip3 install urllib3==1.24.2
+pushd python/kfserving >/dev/null
+    pip3 install -r requirements.txt
+    python3 setup.py install --force
+popd
+
+echo "Starting E2E functional tests ..."
+pushd test/e2e >/dev/null
+  pytest
+popd

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -208,6 +208,10 @@
                     name: "pylint-checking",
                     template: "pylint-checking",
                   },
+                  {
+                    name: "setup-cluster",
+                    template: "setup-cluster",
+                  },
                 ],
                 [
                   {
@@ -241,8 +245,8 @@
                 ],
                 [
                   {
-                    name: "run-tests",
-                    template: "run-tests",
+                    name: "run-e2e-tests",
+                    template: "run-e2e-tests",
                   },
                 ],
               ],
@@ -250,6 +254,11 @@
             {
               name: "exit-handler",
               steps: [
+                [{
+                  name: "teardown-cluster",
+                  template: "teardown-cluster",
+
+                }],
                 [{
                   name: "copy-artifacts",
                   template: "copy-artifacts",
@@ -276,9 +285,15 @@
                 ],
               },
             },  // checkout
-            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("run-tests", helmImage, [
-              "test/scripts/run-tests.sh",
-            ]),  // run tests
+            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("setup-cluster",testWorkerImage, [
+              "test/scripts/create-cluster.sh",
+            ]),  // setup cluster
+            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("run-e2e-tests",testWorkerImage, [
+              "test/scripts/run-e2e-tests.sh",
+            ]),  // deploy kfserving
+            $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("teardown-cluster",testWorkerImage, [
+              "test/scripts/delete-cluster.sh",
+             ]),  // teardown cluster
             $.parts(namespace, name, overrides).e2e(prow_env, bucket).buildTemplate("build-kfserving", testWorkerImage, [
               "test/scripts/build-kfserving.sh",
             ]),  // build-kfserving


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Adding E2E test for KFServing. 
My initial thoughts are deploy KFServing and then execute notebook sample, but seems that taks long time. Discussed with @yuzisun , just deploy KFServing and create a sample KFService. 

The E2E case includes:
1. Create a CI/CD cluster;
2. Install istio, knative and KFServing on the cluster;
3. Using python client to create a KFService and ensure that can be started normally.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/383)
<!-- Reviewable:end -->
