### PR TITLE
Explainer Parameters in Request

### DIFF
--- a/python/alibiexplainer.Dockerfile
+++ b/python/alibiexplainer.Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7
 
 COPY . .
 RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN git clone https://github.com/SeldonIO/alibi.git && \
+RUN git clone -b 'v0.3.2' --single-branch https://github.com/SeldonIO/alibi.git && \
     cd alibi && \
     pip install .
 RUN pip install -e ./alibiexplainer

--- a/python/alibiexplainer/alibiexplainer/__main__.py
+++ b/python/alibiexplainer/alibiexplainer/__main__.py
@@ -84,6 +84,8 @@ parser_anchor_text.add_argument('--delta', type=float, action=GroupedAction, des
                                 default=argparse.SUPPRESS)
 parser_anchor_text.add_argument('--tau', type=float, action=GroupedAction, dest='explainer.tau',
                                 default=argparse.SUPPRESS)
+parser_anchor_text.add_argument('--top_n', type=int, action=GroupedAction, dest='explainer.top_n',
+                                default=argparse.SUPPRESS)
 parser_anchor_text.add_argument('--batch_size', type=int, action=GroupedAction,
                                 dest='explainer.batch_size', default=argparse.SUPPRESS)
 parser_anchor_text.add_argument('--desired_label', type=int, action=GroupedAction,

--- a/python/alibiexplainer/alibiexplainer/__main__.py
+++ b/python/alibiexplainer/alibiexplainer/__main__.py
@@ -125,7 +125,8 @@ if __name__ == "__main__":
             logging.info("Loading Alibi model")
             alibi_model = dill.load(f)
 
-    explainer = AlibiExplainer(args.model_name,
+    explainer = AlibiExplainer(parser,
+                               args.model_name,
                                args.predictor_host,
                                ExplainerMethod(args.command),
                                extra,

--- a/python/alibiexplainer/alibiexplainer/anchor_images.py
+++ b/python/alibiexplainer/alibiexplainer/anchor_images.py
@@ -21,7 +21,6 @@ from alibiexplainer.explainer_wrapper import ExplainerWrapper
 
 logging.basicConfig(level=kfserving.constants.KFSERVING_LOGLEVEL)
 
-
 class AnchorImages(ExplainerWrapper):
 
     def __init__(self, predict_fn: Callable, explainer: alibi.explainers.AnchorImage, **kwargs):
@@ -29,7 +28,9 @@ class AnchorImages(ExplainerWrapper):
         self.anchors_image = explainer
         self.kwargs = kwargs
 
-    def explain(self, inputs: List) -> Dict:
+    def explain(self, inputs: List, requestArgs: Dict) -> Dict:
+        args = ExplainerWrapper.mergeArgs(self.kwargs, requestArgs)
+        logging.info("Merged Request Args: %s ", args)
         if not self.anchors_image is None:
             arr = np.array(inputs)
             logging.info("Calling explain on image of shape %s", (arr.shape,))
@@ -42,7 +43,7 @@ class AnchorImages(ExplainerWrapper):
                 self.anchors_image.predict_fn = lambda x: np.argmax(self.predict_fn(x), axis=1)
             # We assume the input has batch dimension but Alibi explainers presently assume no batch
             np.random.seed(0)
-            anchor_exp = self.anchors_image.explain(arr[0], **self.kwargs)
+            anchor_exp = self.anchors_image.explain(arr[0], **args)
             return anchor_exp
         else:
             raise Exception("Explainer not initialized")

--- a/python/alibiexplainer/alibiexplainer/anchor_tabular.py
+++ b/python/alibiexplainer/alibiexplainer/anchor_tabular.py
@@ -75,7 +75,9 @@ class AnchorTabular(ExplainerWrapper):
         logging.info("Fitting AnchorTabular")
         self.anchors_tabular.fit(training_data)
 
-    def explain(self, inputs: List) -> Dict:
+    def explain(self, inputs: List, requestArgs: Dict) -> Dict:
+        args = ExplainerWrapper.mergeArgs(self.kwargs, requestArgs)
+        logging.info("Merged Request Args: %s ", args)
         if not self.anchors_tabular is None:
             arr = np.array(inputs)
             # set anchor_tabular predict function so it always returns predicted class
@@ -86,7 +88,7 @@ class AnchorTabular(ExplainerWrapper):
             else:
                 self.anchors_tabular.predict_fn = lambda x: np.argmax(self.predict_fn(x), axis=1)
             # We assume the input has batch dimension but Alibi explainers presently assume no batch
-            anchor_exp = self.anchors_tabular.explain(arr[0], **self.kwargs)
+            anchor_exp = self.anchors_tabular.explain(arr[0], **args)
             if not self.cmap is None:
                 # convert to interpretable raw features
                 for i in range(len(anchor_exp['raw']['examples'])):

--- a/python/alibiexplainer/alibiexplainer/anchor_text.py
+++ b/python/alibiexplainer/alibiexplainer/anchor_text.py
@@ -31,6 +31,7 @@ class AnchorText(ExplainerWrapper):
         self.predict_fn = predict_fn
         self.kwargs = kwargs
         logging.info("Anchor Text args %s", self.kwargs)
+        logging.info("Hey")
         if explainer is None:
             logging.info("Loading Spacy Language model for %s", spacy_language_model)
             spacy_model(model=spacy_language_model)
@@ -38,10 +39,12 @@ class AnchorText(ExplainerWrapper):
             logging.info("Language model loaded")
         self.anchors_text = explainer
 
-    def explain(self, inputs: List) -> Dict:
+    def explain(self, inputs: List, requestArgs: Dict) -> Dict:
+        args = ExplainerWrapper.mergeArgs(self.kwargs, requestArgs)
+        logging.info("Merged Request Args: %s ", args)
         if self.anchors_text is None:
             self.anchors_text = alibi.explainers.AnchorText(self.nlp, self.predict_fn)
         # We assume the input has batch dimension but Alibi explainers presently assume no batch
         np.random.seed(0)
-        anchor_exp = self.anchors_text.explain(inputs[0], **self.kwargs)
+        anchor_exp = self.anchors_text.explain(inputs[0], **args)
         return anchor_exp

--- a/python/alibiexplainer/alibiexplainer/explainer.py
+++ b/python/alibiexplainer/alibiexplainer/explainer.py
@@ -74,23 +74,21 @@ class AlibiExplainer(kfserving.KFModel):
         return np.array(resp["predictions"])
 
     def parse_headers(self, headers: List) -> Dict:
-        argsStr = '--predictor_host x AnchorText'
+        argsStr = '--predictor_host x ' + str(self.method)
         for key,value in headers:
-            print(key,value)
             if key.startswith("Alibi-"):
                 argName = '_'.join(key.lower().split("-")[1:])
                 argsStr += " --"+argName + " " + value
         try:
             args, _ = self.parser.parse_known_args(argsStr.split())
-            argdDict = vars(args).copy()
-            if 'explainer' in argdDict:
+            argsDict = vars(args).copy()
+            if 'explainer' in argsDict:
                 extra = vars(args.explainer)
             else:
                 extra = {}
-            logging.info("Extra Request args: %s", extra)
             return extra
         except Exception as inst:
-            logging.error("Failed to parser extra args: %s",inst)
+            logging.error("Failed to parse extra args: %s",inst)
             return {}
 
     def explain(self, request: Dict, headers: List = []) -> Any:

--- a/python/alibiexplainer/alibiexplainer/explainer.py
+++ b/python/alibiexplainer/alibiexplainer/explainer.py
@@ -74,20 +74,24 @@ class AlibiExplainer(kfserving.KFModel):
         return np.array(resp["predictions"])
 
     def parse_headers(self, headers: List) -> Dict:
-        argsStr = '--predictor_host x AnchorText '
+        argsStr = '--predictor_host x AnchorText'
         for key,value in headers:
             print(key,value)
             if key.startswith("Alibi-"):
                 argName = '_'.join(key.lower().split("-")[1:])
-                argsStr += "--"+argName + " " + value
-        args, _ = self.parser.parse_known_args(argsStr.split())
-        argdDict = vars(args).copy()
-        if 'explainer' in argdDict:
-            extra = vars(args.explainer)
-        else:
-            extra = {}
-        logging.info("Extra Request args: %s", extra)
-        return extra
+                argsStr += " --"+argName + " " + value
+        try:
+            args, _ = self.parser.parse_known_args(argsStr.split())
+            argdDict = vars(args).copy()
+            if 'explainer' in argdDict:
+                extra = vars(args.explainer)
+            else:
+                extra = {}
+            logging.info("Extra Request args: %s", extra)
+            return extra
+        except Exception as inst:
+            logging.error("Failed to parser extra args: %s",inst)
+            return {}
 
     def explain(self, request: Dict, headers: List = []) -> Any:
         requestArgs = self.parse_headers(headers)

--- a/python/alibiexplainer/alibiexplainer/explainer_wrapper.py
+++ b/python/alibiexplainer/alibiexplainer/explainer_wrapper.py
@@ -20,5 +20,11 @@ class ExplainerWrapper(object):
     def validate(self, training_data_url: Optional[str]):
         pass
 
-    def explain(self, inputs: List) -> Dict:
+    def explain(self, inputs: List, reqeustArgs: Dict) -> Dict:
         pass
+
+    @staticmethod
+    def mergeArgs(orig: Dict, extra: Dict) -> Dict:
+        args = orig.copy()
+        args.update({k: v for k, v in extra.items() if v is not None})
+        return args

--- a/python/alibiexplainer/alibiexplainer/test_explainer_wrapper.py
+++ b/python/alibiexplainer/alibiexplainer/test_explainer_wrapper.py
@@ -1,0 +1,8 @@
+from alibiexplainer.explainer_wrapper import ExplainerWrapper
+
+def test_merge_args():
+    args = {"threshold": 0.9, "tau": 0.1}
+    requestArgs = {"tau":0.4}
+    argsNew =  ExplainerWrapper.mergeArgs(args, requestArgs)
+    assert argsNew["tau"] == 0.4
+    assert argsNew["threshold"] == 0.9

--- a/python/kfserving/kfserving/handlers/http.py
+++ b/python/kfserving/kfserving/handlers/http.py
@@ -42,7 +42,6 @@ class HTTPHandler(tornado.web.RequestHandler):
             )
         return body
 
-
 class PredictHandler(HTTPHandler):
     def post(self, name: str):
         model = self.get_model(name)
@@ -58,6 +57,6 @@ class ExplainHandler(HTTPHandler):
         model = self.get_model(name)
         request = self.validate(self.request)
         request = model.preprocess(request)
-        response = model.explain(request)
+        response = model.explain(request, self.request.headers.get_all())
         response = model.postprocess(response)
         self.write(json.dumps(response))

--- a/python/kfserving/kfserving/kfmodel.py
+++ b/python/kfserving/kfserving/kfmodel.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from typing import Dict
+from typing import Dict, List
 
 import json
 import requests
@@ -53,7 +53,7 @@ class KFModel():
                 reason=response.content)
         return response.json()
 
-    def explain(self, request: Dict) -> Dict:
+    def explain(self, request: Dict, headers: List = []) -> Dict:
         if self.explainer_host is None:
             raise NotImplementedError
 


### PR DESCRIPTION

To get effective explanations its important to be able to explore different parameters to the explain process. These should be passed in requests rather than requiring an updated explainer each time.

 * Allows Alibi parameters to be passed as headers in the request with a prefix "Alibi-"

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/520)
<!-- Reviewable:end -->
