### PR TITLE
Downgrade istio and knative in e2e tests

### DIFF
--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -25,7 +25,8 @@ ZONE="${GCP_ZONE}"
 PROJECT="${GCP_PROJECT}"
 NAMESPACE="${DEPLOY_NAMESPACE}"
 REGISTRY="${GCP_REGISTRY}"
-KNATIVE_VERSION="v0.9.0"
+ISTIO_VERSION="1.1.6"
+KNATIVE_VERSION="v0.8.0"
 
 # Check and wait for istio/knative/kfserving pod started normally.
 waiting_pod_running(){
@@ -60,8 +61,8 @@ kubectl create clusterrolebinding cluster-admin-binding \
 echo "Install istio ..."
 mkdir istio_tmp
 pushd istio_tmp >/dev/null
-  curl -L https://git.io/getLatestIstio | sh -
-  cd istio-*
+  curl -L https://git.io/getLatestIstio | ISTIO_VERSION=${ISTIO_VERSION} sh -
+  cd istio-${ISTIO_VERSION}
   export PATH=$PWD/bin:$PATH
   kubectl create namespace istio-system
   helm template install/kubernetes/helm/istio-init \


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Downgrade istio and knative in e2e tests to see if inferenceservice can be READY normally with below version:
ISTIO: 1.1.6
KNATIVE: 0.8.0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/478)
<!-- Reviewable:end -->
