### PR TITLE
add docs for pvc supporting

### DIFF
--- a/docs/samples/pvc/README.md
+++ b/docs/samples/pvc/README.md
@@ -1,0 +1,31 @@
+
+# Create a InferenceService for on-prem cluster
+
+The guide shows how to train model and create InferenceService for the trained model for on-prem cluster.
+
+## Prerequisites
+Refer to the [document](https://kubernetes.io/docs/concepts/storage/persistent-volumes/) to create Persistent Volume (PV) and Persistent Volume Claim (PVC), the PVC will be used to store model.
+
+## Training model
+
+Following the mnist example [guide](https://github.com/kubeflow/examples/tree/master/mnist#local-storage) to train mnist model and store to PVC. In the example, the relative path of model will be `./export/` on the PVC.
+
+## Create the InferenceService
+
+Update the ${PVC_NAME} to the created PVC name in the `mnis-pvc.yaml` and apply:
+```bash
+kubectl apply -f mnist-pvc.yaml
+```
+
+Expected Output
+```
+$ inferenceservice.serving.kubeflow.org/mnist-sample configured
+```
+
+## Check the InferenceService
+
+```bash
+$ kubectl get inferenceservice
+NAME           URL                                                               READY     DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
+mnist-sample   http://mnist-sample.kubeflow.example.com/v1/models/mnist-sample   True      100                                1m
+```

--- a/docs/samples/pvc/mnist-pvc.yaml
+++ b/docs/samples/pvc/mnist-pvc.yaml
@@ -1,0 +1,9 @@
+apiVersion: "serving.kubeflow.org/v1alpha2"
+kind: "InferenceService"
+metadata:
+  name: "mnist-sample"
+spec:
+  default:
+    predictor:
+      tensorflow:
+        storageUri: "pvc://${PVC_NAME}/export"

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -104,6 +104,9 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 		}
 		storageInitializerMounts = append(storageInitializerMounts, pvcSourceVolumeMount)
 
+		// Since the model path is linked from source pvc, userContainer also need to mount the pvc.
+		userContainer.VolumeMounts = append(userContainer.VolumeMounts, pvcSourceVolumeMount)
+
 		// modify the sourceURI to point to the PVC path
 		srcURI = PvcSourceMountPath + "/" + pvcPath
 	}

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -186,6 +186,11 @@ func TestStorageInitializerInjector(t *testing.T) {
 							Name: "user-container",
 							VolumeMounts: []v1.VolumeMount{
 								{
+									Name:      "kfserving-pvc-source",
+									MountPath: "/mnt/pvc",
+									ReadOnly:  true,
+								},
+								{
 									Name:      "kfserving-provision-location",
 									MountPath: constants.DefaultModelLocalMountPath,
 									ReadOnly:  true,

--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -45,6 +45,11 @@ KFServing supports the following storage providers:
     * Absolute path: `/absolute/path` or `file:///absolute/path`
     * Relative path: `relative/path` or `file://relative/path`
     * For local filesystem, we recommended to use relative path without any prefix.
+* Persistent Volume Claim (PVC) with the format "pvc://{$pvcname}/[path]".
+    * The `pvcname` is the name of the PVC that contains the model.
+    * The `[path]` is the relative path to the model on the PVC.
+    * For e.g. `pvc://mypvcname/model/path/on/pvc`
+
 
 ## KFServing Client
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The PR is address below items:
1. Added docs for pvc supporting. since someone asked me about how to use model in local (PVC) in KFServing for on-prem cluster, I also did not find the docs, in fact we support the great feature, add related docs. 
2. Add one sample for pvc for on-prem cluster, as @rakelkar commented below.
3. During implement item 2, I found a bug for PVC supporting, the PR fixes that.

    Bug: since the init container is linked the model path from source PVC, but the source PVC is not mounted to user container, so that the model cannot be found, as below:
```
2019-10-23 13:13:34.129523: I tensorflow_serving/model_servers/server_core.cc:573]  (Re-)adding model: mnist-sample
2019-10-23 13:13:34.231473: E tensorflow_serving/util/retrier.cc:37] Reserving resources for servable: {name: mnist-sample version: 1571834677} failed: Not found: /mnt/models/1571834677 not found
```

Fix solution: mount the PVC for user container, with the fix, inference service started normally.

```
[root@jinchi1 kfserving]# kubectl get inferenceservice
NAME           URL                                                               READY     DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
mnist-sample   http://mnist-sample.kubeflow.example.com/v1/models/mnist-sample   True      100                                1m
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/468)
<!-- Reviewable:end -->
