### PR TITLE
add optional param

### DIFF
--- a/python/kfserving/kfserving/api/kf_serving_client.py
+++ b/python/kfserving/kfserving/api/kf_serving_client.py
@@ -28,8 +28,8 @@ class KFServingClient(object):
 
     def __init__(self, config_file=None, context=None,
                  client_configuration=None, persist_config=True,
-                 force_kubeconfig=False):
-        if force_kubeconfig or not utils.is_running_in_k8s():
+                 load_kube_config=False):
+        if load_kube_config or not utils.is_running_in_k8s():
             config.load_kube_config(
                 config_file=config_file,
                 context=context,

--- a/python/kfserving/kfserving/api/kf_serving_client.py
+++ b/python/kfserving/kfserving/api/kf_serving_client.py
@@ -23,7 +23,7 @@ from ..models.v1alpha2_kf_service import V1alpha2KFService
 from ..models.v1alpha2_kf_service_spec import V1alpha2KFServiceSpec
 
 
-class KFServingClient(object):
+class KFServingClient(object): # pylint: disable=too-many-arguments
     '''KFServing Client Apis.'''
 
     def __init__(self, config_file=None, context=None,

--- a/python/kfserving/kfserving/api/kf_serving_client.py
+++ b/python/kfserving/kfserving/api/kf_serving_client.py
@@ -23,10 +23,10 @@ from ..models.v1alpha2_kf_service import V1alpha2KFService
 from ..models.v1alpha2_kf_service_spec import V1alpha2KFServiceSpec
 
 
-class KFServingClient(object): # pylint: disable=too-many-arguments
+class KFServingClient(object):
     '''KFServing Client Apis.'''
 
-    def __init__(self, config_file=None, context=None,
+    def __init__(self, config_file=None, context=None, # pylint: disable=too-many-arguments
                  client_configuration=None, persist_config=True,
                  load_kube_config=False):
         if load_kube_config or not utils.is_running_in_k8s():

--- a/python/kfserving/kfserving/api/kf_serving_client.py
+++ b/python/kfserving/kfserving/api/kf_serving_client.py
@@ -27,15 +27,16 @@ class KFServingClient(object):
     '''KFServing Client Apis.'''
 
     def __init__(self, config_file=None, context=None,
-                 client_configuration=None, persist_config=True):
-        if utils.is_running_in_k8s():
-            config.load_incluster_config()
-        else:
+                 client_configuration=None, persist_config=True,
+                 force_kubeconfig=False):
+        if force_kubeconfig or utils.is_running_in_k8s() == False:
             config.load_kube_config(
                 config_file=config_file,
                 context=context,
                 client_configuration=client_configuration,
                 persist_config=persist_config)
+        else:
+            config.load_incluster_config()
 
         self.api_instance = client.CustomObjectsApi()
 

--- a/python/kfserving/kfserving/api/kf_serving_client.py
+++ b/python/kfserving/kfserving/api/kf_serving_client.py
@@ -29,7 +29,7 @@ class KFServingClient(object):
     def __init__(self, config_file=None, context=None,
                  client_configuration=None, persist_config=True,
                  force_kubeconfig=False):
-        if force_kubeconfig or utils.is_running_in_k8s() == False:
+        if force_kubeconfig or not utils.is_running_in_k8s():
             config.load_kube_config(
                 config_file=config_file,
                 context=context,


### PR DESCRIPTION
Add an optional parameter to choose KUBECONFIG even when running on k8s.

Currently the code assumes the script using Python SDK will be running in the same cluster as KFServing does.  This will not be true if we use Python SDK in Kubeflow cluster and try to deploy to KFServing in another cluster.  In this case the assumption will break and in-cluster config will not have permission to deploy to KfServing cluster.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/390)
<!-- Reviewable:end -->
