### PR TITLE
Specify inference server container name

### DIFF
--- a/pkg/apis/serving/v1alpha2/explainer_alibi.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi.go
@@ -35,6 +35,7 @@ func (s *AlibiExplainerSpec) CreateExplainerContainer(modelName string, predicto
 
 	return &v1.Container{
 		Image:     config.Explainers.AlibiExplainer.ContainerImage + ":" + s.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
 		Resources: s.Resources,
 		Args:      args,
 	}

--- a/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
@@ -2,6 +2,7 @@ package v1alpha2
 
 import (
 	"fmt"
+	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	v1 "k8s.io/api/core/v1"
@@ -81,6 +82,7 @@ func TestCreateAlibiExplainerContainer(t *testing.T) {
 
 	expectedContainer := &v1.Container{
 		Image:     "seldon.io/alibi:0.1.0",
+		Name:      constants.InferenceServiceContainerName,
 		Resources: requestedResource,
 		Args: []string{
 			"--model_name",

--- a/pkg/apis/serving/v1alpha2/framework_custom.go
+++ b/pkg/apis/serving/v1alpha2/framework_custom.go
@@ -49,5 +49,8 @@ func (c *CustomSpec) Validate(config *InferenceServicesConfig) error {
 	if err != nil {
 		return fmt.Errorf("Custom container validation error: %s", err.Error())
 	}
+	if c.GetStorageUri() != "" && c.Container.Name != constants.InferenceServiceContainerName {
+		return fmt.Errorf("Custom container validation error: container name must be %q", constants.InferenceServiceContainerName)
+	}
 	return nil
 }

--- a/pkg/apis/serving/v1alpha2/framework_onnx.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx.go
@@ -35,6 +35,7 @@ func (s *ONNXSpec) GetStorageUri() string {
 func (s *ONNXSpec) GetContainer(modelName string, config *InferenceServicesConfig) *v1.Container {
 	return &v1.Container{
 		Image:     config.Predictors.ONNX.ContainerImage + ":" + s.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
 		Resources: s.Resources,
 		Args: []string{
 			"--model_path", constants.DefaultModelLocalMountPath + "/" + ONNXModelFileName,

--- a/pkg/apis/serving/v1alpha2/framework_onnx_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )
@@ -58,6 +59,7 @@ func TestCreateOnnxModelServingContainer(t *testing.T) {
 
 	expectedContainer := &v1.Container{
 		Image:     "someOtherImage:someAmazingVersion",
+		Name:      constants.InferenceServiceContainerName,
 		Resources: onnxRequestedResource,
 		Args: []string{
 			"--model_path", "/mnt/models/model.onnx",

--- a/pkg/apis/serving/v1alpha2/framework_pytorch.go
+++ b/pkg/apis/serving/v1alpha2/framework_pytorch.go
@@ -35,6 +35,7 @@ func (s *PyTorchSpec) GetStorageUri() string {
 func (s *PyTorchSpec) GetContainer(modelName string, config *InferenceServicesConfig) *v1.Container {
 	return &v1.Container{
 		Image:     config.Predictors.PyTorch.ContainerImage + ":" + s.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
 		Resources: s.Resources,
 		Args: []string{
 			"--model_name=" + modelName,

--- a/pkg/apis/serving/v1alpha2/framework_pytorch_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_pytorch_test.go
@@ -2,6 +2,7 @@ package v1alpha2
 
 import (
 	"fmt"
+	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"k8s.io/api/core/v1"
@@ -81,6 +82,7 @@ func TestCreatePytorchModelServingContainer(t *testing.T) {
 
 	expectedContainer := &v1.Container{
 		Image:     "someOtherImage:0.1.0",
+		Name:      constants.InferenceServiceContainerName,
 		Resources: requestedResource,
 		Args: []string{
 			"--model_name=someName",

--- a/pkg/apis/serving/v1alpha2/framework_scikit.go
+++ b/pkg/apis/serving/v1alpha2/framework_scikit.go
@@ -35,6 +35,7 @@ func (s *SKLearnSpec) GetStorageUri() string {
 func (s *SKLearnSpec) GetContainer(modelName string, config *InferenceServicesConfig) *v1.Container {
 	return &v1.Container{
 		Image:     config.Predictors.SKlearn.ContainerImage + ":" + s.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
 		Resources: s.Resources,
 		Args: []string{
 			"--model_name=" + modelName,

--- a/pkg/apis/serving/v1alpha2/framework_scikit_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_scikit_test.go
@@ -2,6 +2,7 @@ package v1alpha2
 
 import (
 	"fmt"
+	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"k8s.io/api/core/v1"
@@ -80,6 +81,7 @@ func TestCreateSKLearnModelServingContainer(t *testing.T) {
 
 	expectedContainer := &v1.Container{
 		Image:     "someOtherImage:0.1.0",
+		Name:      constants.InferenceServiceContainerName,
 		Resources: requestedResource,
 		Args: []string{
 			"--model_name=someName",

--- a/pkg/apis/serving/v1alpha2/framework_tensorflow.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorflow.go
@@ -39,6 +39,7 @@ func (t *TensorflowSpec) GetStorageUri() string {
 func (t *TensorflowSpec) GetContainer(modelName string, config *InferenceServicesConfig) *v1.Container {
 	return &v1.Container{
 		Image:     config.Predictors.Tensorflow.ContainerImage + ":" + t.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
 		Command:   []string{TensorflowEntrypointCommand},
 		Resources: t.Resources,
 		Args: []string{

--- a/pkg/apis/serving/v1alpha2/framework_tensorrt.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorrt.go
@@ -37,6 +37,7 @@ func (t *TensorRTSpec) GetContainer(modelName string, config *InferenceServicesC
 	// based on example at: https://github.com/NVIDIA/tensorrt-laboratory/blob/master/examples/Deployment/Kubernetes/basic-trtis-deployment/deploy.yml
 	return &v1.Container{
 		Image:     config.Predictors.TensorRT.ContainerImage + ":" + t.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
 		Resources: t.Resources,
 		Args: []string{
 			"trtserver",

--- a/pkg/apis/serving/v1alpha2/framework_tensorrt_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorrt_test.go
@@ -21,6 +21,7 @@ import (
 
 	"k8s.io/apimachinery/pkg/api/resource"
 
+	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 )
@@ -55,6 +56,7 @@ func TestCreateModelServingContainer(t *testing.T) {
 
 	expectedContainer := &v1.Container{
 		Image:     "someOtherImage:19.05-py3",
+		Name:      constants.InferenceServiceContainerName,
 		Resources: requestedResource,
 		Args: []string{
 			"trtserver",

--- a/pkg/apis/serving/v1alpha2/framework_xgboost.go
+++ b/pkg/apis/serving/v1alpha2/framework_xgboost.go
@@ -32,6 +32,7 @@ func (x *XGBoostSpec) GetStorageUri() string {
 func (x *XGBoostSpec) GetContainer(modelName string, config *InferenceServicesConfig) *v1.Container {
 	return &v1.Container{
 		Image:     config.Predictors.Xgboost.ContainerImage + ":" + x.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
 		Resources: x.Resources,
 		Args: []string{
 			"--model_name=" + modelName,

--- a/pkg/apis/serving/v1alpha2/framework_xgboost_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_xgboost_test.go
@@ -2,6 +2,7 @@ package v1alpha2
 
 import (
 	"fmt"
+	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
 	"github.com/onsi/gomega/types"
 	"k8s.io/api/core/v1"
@@ -80,6 +81,7 @@ func TestCreateXGBoostContainer(t *testing.T) {
 
 	expectedContainer := &v1.Container{
 		Image:     "someOtherImage:0.1.0",
+		Name:      constants.InferenceServiceContainerName,
 		Resources: requestedResource,
 		Args: []string{
 			"--model_name=someName",

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -114,6 +114,11 @@ const (
 	ArgumentPredictorHost = "--predictor_host"
 )
 
+// InferenceService container name
+const (
+	InferenceServiceContainerName = "kfserving-container"
+)
+
 func (e InferenceServiceComponent) String() string {
 	return string(e)
 }

--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -169,6 +169,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 									{
 										Image: TensorflowServingImageName + ":" +
 											defaultInstance.Spec.Default.Predictor.Tensorflow.RuntimeVersion,
+										Name:    constants.InferenceServiceContainerName,
 										Command: []string{kfserving.TensorflowEntrypointCommand},
 										Args: []string{
 											"--port=" + kfserving.TensorflowServingGRPCPort,
@@ -399,6 +400,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 									{
 										Image: TensorflowServingImageName + ":" +
 											canary.Spec.Canary.Predictor.Tensorflow.RuntimeVersion,
+										Name:    constants.InferenceServiceContainerName,
 										Command: []string{kfserving.TensorflowEntrypointCommand},
 										Args: []string{
 											"--port=" + kfserving.TensorflowServingGRPCPort,

--- a/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
+++ b/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
@@ -132,6 +132,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 											{
 												Image:   TensorflowServingImageName + ":" + DefaultTensorflowRuntimeVersion,
 												Command: []string{v1alpha2.TensorflowEntrypointCommand},
+												Name:    constants.InferenceServiceContainerName,
 												Args: []string{
 													"--port=" + v1alpha2.TensorflowServingGRPCPort,
 													"--rest_api_port=" + v1alpha2.TensorflowServingRestPort,
@@ -171,6 +172,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 										Containers: []v1.Container{
 											{
 												Image:   TensorflowServingImageName + ":" + DefaultTensorflowRuntimeVersion,
+												Name:    constants.InferenceServiceContainerName,
 												Command: []string{v1alpha2.TensorflowEntrypointCommand},
 												Args: []string{
 													"--port=" + v1alpha2.TensorflowServingGRPCPort,
@@ -229,6 +231,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 										Containers: []v1.Container{
 											{
 												Image:   TensorflowServingImageName + ":" + DefaultTensorflowRuntimeVersion,
+												Name:    constants.InferenceServiceContainerName,
 												Command: []string{v1alpha2.TensorflowEntrypointCommand},
 												Args: []string{
 													"--port=" + v1alpha2.TensorflowServingGRPCPort,

--- a/pkg/controller/inferenceservice/resources/knative/service_test.go
+++ b/pkg/controller/inferenceservice/resources/knative/service_test.go
@@ -106,6 +106,7 @@ var defaultService = &knservingv1alpha1.Service{
 							Containers: []v1.Container{
 								{
 									Image:   TensorflowServingImageName + ":" + isvc.Spec.Default.Predictor.Tensorflow.RuntimeVersion,
+									Name:    constants.InferenceServiceContainerName,
 									Command: []string{v1alpha2.TensorflowEntrypointCommand},
 									Args: []string{
 										"--port=" + v1alpha2.TensorflowServingGRPCPort,
@@ -150,6 +151,7 @@ var canaryService = &knservingv1alpha1.Service{
 							Containers: []v1.Container{
 								{
 									Image:   TensorflowServingImageName + ":" + isvc.Spec.Default.Predictor.Tensorflow.RuntimeVersion,
+									Name:    constants.InferenceServiceContainerName,
 									Command: []string{v1alpha2.TensorflowEntrypointCommand},
 									Args: []string{
 										"--port=" + v1alpha2.TensorflowServingGRPCPort,
@@ -268,6 +270,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 										Containers: []v1.Container{
 											{
 												Image: SKLearnServerImageName + ":" + DefaultSKLearnRuntimeVersion,
+												Name:  constants.InferenceServiceContainerName,
 												Args: []string{
 													"--model_name=sklearn",
 													"--model_dir=" + constants.DefaultModelLocalMountPath,
@@ -323,6 +326,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 										Containers: []v1.Container{
 											{
 												Image: XGBoostServerImageName + ":" + DefaultXGBoostRuntimeVersion,
+												Name:  constants.InferenceServiceContainerName,
 												Args: []string{
 													"--model_name=xgboost",
 													"--model_dir=" + constants.DefaultModelLocalMountPath,
@@ -378,6 +382,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 										Containers: []v1.Container{
 											{
 												Image: "kfserving/xgbserver:" + DefaultXGBoostRuntimeVersion,
+												Name:  constants.InferenceServiceContainerName,
 												Args: []string{
 													"--model_name=xgboost",
 													"--model_dir=" + constants.DefaultModelLocalMountPath,
@@ -448,6 +453,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 										Containers: []v1.Container{
 											{
 												Image: SKLearnServerImageName + ":" + DefaultSKLearnRuntimeVersion,
+												Name:  constants.InferenceServiceContainerName,
 												Args: []string{
 													"--model_name=sklearn",
 													"--model_dir=" + constants.DefaultModelLocalMountPath,
@@ -769,6 +775,7 @@ func TestExplainerToKnativeService(t *testing.T) {
 								Containers: []v1.Container{
 									{
 										Image: "alibi:latest",
+										Name:  constants.InferenceServiceContainerName,
 										Args: []string{
 											constants.ArgumentModelName,
 											isvc.Name,
@@ -809,6 +816,7 @@ func TestExplainerToKnativeService(t *testing.T) {
 								Containers: []v1.Container{
 									{
 										Image: "alibi:latest",
+										Name:  constants.InferenceServiceContainerName,
 										Args: []string{
 											constants.ArgumentModelName,
 											isvc.Name,

--- a/pkg/webhook/admission/pod/storage_initializer_injector.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector.go
@@ -34,7 +34,6 @@ const (
 	PvcURIPrefix                            = "pvc://"
 	PvcSourceMountName                      = "kfserving-pvc-source"
 	PvcSourceMountPath                      = "/mnt/pvc"
-	UserContainerName                       = "user-container"
 )
 
 type StorageInitializerConfig struct {
@@ -91,17 +90,17 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 		}
 	}
 
-	// Find the knative user-container (this is the model inference server)
+	// Find the kfserving-container (this is the model inference server)
 	var userContainer *v1.Container
 	for idx, container := range pod.Spec.Containers {
-		if strings.Compare(container.Name, UserContainerName) == 0 {
+		if strings.Compare(container.Name, constants.InferenceServiceContainerName) == 0 {
 			userContainer = &pod.Spec.Containers[idx]
 			break
 		}
 	}
 
 	if userContainer == nil {
-		return fmt.Errorf("Invalid configuration: cannot find container: %s", UserContainerName)
+		return fmt.Errorf("Invalid configuration: cannot find container: %s", constants.InferenceServiceContainerName)
 	}
 
 	podVolumes := []v1.Volume{}
@@ -141,7 +140,7 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 		srcURI = PvcSourceMountPath + "/" + pvcPath
 	}
 
-	// Create a volume that is shared between the storage-initializer and user-container
+	// Create a volume that is shared between the storage-initializer and kfserving-container
 	sharedVolume := v1.Volume{
 		Name: StorageInitializerVolumeName,
 		VolumeSource: v1.VolumeSource{
@@ -183,7 +182,7 @@ func (mi *StorageInitializerInjector) InjectStorageInitializer(pod *v1.Pod) erro
 		},
 	}
 
-	// Add a mount the shared volume on the user-container, update the PodSpec
+	// Add a mount the shared volume on the kfserving-container, update the PodSpec
 	sharedVolumeReadMount := v1.VolumeMount{
 		Name:      StorageInitializerVolumeName,
 		MountPath: constants.DefaultModelLocalMountPath,

--- a/pkg/webhook/admission/pod/storage_initializer_injector_test.go
+++ b/pkg/webhook/admission/pod/storage_initializer_injector_test.go
@@ -71,7 +71,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 						},
 					},
 				},
@@ -83,7 +83,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 						},
 					},
 				},
@@ -99,7 +99,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 						},
 					},
 					InitContainers: []v1.Container{
@@ -118,7 +118,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 						},
 					},
 					InitContainers: []v1.Container{
@@ -139,7 +139,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 						},
 					},
 				},
@@ -153,7 +153,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "kfserving-provision-location",
@@ -198,7 +198,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 						},
 					},
 				},
@@ -212,7 +212,7 @@ func TestStorageInitializerInjector(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "kfserving-pvc-source",
@@ -340,7 +340,7 @@ func TestCustomSpecStorageUriInjection(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						v1.Container{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							Env: []v1.EnvVar{
 								v1.EnvVar{
 									Name:  constants.CustomSpecStorageUriEnvVarKey,
@@ -366,7 +366,7 @@ func TestCustomSpecStorageUriInjection(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						v1.Container{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							Env: []v1.EnvVar{
 								v1.EnvVar{
 									Name:  constants.CustomSpecStorageUriEnvVarKey,
@@ -392,7 +392,7 @@ func TestCustomSpecStorageUriInjection(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						v1.Container{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							Env: []v1.EnvVar{
 								v1.EnvVar{
 									Name:  "TestRandom",
@@ -442,7 +442,7 @@ func makePod() *v1.Pod {
 		Spec: v1.PodSpec{
 			Containers: []v1.Container{
 				{
-					Name: "user-container",
+					Name: constants.InferenceServiceContainerName,
 				},
 			},
 		},
@@ -495,7 +495,7 @@ func TestCredentialInjection(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "kfserving-provision-location",
@@ -594,7 +594,7 @@ func TestCredentialInjection(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						v1.Container{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "kfserving-provision-location",
@@ -698,7 +698,7 @@ func TestStorageInitializerConfigmap(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 						},
 					},
 				},
@@ -712,7 +712,7 @@ func TestStorageInitializerConfigmap(t *testing.T) {
 				Spec: v1.PodSpec{
 					Containers: []v1.Container{
 						{
-							Name: "user-container",
+							Name: constants.InferenceServiceContainerName,
 							VolumeMounts: []v1.VolumeMount{
 								{
 									Name:      "kfserving-provision-location",


### PR DESCRIPTION
For now inferenceservice container name is not specified, knative serving will generates the corresponding Pod with a name from `container-name-template` value in ConfigMap config-defaults in knative-serving namespace, which is editable.

For now, inferenceservice webhook mounts volume on the container with hard-code name "user-container", once `container-name-template` changed, inferenceservice cannot work.

so we can add a name to all kinds of component container, not using knative default one.
Fixes #474

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/475)
<!-- Reviewable:end -->
