### PR TITLE
Set KFservice default timeout to lower value

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,7 +52,7 @@ var (
 // Controller Constants
 var (
 	ControllerLabelName        = KFServingName + "-controller-manager"
-	DefaultTimeout       int64 = 300
+	DefaultTimeout       int64 = 30
 	DefaultScalingTarget       = "1"
 )
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -52,7 +52,7 @@ var (
 // Controller Constants
 var (
 	ControllerLabelName        = KFServingName + "-controller-manager"
-	DefaultTimeout       int64 = 30
+	DefaultTimeout       int64 = 10
 	DefaultScalingTarget       = "1"
 )
 


### PR DESCRIPTION
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
This is to reduce default terminationGracePeriod so that user-container
which ignore SIGTERM can be terminated more quickly
Fix #394

**Special notes for your reviewer**:
If the PR broke initial assumption when deciding the previous default value

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/395)
<!-- Reviewable:end -->
