### PR TITLE
Refactor ExplainerSpec for better validation

### DIFF
--- a/pkg/apis/serving/v1alpha2/explainer.go
+++ b/pkg/apis/serving/v1alpha2/explainer.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/klog"
 )
 
 type Explainer interface {
@@ -87,7 +88,9 @@ func getExplainer(explainerSpec *ExplainerSpec) (Explainer, error) {
 		handlers = append(handlers, explainerSpec.Alibi)
 	}
 	if len(handlers) != 1 {
-		return nil, fmt.Errorf(ExactlyOneExplainerViolatedError)
+		err := fmt.Errorf(ExactlyOneExplainerViolatedError)
+		klog.Error(err)
+		return nil, err
 	}
 	return handlers[0], nil
 }

--- a/pkg/apis/serving/v1alpha2/predictor.go
+++ b/pkg/apis/serving/v1alpha2/predictor.go
@@ -21,6 +21,7 @@ import (
 	"github.com/kubeflow/kfserving/pkg/constants"
 	v1 "k8s.io/api/core/v1"
 	resource "k8s.io/apimachinery/pkg/api/resource"
+	"k8s.io/klog"
 )
 
 type Predictor interface {
@@ -186,7 +187,9 @@ func getPredictor(predictorSpec *PredictorSpec) (Predictor, error) {
 		predictors = append(predictors, predictorSpec.TensorRT)
 	}
 	if len(predictors) != 1 {
-		return nil, fmt.Errorf(ExactlyOnePredictorViolatedError)
+		err := fmt.Errorf(ExactlyOnePredictorViolatedError)
+		klog.Error(err)
+		return nil, err
 	}
 	return predictors[0], nil
 }


### PR DESCRIPTION
**What this PR does / why we need it**:
- Fix kfserving from crashing if spec is invalid
- Add validation for explainer's storage URI

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #396

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/406)
<!-- Reviewable:end -->
