### PR TITLE
Fix missing alibi key in explainers configmap

### DIFF
--- a/config/default/configmap/inferenceservice.yaml
+++ b/config/default/configmap/inferenceservice.yaml
@@ -63,16 +63,16 @@ data:
   explainers: |-
     {
         "alibi": {
-            "image" : "docker.io/seldonio/alibiexplainer",
-            "defaultImageVersion": "0.2.3",
+            "image" : "gcr.io/kfserving/alibi-explainer",
+            "defaultImageVersion": "0.2.0",
             "allowedImageVersions": [
-               "0.2.3"
+               "0.2.0"
             ]
         }
     }
   storageInitializer: |-
     {
-        "image" : "gcr.io/kfserving/storage-initializer:latest"
+        "image" : "gcr.io/kfserving/storage-initializer:0.2.0"
     }
   credentials: |-
     {

--- a/config/default/configmap/inferenceservice.yaml
+++ b/config/default/configmap/inferenceservice.yaml
@@ -62,11 +62,13 @@ data:
     }
   explainers: |-
     {
-        "image" : "docker.io/seldonio/alibiexplainer",
-        "defaultImageVersion": "0.2.3",
-        "allowedImageVersions": [
-           "0.2.3"
-        ]
+        "alibi": {
+            "image" : "docker.io/seldonio/alibiexplainer",
+            "defaultImageVersion": "0.2.3",
+            "allowedImageVersions": [
+               "0.2.3"
+            ]
+        }
     }
   storageInitializer: |-
     {

--- a/install/0.2.0/kfserving.yaml
+++ b/install/0.2.0/kfserving.yaml
@@ -757,10 +757,10 @@ data:
   explainers: |-
     {
         "alibi": {
-           "image" : "docker.io/seldonio/alibiexplainer",
-           "defaultImageVersion": "0.2.3",
+           "image" : "gcr.io/kfserving/alibi-explainer",
+           "defaultImageVersion": "0.2.0",
            "allowedImageVersions": [
-              "0.2.3"
+              "0.2.0"
            ]
         }
     }

--- a/install/0.2.0/kfserving.yaml
+++ b/install/0.2.0/kfserving.yaml
@@ -756,11 +756,13 @@ data:
     }
   explainers: |-
     {
-        "image" : "docker.io/seldonio/alibiexplainer",
-        "defaultImageVersion": "0.2.3",
-        "allowedImageVersions": [
-           "0.2.3"
-        ]
+        "alibi": {
+           "image" : "docker.io/seldonio/alibiexplainer",
+           "defaultImageVersion": "0.2.3",
+           "allowedImageVersions": [
+              "0.2.3"
+           ]
+        }
     }
   ingress: |-
     {

--- a/pkg/apis/serving/v1alpha2/explainer_alibi.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi.go
@@ -9,7 +9,6 @@ import (
 )
 
 var (
-	AlibiImageName                  = "docker.io/seldonio/alibiexplainer"
 	InvalidAlibiRuntimeVersionError = "RuntimeVersion must be one of %s"
 )
 
@@ -18,11 +17,6 @@ func (s *AlibiExplainerSpec) GetStorageUri() string {
 }
 
 func (s *AlibiExplainerSpec) CreateExplainerContainer(modelName string, predictorHost string, config *InferenceServicesConfig) *v1.Container {
-	imageName := AlibiImageName
-	if config.Explainers.AlibiExplainer.ContainerImage != "" {
-		imageName = config.Explainers.AlibiExplainer.ContainerImage
-	}
-
 	var args = []string{
 		constants.ArgumentModelName, modelName,
 		constants.ArgumentPredictorHost, predictorHost,
@@ -40,7 +34,7 @@ func (s *AlibiExplainerSpec) CreateExplainerContainer(modelName string, predicto
 	}
 
 	return &v1.Container{
-		Image:     imageName + ":" + s.RuntimeVersion,
+		Image:     config.Explainers.AlibiExplainer.ContainerImage + ":" + s.RuntimeVersion,
 		Resources: s.Resources,
 		Args:      args,
 	}

--- a/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
@@ -1,0 +1,99 @@
+package v1alpha2
+
+import (
+	"fmt"
+	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/types"
+	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
+	"strings"
+	"testing"
+)
+
+func TestAlibiExplainer(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	allowedAlibiImageVersionsArray := []string{
+		DefaultAlibiExplainerRuntimeVersion,
+	}
+	allowedAlibiImageVersions := strings.Join(allowedAlibiImageVersionsArray, ", ")
+
+	scenarios := map[string]struct {
+		spec    AlibiExplainerSpec
+		matcher types.GomegaMatcher
+	}{
+		"AcceptGoodRuntimeVersion": {
+			spec: AlibiExplainerSpec{
+				RuntimeVersion: DefaultAlibiExplainerRuntimeVersion,
+			},
+			matcher: gomega.Succeed(),
+		},
+		"RejectBadRuntimeVersion": {
+			spec: AlibiExplainerSpec{
+				RuntimeVersion: "",
+			},
+			matcher: gomega.MatchError(fmt.Sprintf(InvalidAlibiRuntimeVersionError, allowedAlibiImageVersions)),
+		},
+	}
+
+	for name, scenario := range scenarios {
+		config := &InferenceServicesConfig{
+			Explainers: &ExplainersConfig{
+				AlibiExplainer: ExplainerConfig{
+					ContainerImage:       "seldon.io/alibi",
+					DefaultImageVersion:  "latest",
+					AllowedImageVersions: allowedAlibiImageVersionsArray,
+				},
+			},
+		}
+		g.Expect(scenario.spec.Validate(config)).Should(scenario.matcher, fmt.Sprintf("Testing %s", name))
+	}
+}
+
+func TestCreateAlibiExplainerContainer(t *testing.T) {
+
+	var requestedResource = v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			"cpu": resource.Quantity{
+				Format: "100",
+			},
+		},
+		Requests: v1.ResourceList{
+			"cpu": resource.Quantity{
+				Format: "90",
+			},
+		},
+	}
+	config := &InferenceServicesConfig{
+		Explainers: &ExplainersConfig{
+			AlibiExplainer: ExplainerConfig{
+				ContainerImage:      "seldon.io/alibi",
+				DefaultImageVersion: "latest",
+			},
+		},
+	}
+	var spec = AlibiExplainerSpec{
+		Type:           "Anchor",
+		StorageURI:     "gs://someUri",
+		Resources:      requestedResource,
+		RuntimeVersion: "0.1.0",
+	}
+	g := gomega.NewGomegaWithT(t)
+
+	expectedContainer := &v1.Container{
+		Image:     "seldon.io/alibi:0.1.0",
+		Resources: requestedResource,
+		Args: []string{
+			"--model_name",
+			"someName",
+			"--predictor_host",
+			"predictor.svc.cluster.local",
+			"--storage_uri",
+			"/mnt/models",
+			"Anchor",
+		},
+	}
+
+	// Test Create with config
+	container := spec.CreateExplainerContainer("someName", "predictor.svc.cluster.local", config)
+	g.Expect(container).To(gomega.Equal(expectedContainer))
+}

--- a/pkg/apis/serving/v1alpha2/inferenceservice_defaults_test.go
+++ b/pkg/apis/serving/v1alpha2/inferenceservice_defaults_test.go
@@ -231,3 +231,40 @@ func TestTensorRTDefaults(t *testing.T) {
 	g.Expect(isvc.Spec.Canary.Predictor.TensorRT.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
 	g.Expect(isvc.Spec.Canary.Predictor.TensorRT.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }
+
+func TestAlibiExplainerDefaults(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	isvc := InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "foo",
+			Namespace: "default",
+		},
+		Spec: InferenceServiceSpec{
+			Default: EndpointSpec{
+				Predictor: PredictorSpec{
+					Tensorflow: &TensorflowSpec{
+						StorageURI:     "gs://testbucket/testmodel",
+					},
+				},
+				Explainer: &ExplainerSpec{
+					Alibi: &AlibiExplainerSpec{
+						StorageURI: "gs://testbucket/testmodel",
+					},
+				},
+			},
+		},
+	}
+	isvc.Spec.Canary = isvc.Spec.Default.DeepCopy()
+	isvc.Spec.Canary.Explainer.Alibi.RuntimeVersion = "0.2.4"
+	isvc.Spec.Canary.Explainer.Alibi.Resources.Requests = v1.ResourceList{v1.ResourceMemory: resource.MustParse("3Gi")}
+	isvc.Default(c)
+
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.RuntimeVersion).To(gomega.Equal(DefaultAlibiExplainerRuntimeVersion))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Canary.Explainer.Alibi.RuntimeVersion).To(gomega.Equal("0.2.4"))
+	g.Expect(isvc.Spec.Canary.Explainer.Alibi.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Explainer.Alibi.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
+}

