### PR TITLE
fix one e2e test problem

### DIFF
--- a/test/e2e/utils.py
+++ b/test/e2e/utils.py
@@ -20,6 +20,7 @@ def wait_for_kfservice_ready(name, namespace='kfserving-ci-e2e-test', Timeout_se
     for _ in range(round(Timeout_seconds/10)):
         time.sleep(10)
         kfsvc_status = KFServing.get(name, namespace=namespace)
+        status = 'Unknown'
         for condition in kfsvc_status['status'].get('conditions', {}):
             if condition.get('type', '') == 'Ready':
                 status = condition.get('status', 'Unknown')


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
fix one e2e test problem
```
name = 'isvc-tensorflow-test', namespace = 'kfserving-ci-e2e-test'
Timeout_seconds = 600
   def wait_for_kfservice_ready(name, namespace='kfserving-ci-e2e-test', Timeout_seconds=600):
       for _ in range(round(Timeout_seconds/10)):
           time.sleep(10)
           kfsvc_status = KFServing.get(name, namespace=namespace)
           for condition in kfsvc_status['status'].get('conditions', {}):
               if condition.get('type', '') == 'Ready':
                   status = condition.get('status', 'Unknown')
>           if status == 'True':
E           UnboundLocalError: local variable 'status' referenced before assignment
```

**Which issue(s) this PR fixes**:
Fixes #458 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/459)
<!-- Reviewable:end -->
