### PR TITLE
Order explainer config in container args

### DIFF
--- a/pkg/apis/serving/v1alpha2/explainer_alibi.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi.go
@@ -36,8 +36,8 @@ func (s *AlibiExplainerSpec) CreateExplainerContainer(modelName string, predicto
 	}
 	sort.Strings(keys)
 	for _, k := range keys {
-		arg := "--" + k + "=" + s.Config[k]
-		args = append(args, arg)
+		args = append(args, "--"+k)
+		args = append(args, s.Config[k])
 	}
 
 	return &v1.Container{

--- a/pkg/apis/serving/v1alpha2/explainer_alibi.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi.go
@@ -5,6 +5,7 @@ import (
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/kubeflow/kfserving/pkg/utils"
 	"k8s.io/api/core/v1"
+	"sort"
 	"strings"
 )
 
@@ -28,8 +29,14 @@ func (s *AlibiExplainerSpec) CreateExplainerContainer(modelName string, predicto
 
 	args = append(args, string(s.Type))
 
-	for k, v := range s.Config {
-		arg := "--" + k + "=" + v
+	// Order explainer config map keys
+	var keys []string
+	for k, _ := range s.Config {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		arg := "--" + k + "=" + s.Config[k]
 		args = append(args, arg)
 	}
 

--- a/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
@@ -99,3 +99,61 @@ func TestCreateAlibiExplainerContainer(t *testing.T) {
 	container := spec.CreateExplainerContainer("someName", "predictor.svc.cluster.local", config)
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }
+
+func TestCreateAlibiExplainerContainerWithConfig(t *testing.T) {
+
+	var requestedResource = v1.ResourceRequirements{
+		Limits: v1.ResourceList{
+			"cpu": resource.Quantity{
+				Format: "100",
+			},
+		},
+		Requests: v1.ResourceList{
+			"cpu": resource.Quantity{
+				Format: "90",
+			},
+		},
+	}
+	config := &InferenceServicesConfig{
+		Explainers: &ExplainersConfig{
+			AlibiExplainer: ExplainerConfig{
+				ContainerImage:      "seldon.io/alibi",
+				DefaultImageVersion: "latest",
+			},
+		},
+	}
+	var spec = AlibiExplainerSpec{
+		Type:           "AnchorText",
+		StorageURI:     "gs://someUri",
+		Resources:      requestedResource,
+		RuntimeVersion: "0.1.0",
+		Config: map[string]string{
+			"threshold":    "0.95",
+			"use_unk":      "False",
+			"sample_proba": "0.5",
+		},
+	}
+	g := gomega.NewGomegaWithT(t)
+
+	expectedContainer := &v1.Container{
+		Image:     "seldon.io/alibi:0.1.0",
+		Name:      constants.InferenceServiceContainerName,
+		Resources: requestedResource,
+		Args: []string{
+			"--model_name",
+			"someName",
+			"--predictor_host",
+			"predictor.svc.cluster.local",
+			"--storage_uri",
+			"/mnt/models",
+			"AnchorText",
+			"--sample_proba=0.5",
+			"--threshold=0.95",
+			"--use_unk=False",
+		},
+	}
+
+	// Test Create with config
+	container := spec.CreateExplainerContainer("someName", "predictor.svc.cluster.local", config)
+	g.Expect(container).To(gomega.Equal(expectedContainer))
+}

--- a/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi_test.go
@@ -147,9 +147,12 @@ func TestCreateAlibiExplainerContainerWithConfig(t *testing.T) {
 			"--storage_uri",
 			"/mnt/models",
 			"AnchorText",
-			"--sample_proba=0.5",
-			"--threshold=0.95",
-			"--use_unk=False",
+			"--sample_proba",
+			"0.5",
+			"--threshold",
+			"0.95",
+			"--use_unk",
+			"False",
 		},
 	}
 


### PR DESCRIPTION
Explainer config is a map and needs consistent ordering when turned into container args otherwise muleiple reconciles will happen causing thrashing of pod creations.

Fixes #489 

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/484)
<!-- Reviewable:end -->