--- a/pkg/apis/serving/v1alpha2/inferenceservice_defaults_test.go
+++ b/pkg/apis/serving/v1alpha2/inferenceservice_defaults_test.go
@@ -243,7 +243,7 @@ func TestAlibiExplainerDefaults(t *testing.T) {
 			Default: EndpointSpec{
 				Predictor: PredictorSpec{
 					Tensorflow: &TensorflowSpec{
-						StorageURI:     "gs://testbucket/testmodel",
+						StorageURI: "gs://testbucket/testmodel",
 					},
 				},
 				Explainer: &ExplainerSpec{

--- a/pkg/apis/serving/v1alpha2/inferenceservice_validation_test.go
+++ b/pkg/apis/serving/v1alpha2/inferenceservice_validation_test.go
@@ -211,3 +211,15 @@ func TestRejectBadExplainer(t *testing.T) {
 	isvc.Spec.Default.Explainer = &ExplainerSpec{}
 	g.Expect(isvc.ValidateCreate(c)).Should(gomega.MatchError(ExactlyOneExplainerViolatedError))
 }
+
+func TestGoodExplainer(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	isvc := makeTestInferenceService()
+	isvc.Spec.Default.Explainer = &ExplainerSpec{
+		Alibi: &AlibiExplainerSpec{
+			StorageURI: "gs://testbucket/testmodel",
+		},
+	}
+	isvc.Default(c)
+	g.Expect(isvc.ValidateCreate(c)).Should(gomega.Succeed())
+}

--- a/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
+++ b/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
@@ -67,7 +67,7 @@ func TestMain(m *testing.M) {
 
 	// Create configmap
 	configs := map[string]string{
-		"predictors": `{
+	"predictors": `{
         "tensorflow" : {
             "image" : "tensorflow/serving",
             "defaultImageVersion": "latest",
@@ -117,7 +117,7 @@ func TestMain(m *testing.M) {
             ]
         }
     }`,
-		"explainers": `{
+    "explainers": `{
         "alibi" : {
             "image" : "docker.io/seldonio/alibiexplainer",
             "defaultImageVersion": "0.2.3",

--- a/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
+++ b/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
@@ -43,6 +43,7 @@ const (
 	DefaultXGBoostRuntimeVersion       = "0.1.0"
 	DefaultTensorRTRuntimeVersion      = "19.05-py3"
 	DefaultONNXRuntimeVersion          = "v0.5.0"
+	DefaultAlibiExplainerRuntimeVersion = "0.2.3"
 )
 
 func TestMain(m *testing.M) {
@@ -66,7 +67,7 @@ func TestMain(m *testing.M) {
 
 	// Create configmap
 	configs := map[string]string{
-		"predictors": `{
+	"predictors": `{
         "tensorflow" : {
             "image" : "tensorflow/serving",
             "defaultImageVersion": "latest",
@@ -113,6 +114,15 @@ func TestMain(m *testing.M) {
             "defaultImageVersion": "19.05-py3",
             "allowedImageVersions": [
                "19.05-py3"
+            ]
+        }
+    }`,
+    "explainers" : `{
+        "alibi" : {
+            "image" : "docker.io/seldonio/alibiexplainer",
+            "defaultImageVersion": "0.2.3",
+            "allowedImageVersions": [
+               "0.2.3"
             ]
         }
     }`,

--- a/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
+++ b/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
@@ -36,13 +36,13 @@ var cfg *rest.Config
 var c client.Client
 
 const (
-	DefaultTensorflowRuntimeVersion    = "latest"
-	DefaultTensorflowRuntimeVersionGPU = "latest-gpu"
-	DefaultSKLearnRuntimeVersion       = "0.1.0"
-	DefaultPyTorchRuntimeVersion       = "0.1.0"
-	DefaultXGBoostRuntimeVersion       = "0.1.0"
-	DefaultTensorRTRuntimeVersion      = "19.05-py3"
-	DefaultONNXRuntimeVersion          = "v0.5.0"
+	DefaultTensorflowRuntimeVersion     = "latest"
+	DefaultTensorflowRuntimeVersionGPU  = "latest-gpu"
+	DefaultSKLearnRuntimeVersion        = "0.1.0"
+	DefaultPyTorchRuntimeVersion        = "0.1.0"
+	DefaultXGBoostRuntimeVersion        = "0.1.0"
+	DefaultTensorRTRuntimeVersion       = "19.05-py3"
+	DefaultONNXRuntimeVersion           = "v0.5.0"
 	DefaultAlibiExplainerRuntimeVersion = "0.2.3"
 )
 
@@ -67,7 +67,7 @@ func TestMain(m *testing.M) {
 
 	// Create configmap
 	configs := map[string]string{
-	"predictors": `{
+		"predictors": `{
         "tensorflow" : {
             "image" : "tensorflow/serving",
             "defaultImageVersion": "latest",
@@ -117,7 +117,7 @@ func TestMain(m *testing.M) {
             ]
         }
     }`,
-    "explainers" : `{
+		"explainers": `{
         "alibi" : {
             "image" : "docker.io/seldonio/alibiexplainer",
             "defaultImageVersion": "0.2.3",

--- a/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
+++ b/pkg/apis/serving/v1alpha2/v1alpha2_suite_test.go
@@ -67,65 +67,65 @@ func TestMain(m *testing.M) {
 
 	// Create configmap
 	configs := map[string]string{
-	"predictors": `{
-        "tensorflow" : {
-            "image" : "tensorflow/serving",
-            "defaultImageVersion": "latest",
-            "defaultGPUImageVersion": "latest-gpu",
-            "allowedImageVersions": [
-               "latest",
-               "latest-gpu"
-            ]
-        },
-        "sklearn" : {
-            "image" : "kfserving/sklearnserver",
-            "defaultImageVersion": "0.1.0",
-            "allowedImageVersions": [
-               "latest",
-               "0.1.0"
-            ]
-        },
-        "xgboost" : {
-            "image" : "kfserving/xgbserver",
-            "defaultImageVersion": "0.1.0",
-            "allowedImageVersions": [
-               "latest",
-               "0.1.0"
-            ]
-        },
-        "pytorch" : {
-            "image" : "kfserving/pytorchserver",
-            "defaultImageVersion": "0.1.0",
-            "allowedImageVersions": [
-               "latest",
-               "0.1.0"
-            ]
-        },
-        "onnx" : {
-            "image" : "onnxruntime/server",
-            "defaultImageVersion": "v0.5.0",
-            "allowedImageVersions": [
-               "latest",
-               "v0.5.0"
-            ]
-        },
-        "tensorrt" : {
-            "image" : "nvcr.io/nvidia/tensorrtserver",
-            "defaultImageVersion": "19.05-py3",
-            "allowedImageVersions": [
-               "19.05-py3"
-            ]
-        }
-    }`,
-    "explainers": `{
-        "alibi" : {
-            "image" : "docker.io/seldonio/alibiexplainer",
-            "defaultImageVersion": "0.2.3",
-            "allowedImageVersions": [
-               "0.2.3"
-            ]
-        }
-    }`,
+		"predictors": `{
+			"tensorflow" : {
+				"image" : "tensorflow/serving",
+				"defaultImageVersion": "latest",
+				"defaultGPUImageVersion": "latest-gpu",
+				"allowedImageVersions": [
+				   "latest",
+				   "latest-gpu"
+				]
+			},
+			"sklearn" : {
+				"image" : "kfserving/sklearnserver",
+				"defaultImageVersion": "0.1.0",
+				"allowedImageVersions": [
+				   "latest",
+				   "0.1.0"
+				]
+			},
+			"xgboost" : {
+				"image" : "kfserving/xgbserver",
+				"defaultImageVersion": "0.1.0",
+				"allowedImageVersions": [
+				   "latest",
+				   "0.1.0"
+				]
+			},
+			"pytorch" : {
+				"image" : "kfserving/pytorchserver",
+				"defaultImageVersion": "0.1.0",
+				"allowedImageVersions": [
+				   "latest",
+				   "0.1.0"
+				]
+			},
+			"onnx" : {
+				"image" : "onnxruntime/server",
+				"defaultImageVersion": "v0.5.0",
+				"allowedImageVersions": [
+				   "latest",
+				   "v0.5.0"
+				]
+			},
+			"tensorrt" : {
+				"image" : "nvcr.io/nvidia/tensorrtserver",
+				"defaultImageVersion": "19.05-py3",
+				"allowedImageVersions": [
+				   "19.05-py3"
+				]
+			}
+		}`,
+		"explainers": `{
+			"alibi" : {
+				"image" : "docker.io/seldonio/alibiexplainer",
+				"defaultImageVersion": "0.2.3",
+				"allowedImageVersions": [
+				   "0.2.3"
+				]
+			}
+        }`,
 	}
 	var configMap = &v1.ConfigMap{
 		ObjectMeta: metav1.ObjectMeta{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Get validation error when creating the inference service with explainer
```
Reason: Bad Request
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/json', 'Date': 'Sat, 12 Oct 2019 22:28:00 GMT', 'Content-Length': '217'})
HTTP response body: {"kind":"Status","apiVersion":"v1","metadata":{},"status":"Failure","message":"admission webhook \"inferenceservice.kfserving-webhook-server.validator\" denied the request: RuntimeVersion must be one of ","code":400}
```
The alibi key is missing in explainers configmap, it should be 
```json
    "explainers": {
        "alibi" : {
            "image" : "docker.io/seldonio/alibiexplainer",
            "defaultImageVersion": "0.2.3",
            "allowedImageVersions": [
               "0.2.3"
            ]
        }
    }
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #441

**Special notes for your reviewer**:
Add the missing tests for explainer

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/439)
<!-- Reviewable:end -->