### PR TITLE
update sdk requirements and version

### DIFF
--- a/python/kfserving/requirements.txt
+++ b/python/kfserving/requirements.txt
@@ -1,14 +1,14 @@
-certifi >= 14.05.14
-six >= 1.10
-python_dateutil >= 2.5.3
-setuptools >= 21.0.0
-urllib3 >= 1.15.1
-kubernetes >= 10.0.1
-tornado >= 1.4.1
-argparse >= 1.4.0
-minio >= 4.0.9
-google-cloud-storage >= 1.16.0
-adal >= 1.2.2
-table_logger >= 0.3.5
-numpy >= 1.17.3
-azure-storage-blob == 1.3.0
+certifi>=14.05.14
+six>=1.10
+python_dateutil>=2.5.3
+setuptools>=21.0.0
+urllib3>=1.15.1
+kubernetes>=10.0.1
+tornado>=1.4.1
+argparse>=1.4.0
+minio>=4.0.9
+google-cloud-storage>=1.16.0
+adal>=1.2.2
+table_logger>=0.3.5
+numpy>=1.17.3
+azure-storage-blob>=1.3.0,<=2.1.0

--- a/python/kfserving/setup.py
+++ b/python/kfserving/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kfserving',
-    version='0.2.4',
+    version='0.2.1.1',
     author="Kubeflow Authors",
     author_email='ellisbigelow@google.com, hejinchi@cn.ibm.com',
     license="Apache License Version 2.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

 As we have made decision to align SDK version with KFServing release last weekly meeting, I just updated the SDK version. And trying to update in kubeflow-fairing accordingly in https://github.com/kubeflow/fairing/pull/415, but failed in `Travis CI`
```
Installed /home/travis/virtualenv/python3.7.1/lib/python3.7/site-packages/minio-5.0.4-py3.7.egg
error: azure-storage-blob 1.5.0 is installed but azure-storage-blob==1.3.0 is required by {'kfserving'}
The command "python setup.py install" failed and exited with 1 during .
```
That's not good to pin version in requirements, that will cause failure during installation, we should avoid that.

Another thing is we need to release new version for SDK, otherwise back fairing integration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/534)
<!-- Reviewable:end -->
