### PR TITLE
Configure separate timeouts for Predictor, Transformer and Explainer

### DIFF
--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -55,7 +55,7 @@ var (
 // Controller Constants
 var (
 	ControllerLabelName        = KFServingName + "-controller-manager"
-	DefaultTimeout       int64 = 10
+	DefaultTimeout       int64 = 600
 	DefaultScalingTarget       = "1"
 )
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -54,9 +54,11 @@ var (
 
 // Controller Constants
 var (
-	ControllerLabelName        = KFServingName + "-controller-manager"
-	DefaultTimeout       int64 = 600
-	DefaultScalingTarget       = "1"
+	ControllerLabelName             = KFServingName + "-controller-manager"
+	DefaultPredictorTimeout   int64 = 60
+	DefaultTransformerTimeout int64 = 120
+	DefaultExplainerTimeout   int64 = 300
+	DefaultScalingTarget            = "1"
 )
 
 // Webhook Constants

--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -163,7 +163,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
 						RevisionSpec: v1beta1.RevisionSpec{
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultPredictorTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
@@ -394,7 +394,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
 						RevisionSpec: v1beta1.RevisionSpec{
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultPredictorTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
@@ -939,7 +939,7 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
 						RevisionSpec: v1beta1.RevisionSpec{
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultTransformerTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
 									{

--- a/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
+++ b/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
@@ -126,7 +126,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
 								RevisionSpec: v1beta1.RevisionSpec{
-									TimeoutSeconds: &constants.DefaultTimeout,
+									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
@@ -167,7 +167,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
 								RevisionSpec: v1beta1.RevisionSpec{
-									TimeoutSeconds: &constants.DefaultTimeout,
+									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
@@ -226,7 +226,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
 								RevisionSpec: v1beta1.RevisionSpec{
-									TimeoutSeconds: &constants.DefaultTimeout,
+									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
 											{

--- a/pkg/controller/inferenceservice/resources/knative/service.go
+++ b/pkg/controller/inferenceservice/resources/knative/service.go
@@ -137,7 +137,7 @@ func (c *ServiceBuilder) CreatePredictorService(name string, metadata metav1.Obj
 						RevisionSpec: v1beta1.RevisionSpec{
 							// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 							// we may need to expose this field in future
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultPredictorTimeout,
 							PodSpec: v1.PodSpec{
 								ServiceAccountName: predictorSpec.ServiceAccountName,
 								Containers: []v1.Container{
@@ -201,7 +201,7 @@ func (c *ServiceBuilder) CreateTransformerService(name string, metadata metav1.O
 						RevisionSpec: v1beta1.RevisionSpec{
 							// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 							// we may need to expose this field in future
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultTransformerTimeout,
 							PodSpec: v1.PodSpec{
 								ServiceAccountName: transformerSpec.ServiceAccountName,
 								Containers: []v1.Container{
@@ -258,7 +258,7 @@ func (c *ServiceBuilder) CreateExplainerService(name string, metadata metav1.Obj
 						RevisionSpec: v1beta1.RevisionSpec{
 							// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 							// we may need to expose this field in future
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultExplainerTimeout,
 							PodSpec: v1.PodSpec{
 								ServiceAccountName: explainerSpec.ServiceAccountName,
 								Containers: []v1.Container{

--- a/pkg/controller/inferenceservice/resources/knative/service_test.go
+++ b/pkg/controller/inferenceservice/resources/knative/service_test.go
@@ -100,7 +100,7 @@ var defaultService = &knservingv1alpha1.Service{
 				},
 				Spec: knservingv1alpha1.RevisionSpec{
 					RevisionSpec: v1beta1.RevisionSpec{
-						TimeoutSeconds: &constants.DefaultTimeout,
+						TimeoutSeconds: &constants.DefaultPredictorTimeout,
 						PodSpec: v1.PodSpec{
 							ServiceAccountName: "testsvcacc",
 							Containers: []v1.Container{
@@ -146,7 +146,7 @@ var canaryService = &knservingv1alpha1.Service{
 				},
 				Spec: knservingv1alpha1.RevisionSpec{
 					RevisionSpec: v1beta1.RevisionSpec{
-						TimeoutSeconds: &constants.DefaultTimeout,
+						TimeoutSeconds: &constants.DefaultPredictorTimeout,
 						PodSpec: v1.PodSpec{
 							Containers: []v1.Container{
 								{
@@ -265,7 +265,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
 								RevisionSpec: v1beta1.RevisionSpec{
-									TimeoutSeconds: &constants.DefaultTimeout,
+									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
@@ -321,7 +321,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
 								RevisionSpec: v1beta1.RevisionSpec{
-									TimeoutSeconds: &constants.DefaultTimeout,
+									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
@@ -377,7 +377,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
 								RevisionSpec: v1beta1.RevisionSpec{
-									TimeoutSeconds: &constants.DefaultTimeout,
+									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
@@ -448,7 +448,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
 								RevisionSpec: v1beta1.RevisionSpec{
-									TimeoutSeconds: &constants.DefaultTimeout,
+									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
 											{
@@ -587,7 +587,7 @@ func TestTransformerToKnativeService(t *testing.T) {
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
 						RevisionSpec: v1beta1.RevisionSpec{
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultTransformerTimeout,
 							PodSpec: v1.PodSpec{
 								ServiceAccountName: "testsvcacc",
 								Containers: []v1.Container{
@@ -629,7 +629,7 @@ func TestTransformerToKnativeService(t *testing.T) {
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
 						RevisionSpec: v1beta1.RevisionSpec{
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultTransformerTimeout,
 							PodSpec: v1.PodSpec{
 								ServiceAccountName: "testsvcacc",
 								Containers: []v1.Container{
@@ -770,7 +770,7 @@ func TestExplainerToKnativeService(t *testing.T) {
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
 						RevisionSpec: v1beta1.RevisionSpec{
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultExplainerTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
 									{
@@ -811,7 +811,7 @@ func TestExplainerToKnativeService(t *testing.T) {
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
 						RevisionSpec: v1beta1.RevisionSpec{
-							TimeoutSeconds: &constants.DefaultTimeout,
+							TimeoutSeconds: &constants.DefaultExplainerTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
 									{


### PR DESCRIPTION
Explanation examples can break due to low revision timeout.

Fixes #490

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/491)
<!-- Reviewable:end -->
