### PR TITLE
Fix url path in the example

### DIFF
--- a/docs/samples/pytorch/README.md
+++ b/docs/samples/pytorch/README.md
@@ -84,7 +84,7 @@ CLUSTER_IP=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpat
 
 SERVICE_HOSTNAME=$(kubectl get kfservice pytorch-cifar10 -o jsonpath='{.status.url}' |sed 's/.*:\/\///g')
 
-curl -v -H "Host: ${SERVICE_HOSTNAME}" -d $INPUT_PATH http://$CLUSTER_IP/models/$MODEL_NAME:predict
+curl -v -H "Host: ${SERVICE_HOSTNAME}" -d $INPUT_PATH http://$CLUSTER_IP/v1/models/$MODEL_NAME:predict
 ```
 
 You should see an output similar to the one below:

--- a/docs/samples/sklearn/README.md
+++ b/docs/samples/sklearn/README.md
@@ -29,7 +29,7 @@ X, y = iris.data, iris.target
 formData = {
     'instances': X[0:1].tolist()
 }
-res = requests.post('http://localhost:8080/models/svm:predict', json=formData)
+res = requests.post('http://localhost:8080/v1/models/svm:predict', json=formData)
 print(res)
 print(res.text)
 ```

--- a/docs/samples/sklearn/README.md
+++ b/docs/samples/sklearn/README.md
@@ -58,8 +58,8 @@ $ kfservice.serving.kubeflow.org/sklearn-iris created
 MODEL_NAME=sklearn-iris
 INPUT_PATH=@./iris-input.json
 CLUSTER_IP=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-curl -v -H "Host: sklearn-iris.default.svc.cluster.local" http://$CLUSTER_IP/models/$MODEL_NAME:predict -d $INPUT_PATH
+SERVICE_HOSTNAME=$(kubectl get kfservice sklearn-iris -o jsonpath='{.status.url}' | sed 's/.*:\/\///g')
+curl -v -H "Host: ${SERVICE_HOSTNAME}" http://$CLUSTER_IP/v1/models/$MODEL_NAME:predict -d $INPUT_PATH
 ```
 
 Expected Output

--- a/docs/samples/transformer/image_transformer/README.md
+++ b/docs/samples/transformer/image_transformer/README.md
@@ -72,7 +72,7 @@ CLUSTER_IP=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpat
 
 SERVICE_HOSTNAME=$(kubectl get kfservice transformer-cifar10 -o jsonpath='{.status.url}' | sed 's/.*:\/\///g')
 
-curl -v -H "Host: ${SERVICE_HOSTNAME}" -d $INPUT_PATH http://$CLUSTER_IP/models/$MODEL_NAME:predict
+curl -v -H "Host: ${SERVICE_HOSTNAME}" -d $INPUT_PATH http://$CLUSTER_IP/v1/models/$MODEL_NAME:predict
 ```
 
 You should see an output similar to the one below:

--- a/docs/samples/xgboost/README.md
+++ b/docs/samples/xgboost/README.md
@@ -81,8 +81,8 @@ $ kfservice.serving.kubeflow.org/xgboost-iris created
 MODEL_NAME=xgboost-iris
 INPUT_PATH=@./iris-input.json
 CLUSTER_IP=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
-
-curl -v -H "Host: xgboost-iris.default.svc.cluster.local" http://$CLUSTER_IP/v1/models/$MODEL_NAME:predict -d $INPUT_PATH
+SERVICE_HOSTNAME=$(kubectl get kfservice xgboost-iris -o jsonpath='{.status.url}' | sed 's/.*:\/\///g')
+curl -v -H "Host: ${SERVICE_HOSTNAME}" http://$CLUSTER_IP/v1/models/$MODEL_NAME:predict -d $INPUT_PATH
 ```
 
 Expected Output

--- a/docs/samples/xgboost/README.md
+++ b/docs/samples/xgboost/README.md
@@ -82,7 +82,7 @@ MODEL_NAME=xgboost-iris
 INPUT_PATH=@./iris-input.json
 CLUSTER_IP=$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 
-curl -v -H "Host: xgboost-iris.default.svc.cluster.local" http://$CLUSTER_IP/models/$MODEL_NAME:predict -d $INPUT_PATH
+curl -v -H "Host: xgboost-iris.default.svc.cluster.local" http://$CLUSTER_IP/v1/models/$MODEL_NAME:predict -d $INPUT_PATH
 ```
 
 Expected Output


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Url path in examples are wrong after the v1 protocol change

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

tested the examples they all work now

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/410)
<!-- Reviewable:end -->
