### PR TITLE
Validate replicas for explainer and transformer too

### DIFF
--- a/pkg/apis/serving/v1alpha2/explainer.go
+++ b/pkg/apis/serving/v1alpha2/explainer.go
@@ -62,12 +62,12 @@ func (e *ExplainerSpec) Validate(config *InferenceServicesConfig) error {
 	if err != nil {
 		return err
 	}
-	errs := []error{
+	for _, err := range []error{
 		explainer.Validate(config),
 		validateStorageURI(e.GetStorageUri()),
+		validateReplicas(e.MinReplicas, e.MaxReplicas),
 		validateResourceRequirements(explainer.GetResourceRequirements()),
-	}
-	for _, err := range errs {
+	} {
 		if err != nil {
 			return err
 		}

--- a/pkg/apis/serving/v1alpha2/predictor.go
+++ b/pkg/apis/serving/v1alpha2/predictor.go
@@ -63,31 +63,17 @@ func (p *PredictorSpec) Validate(config *InferenceServicesConfig) error {
 	if err != nil {
 		return err
 	}
-	errs := []error{
+	for _, err := range []error{
 		predictor.Validate(config),
 		validateStorageURI(p.GetStorageUri()),
 		validateReplicas(p.MinReplicas, p.MaxReplicas),
 		validateResourceRequirements(predictor.GetResourceRequirements()),
-	}
-	for _, err := range errs {
+	} {
 		if err != nil {
 			return err
 		}
 	}
 
-	return nil
-}
-
-func validateReplicas(minReplicas int, maxReplicas int) error {
-	if minReplicas < 0 {
-		return fmt.Errorf(MinReplicasLowerBoundExceededError)
-	}
-	if maxReplicas < 0 {
-		return fmt.Errorf(MaxReplicasLowerBoundExceededError)
-	}
-	if minReplicas > maxReplicas && maxReplicas != 0 {
-		return fmt.Errorf(MinReplicasShouldBeLessThanMaxError)
-	}
 	return nil
 }
 

--- a/pkg/apis/serving/v1alpha2/transformer.go
+++ b/pkg/apis/serving/v1alpha2/transformer.go
@@ -51,10 +51,17 @@ func (t *TransformerSpec) Validate(config *InferenceServicesConfig) error {
 	if err != nil {
 		return err
 	}
-	if err := validateResourceRequirements(&transformer.GetContainerSpec().Resources); err != nil {
-		return err
+	for _, err := range []error{
+		validateReplicas(t.MinReplicas, t.MaxReplicas),
+		validateResourceRequirements(&transformer.GetContainerSpec().Resources),
+		transformer.Validate(config),
+	} {
+		if err != nil {
+			return err
+		}
 	}
-	return transformer.Validate(config)
+
+	return nil
 }
 
 func getTransformer(t *TransformerSpec) (Transformer, error) {

--- a/pkg/apis/serving/v1alpha2/utils.go
+++ b/pkg/apis/serving/v1alpha2/utils.go
@@ -90,3 +90,16 @@ func validateStorageURI(storageURI string) error {
 
 	return fmt.Errorf(UnsupportedStorageURIFormatError, strings.Join(SupportedStorageURIPrefixList, ", "), storageURI)
 }
+
+func validateReplicas(minReplicas int, maxReplicas int) error {
+	if minReplicas < 0 {
+		return fmt.Errorf(MinReplicasLowerBoundExceededError)
+	}
+	if maxReplicas < 0 {
+		return fmt.Errorf(MaxReplicasLowerBoundExceededError)
+	}
+	if minReplicas > maxReplicas && maxReplicas != 0 {
+		return fmt.Errorf(MinReplicasShouldBeLessThanMaxError)
+	}
+	return nil
+}


### PR DESCRIPTION
**What this PR does / why we need it**:
Now predictor already validate min/max replicas, for transformer and explainer we should do that too.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #495

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/500)
<!-- Reviewable:end -->
