### PR TITLE
Request Logging - Control Plane Spec

### DIFF
--- a/pkg/apis/serving/v1alpha2/kfservice_types.go
+++ b/pkg/apis/serving/v1alpha2/kfservice_types.go
@@ -88,6 +88,7 @@ type ExplainerSpec struct {
 // TransformerSpec defines transformer service for pre/post processing
 type TransformerSpec struct {
 	Custom *CustomSpec `json:"custom,omitempty"`
+	RequestLogging *v1.ObjectReference `json:"requestLogging,omitempty"`
 
 	DeploymentSpec `json:",inline"`
 }


### PR DESCRIPTION
Proposal for request logging as initial discussed in community call.

From discussion with the Istio team it is suggested that request logging not be an istio addition but part of our application. A simple solution suggested is to add to Transformer. The base Transformer image will if request logging Sink is provided in spec send request and response to the sink. 

 * Request Logging is an optional addition to Transformer spec.
 * It will be handled automatically by base python Transformer code.
 * If user only specifies `requestLogging` and no Transformer Custom container then the base Transformer code is run which will simply call Predictor and send request and response to Sink specified.

The Sink Object Reference is an Addressable Duck Type. It could be a Knative channel abstracting over a particular implementation, e.g. Kafka channel. It is the user's responsibility to ensure a valid Sink exists with the given ObjectReference.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/418)
<!-- Reviewable:end -->
