### PR TITLE
Change the default resource to be a map to be extensible in future

### DIFF
--- a/pkg/apis/serving/v1alpha2/inferenceservice_defaults_test.go
+++ b/pkg/apis/serving/v1alpha2/inferenceservice_defaults_test.go
@@ -17,11 +17,12 @@ limitations under the License.
 package v1alpha2
 
 import (
-	"github.com/kubeflow/kfserving/pkg/constants"
 	"testing"
 
+	"github.com/kubeflow/kfserving/pkg/constants"
+
 	"github.com/onsi/gomega"
-	"k8s.io/api/core/v1"
+	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -47,12 +48,12 @@ func TestTensorflowDefaults(t *testing.T) {
 	isvc.Default(c)
 
 	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.RuntimeVersion).To(gomega.Equal(DefaultTensorflowRuntimeVersion))
-	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
-	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
+	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.Tensorflow.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
 	g.Expect(isvc.Spec.Canary.Predictor.Tensorflow.RuntimeVersion).To(gomega.Equal("1.11"))
-	g.Expect(isvc.Spec.Canary.Predictor.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Predictor.Tensorflow.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
 	g.Expect(isvc.Spec.Canary.Predictor.Tensorflow.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }
 
@@ -103,12 +104,12 @@ func TestPyTorchDefaults(t *testing.T) {
 	isvc.Default(c)
 
 	g.Expect(isvc.Spec.Default.Predictor.PyTorch.RuntimeVersion).To(gomega.Equal(DefaultPyTorchRuntimeVersion))
-	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
-	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
+	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.PyTorch.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
 	g.Expect(isvc.Spec.Canary.Predictor.PyTorch.RuntimeVersion).To(gomega.Equal("0.2.0"))
-	g.Expect(isvc.Spec.Canary.Predictor.PyTorch.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Predictor.PyTorch.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
 	g.Expect(isvc.Spec.Canary.Predictor.PyTorch.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }
 
@@ -133,12 +134,12 @@ func TestSKLearnDefaults(t *testing.T) {
 	isvc.Default(c)
 
 	g.Expect(isvc.Spec.Default.Predictor.SKLearn.RuntimeVersion).To(gomega.Equal(DefaultSKLearnRuntimeVersion))
-	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
-	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
+	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.SKLearn.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
 	g.Expect(isvc.Spec.Canary.Predictor.SKLearn.RuntimeVersion).To(gomega.Equal("0.2.0"))
-	g.Expect(isvc.Spec.Canary.Predictor.SKLearn.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Predictor.SKLearn.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
 	g.Expect(isvc.Spec.Canary.Predictor.SKLearn.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }
 
@@ -163,12 +164,12 @@ func TestXGBoostDefaults(t *testing.T) {
 	isvc.Default(c)
 
 	g.Expect(isvc.Spec.Default.Predictor.XGBoost.RuntimeVersion).To(gomega.Equal(DefaultXGBoostRuntimeVersion))
-	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
-	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
+	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.XGBoost.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
 	g.Expect(isvc.Spec.Canary.Predictor.XGBoost.RuntimeVersion).To(gomega.Equal("0.2.0"))
-	g.Expect(isvc.Spec.Canary.Predictor.XGBoost.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Predictor.XGBoost.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
 	g.Expect(isvc.Spec.Canary.Predictor.XGBoost.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }
 
@@ -193,12 +194,12 @@ func TestONNXDefaults(t *testing.T) {
 	isvc.Default(c)
 
 	g.Expect(isvc.Spec.Default.Predictor.ONNX.RuntimeVersion).To(gomega.Equal(DefaultONNXRuntimeVersion))
-	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
-	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
+	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.ONNX.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
 	g.Expect(isvc.Spec.Canary.Predictor.ONNX.RuntimeVersion).To(gomega.Equal("0.6.0"))
-	g.Expect(isvc.Spec.Canary.Predictor.ONNX.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Predictor.ONNX.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
 	g.Expect(isvc.Spec.Canary.Predictor.ONNX.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }
 
@@ -223,12 +224,12 @@ func TestTensorRTDefaults(t *testing.T) {
 	isvc.Default(c)
 
 	g.Expect(isvc.Spec.Default.Predictor.TensorRT.RuntimeVersion).To(gomega.Equal(DefaultTensorRTRuntimeVersion))
-	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
-	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
+	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Predictor.TensorRT.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
 	g.Expect(isvc.Spec.Canary.Predictor.TensorRT.RuntimeVersion).To(gomega.Equal("19.09"))
-	g.Expect(isvc.Spec.Canary.Predictor.TensorRT.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Predictor.TensorRT.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
 	g.Expect(isvc.Spec.Canary.Predictor.TensorRT.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }
 
@@ -260,11 +261,11 @@ func TestAlibiExplainerDefaults(t *testing.T) {
 	isvc.Default(c)
 
 	g.Expect(isvc.Spec.Default.Explainer.Alibi.RuntimeVersion).To(gomega.Equal(DefaultAlibiExplainerRuntimeVersion))
-	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
-	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
-	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(DefaultMemory))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Limits[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
+	g.Expect(isvc.Spec.Default.Explainer.Alibi.Resources.Limits[v1.ResourceMemory]).To(gomega.Equal(defaultResource[v1.ResourceMemory]))
 	g.Expect(isvc.Spec.Canary.Explainer.Alibi.RuntimeVersion).To(gomega.Equal("0.2.4"))
-	g.Expect(isvc.Spec.Canary.Explainer.Alibi.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(DefaultCPU))
+	g.Expect(isvc.Spec.Canary.Explainer.Alibi.Resources.Requests[v1.ResourceCPU]).To(gomega.Equal(defaultResource[v1.ResourceCPU]))
 	g.Expect(isvc.Spec.Canary.Explainer.Alibi.Resources.Requests[v1.ResourceMemory]).To(gomega.Equal(resource.MustParse("3Gi")))
 }

--- a/pkg/apis/serving/v1alpha2/predictor.go
+++ b/pkg/apis/serving/v1alpha2/predictor.go
@@ -18,7 +18,6 @@ import (
 
 	"github.com/kubeflow/kfserving/pkg/constants"
 	v1 "k8s.io/api/core/v1"
-	resource "k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/klog"
 )
 
@@ -33,11 +32,6 @@ type Predictor interface {
 const (
 	// ExactlyOnePredictorViolatedError is a known error message
 	ExactlyOnePredictorViolatedError = "Exactly one of [Custom, ONNX, Tensorflow, TensorRT, SKLearn, XGBoost] must be specified in PredictorSpec"
-)
-
-var (
-	DefaultMemory = resource.MustParse("2Gi")
-	DefaultCPU    = resource.MustParse("1")
 )
 
 // Returns a URI to the model. This URI is passed to the storage-initializer via the StorageInitializerSourceUriInternalAnnotationKey

--- a/pkg/apis/serving/v1alpha2/utils.go
+++ b/pkg/apis/serving/v1alpha2/utils.go
@@ -6,33 +6,38 @@ import (
 	"strings"
 
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/kubernetes/pkg/apis/core"
 	"k8s.io/kubernetes/pkg/apis/core/validation"
+)
+
+var (
+	defaultResource = v1.ResourceList{
+		v1.ResourceCPU:    resource.MustParse("2Gi"),
+		v1.ResourceMemory: resource.MustParse("1"),
+	}
 )
 
 func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
 	if requirements.Requests == nil {
 		requirements.Requests = v1.ResourceList{}
 	}
-
-	if _, ok := requirements.Requests[v1.ResourceCPU]; !ok {
-		requirements.Requests[v1.ResourceCPU] = DefaultCPU
-	}
-	if _, ok := requirements.Requests[v1.ResourceMemory]; !ok {
-		requirements.Requests[v1.ResourceMemory] = DefaultMemory
+	for k, v := range defaultResource {
+		if _, ok := requirements.Requests[k]; !ok {
+			requirements.Requests[k] = v
+		}
 	}
 
 	if requirements.Limits == nil {
 		requirements.Limits = v1.ResourceList{}
 	}
+	for k, v := range defaultResource {
+		if _, ok := requirements.Limits[k]; !ok {
+			requirements.Limits[k] = v
+		}
+	}
 
-	if _, ok := requirements.Limits[v1.ResourceCPU]; !ok {
-		requirements.Limits[v1.ResourceCPU] = DefaultCPU
-	}
-	if _, ok := requirements.Limits[v1.ResourceMemory]; !ok {
-		requirements.Limits[v1.ResourceMemory] = DefaultMemory
-	}
 }
 
 func toCoreResourceRequirements(rr *v1.ResourceRequirements) *core.ResourceRequirements {


### PR DESCRIPTION
**What this PR does / why we need it**:
Change the default resource to be a map to be extensible in future.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #496

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/501)
<!-- Reviewable:end -->
