### PR TITLE
enhance sdk due to json path changed

### DIFF
--- a/python/kfserving/kfserving/api/kf_serving_watch.py
+++ b/python/kfserving/kfserving/api/kf_serving_watch.py
@@ -46,8 +46,8 @@ def watch(name=None, namespace=None, timeout_seconds=600):
             continue
         else:
             url = kfserivce['status'].get('url', '')
-            default_traffic = kfserivce['status'].get('default', {}).get('traffic', '')
-            canary_traffic = kfserivce['status'].get('canary', {}).get('traffic', '')
+            default_traffic = kfserivce['status'].get('traffic', '')
+            canary_traffic = kfserivce['status'].get('canaryTraffic', '')
             status = 'Unknown'
             for condition in kfserivce['status'].get('conditions', {}):
                 if condition.get('type', '') == 'Ready':

--- a/python/kfserving/setup.py
+++ b/python/kfserving/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kfserving',
-    version='0.2.0',
+    version='0.2.1',
     author="Kubeflow Authors",
     author_email='ellisbigelow@google.com, hejinchi@cn.ibm.com',
     license="Apache License Version 2.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
SDK API with `watch=Ture` cannot get the traffic due to json path is changed in the #420 
And updated the SDK vesion to refresh KFServing SDK in Pypi.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/425)
<!-- Reviewable:end -->
