### PR TITLE
Update RevisionSpec and duck apis to v1 for Knative 0.9 vendor

### DIFF
--- a/pkg/apis/serving/v1alpha2/inferenceservice_status_test.go
+++ b/pkg/apis/serving/v1alpha2/inferenceservice_status_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"k8s.io/api/core/v1"
 	"knative.dev/pkg/apis/duck"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
 	"testing"
@@ -59,8 +60,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "Different condition type should not be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: v1.ConditionTrue,
 				}},
@@ -70,8 +71,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "False condition status should not be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   v1alpha1.ServiceConditionReady,
 					Status: v1.ConditionFalse,
 				}},
@@ -81,8 +82,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "Unknown condition status should not be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   v1alpha1.ServiceConditionReady,
 					Status: v1.ConditionUnknown,
 				}},
@@ -92,8 +93,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "Missing condition status should not be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type: v1alpha1.ConfigurationConditionReady,
 				}},
 			},
@@ -102,8 +103,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "True condition status should be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   v1alpha1.ConfigurationConditionReady,
 					Status: v1.ConditionTrue,
 				}},
@@ -121,8 +122,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "Default service, route conditions with ready status should be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: v1.ConditionTrue,
 				}, {
@@ -144,8 +145,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "Default/canary service, route conditions with ready status should be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   v1alpha1.ConfigurationConditionReady,
 					Status: v1.ConditionTrue,
 				},
@@ -153,8 +154,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 			},
 		},
 		canaryServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   v1alpha1.ConfigurationConditionReady,
 					Status: v1.ConditionTrue,
 				},
@@ -173,8 +174,8 @@ func TestInferenceServiceIsReady(t *testing.T) {
 	}, {
 		name: "Multiple conditions with ready status false should not be ready",
 		defaultServiceStatus: v1alpha1.ServiceStatus{
-			Status: duckv1beta1.Status{
-				Conditions: duckv1beta1.Conditions{{
+			Status: duckv1.Status{
+				Conditions: duckv1.Conditions{{
 					Type:   "Foo",
 					Status: v1.ConditionTrue,
 				}, {

--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -31,7 +31,7 @@ import (
 	testutils "github.com/kubeflow/kfserving/pkg/testing"
 	v1 "k8s.io/api/core/v1"
 	"knative.dev/pkg/apis"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2"
 	kfserving "github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2"
@@ -39,6 +39,7 @@ import (
 	"golang.org/x/net/context"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	duckv1 "knative.dev/pkg/apis/duck/v1"
 	duckv1beta1 "knative.dev/pkg/apis/duck/v1beta1"
 	"knative.dev/pkg/apis/istio/common/v1alpha1"
 	istiov1alpha1 "knative.dev/pkg/apis/istio/common/v1alpha1"
@@ -175,7 +176,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultPredictorTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
@@ -206,7 +207,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 	updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 	updateDefault.Status.LatestReadyRevisionName = "revision-v1"
 	updateDefault.Status.URL, _ = apis.ParseURL("http://revision-v1.myns.myingress.com")
-	updateDefault.Status.Conditions = duckv1beta1.Conditions{
+	updateDefault.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1alpha1.ServiceConditionReady,
 			Status: "True",
@@ -406,7 +407,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultPredictorTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
@@ -438,7 +439,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 	updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 	updateDefault.Status.LatestReadyRevisionName = "revision-v1"
 	updateDefault.Status.URL, _ = apis.ParseURL("http://revision-v1.myns.myingress.com")
-	updateDefault.Status.Conditions = duckv1beta1.Conditions{
+	updateDefault.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1alpha1.ServiceConditionReady,
 			Status: "True",
@@ -451,7 +452,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 	updateCanary.Status.LatestCreatedRevisionName = "revision-v2"
 	updateCanary.Status.LatestReadyRevisionName = "revision-v2"
 	updateCanary.Status.URL, _ = apis.ParseURL("http://revision-v2.myns.myingress.com")
-	updateCanary.Status.Conditions = duckv1beta1.Conditions{
+	updateCanary.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1alpha1.ServiceConditionReady,
 			Status: "True",
@@ -664,7 +665,7 @@ func TestCanaryDelete(t *testing.T) {
 	updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 	updateDefault.Status.LatestReadyRevisionName = "revision-v1"
 	updateDefault.Status.URL, _ = apis.ParseURL("http://revision-v1.myns.myingress.com")
-	updateDefault.Status.Conditions = duckv1beta1.Conditions{
+	updateDefault.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1alpha1.ServiceConditionReady,
 			Status: "True",
@@ -677,7 +678,7 @@ func TestCanaryDelete(t *testing.T) {
 	updateCanary.Status.LatestCreatedRevisionName = "revision-v2"
 	updateCanary.Status.LatestReadyRevisionName = "revision-v2"
 	updateCanary.Status.URL, _ = apis.ParseURL("http://revision-v2.myns.myingress.com")
-	updateCanary.Status.Conditions = duckv1beta1.Conditions{
+	updateCanary.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1alpha1.ServiceConditionReady,
 			Status: "True",
@@ -962,7 +963,7 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultTransformerTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
@@ -993,7 +994,7 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 		updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 		updateDefault.Status.LatestReadyRevisionName = "revision-v1"
 		updateDefault.Status.URL, _ = apis.ParseURL("http://revision-v1.myns.myingress.com")
-		updateDefault.Status.Conditions = duckv1beta1.Conditions{
+		updateDefault.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",
@@ -1006,7 +1007,7 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 		updateCanary.Status.LatestCreatedRevisionName = "revision-v2"
 		updateCanary.Status.LatestReadyRevisionName = "revision-v2"
 		updateCanary.Status.URL, _ = apis.ParseURL("http://revision-v2.myns.myingress.com")
-		updateCanary.Status.Conditions = duckv1beta1.Conditions{
+		updateCanary.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",
@@ -1022,7 +1023,7 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 		updateDefault.Status.LatestCreatedRevisionName = "t-revision-v1"
 		updateDefault.Status.LatestReadyRevisionName = "t-revision-v1"
 		updateDefault.Status.URL, _ = apis.ParseURL("http://t-revision-v1.myns.myingress.com")
-		updateDefault.Status.Conditions = duckv1beta1.Conditions{
+		updateDefault.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",
@@ -1035,7 +1036,7 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 		updateCanary.Status.LatestCreatedRevisionName = "t-revision-v2"
 		updateCanary.Status.LatestReadyRevisionName = "t-revision-v2"
 		updateCanary.Status.URL, _ = apis.ParseURL("http://t-revision-v2.myns.myingress.com")
-		updateCanary.Status.Conditions = duckv1beta1.Conditions{
+		updateCanary.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",
@@ -1492,7 +1493,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultExplainerTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
@@ -1525,7 +1526,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 		updateDefault.Status.LatestReadyRevisionName = "revision-v1"
 		updateDefault.Status.URL, _ = apis.ParseURL("http://revision-v1.myns.myingress.com")
-		updateDefault.Status.Conditions = duckv1beta1.Conditions{
+		updateDefault.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",
@@ -1538,7 +1539,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		updateCanary.Status.LatestCreatedRevisionName = "revision-v2"
 		updateCanary.Status.LatestReadyRevisionName = "revision-v2"
 		updateCanary.Status.URL, _ = apis.ParseURL("http://revision-v2.myns.myingress.com")
-		updateCanary.Status.Conditions = duckv1beta1.Conditions{
+		updateCanary.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",
@@ -1554,7 +1555,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		updateDefault.Status.LatestCreatedRevisionName = "e-revision-v1"
 		updateDefault.Status.LatestReadyRevisionName = "e-revision-v1"
 		updateDefault.Status.URL, _ = apis.ParseURL("http://e-revision-v1.myns.myingress.com")
-		updateDefault.Status.Conditions = duckv1beta1.Conditions{
+		updateDefault.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",
@@ -1567,7 +1568,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		updateCanary.Status.LatestCreatedRevisionName = "e-revision-v2"
 		updateCanary.Status.LatestReadyRevisionName = "e-revision-v2"
 		updateCanary.Status.URL, _ = apis.ParseURL("http://e-revision-v2.myns.myingress.com")
-		updateCanary.Status.Conditions = duckv1beta1.Conditions{
+		updateCanary.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1alpha1.ServiceConditionReady,
 				Status: "True",

--- a/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
+++ b/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
@@ -31,8 +31,8 @@ import (
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -125,7 +125,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 								},
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
-								RevisionSpec: v1beta1.RevisionSpec{
+								RevisionSpec: knservingv1.RevisionSpec{
 									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
@@ -166,7 +166,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 								},
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
-								RevisionSpec: v1beta1.RevisionSpec{
+								RevisionSpec: knservingv1.RevisionSpec{
 									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
@@ -225,7 +225,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 								},
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
-								RevisionSpec: v1beta1.RevisionSpec{
+								RevisionSpec: knservingv1.RevisionSpec{
 									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{

--- a/pkg/controller/inferenceservice/resources/credentials/service_account_credentials_test.go
+++ b/pkg/controller/inferenceservice/resources/credentials/service_account_credentials_test.go
@@ -28,8 +28,8 @@ import (
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	"knative.dev/serving/pkg/apis/serving/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 var configMap = &v1.ConfigMap{
@@ -83,7 +83,7 @@ func TestS3CredentialBuilder(t *testing.T) {
 				Spec: v1alpha1.ConfigurationSpec{
 					Template: &v1alpha1.RevisionTemplateSpec{
 						Spec: v1alpha1.RevisionSpec{
-							RevisionSpec: v1beta1.RevisionSpec{
+							RevisionSpec: knservingv1.RevisionSpec{
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{},
@@ -98,7 +98,7 @@ func TestS3CredentialBuilder(t *testing.T) {
 				Spec: v1alpha1.ConfigurationSpec{
 					Template: &v1alpha1.RevisionTemplateSpec{
 						Spec: v1alpha1.RevisionSpec{
-							RevisionSpec: v1beta1.RevisionSpec{
+							RevisionSpec: knservingv1.RevisionSpec{
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
@@ -208,7 +208,7 @@ func TestGCSCredentialBuilder(t *testing.T) {
 				Spec: v1alpha1.ConfigurationSpec{
 					Template: &v1alpha1.RevisionTemplateSpec{
 						Spec: v1alpha1.RevisionSpec{
-							RevisionSpec: v1beta1.RevisionSpec{
+							RevisionSpec: knservingv1.RevisionSpec{
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{},
@@ -223,7 +223,7 @@ func TestGCSCredentialBuilder(t *testing.T) {
 				Spec: v1alpha1.ConfigurationSpec{
 					Template: &v1alpha1.RevisionTemplateSpec{
 						Spec: v1alpha1.RevisionSpec{
-							RevisionSpec: v1beta1.RevisionSpec{
+							RevisionSpec: knservingv1.RevisionSpec{
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{
@@ -328,7 +328,7 @@ func TestAzureCredentialBuilder(t *testing.T) {
 				Spec: v1alpha1.ConfigurationSpec{
 					Template: &v1alpha1.RevisionTemplateSpec{
 						Spec: v1alpha1.RevisionSpec{
-							RevisionSpec: v1beta1.RevisionSpec{
+							RevisionSpec: knservingv1.RevisionSpec{
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{},
@@ -343,7 +343,7 @@ func TestAzureCredentialBuilder(t *testing.T) {
 				Spec: v1alpha1.ConfigurationSpec{
 					Template: &v1alpha1.RevisionTemplateSpec{
 						Spec: v1alpha1.RevisionSpec{
-							RevisionSpec: v1beta1.RevisionSpec{
+							RevisionSpec: knservingv1.RevisionSpec{
 								PodSpec: v1.PodSpec{
 									Containers: []v1.Container{
 										{

--- a/pkg/controller/inferenceservice/resources/knative/service.go
+++ b/pkg/controller/inferenceservice/resources/knative/service.go
@@ -29,8 +29,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"knative.dev/serving/pkg/apis/autoscaling"
 	"knative.dev/serving/pkg/apis/serving"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 	knservingv1alpha1 "knative.dev/serving/pkg/apis/serving/v1alpha1"
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
 )
 
 var serviceAnnotationDisallowedList = []string{
@@ -127,7 +127,7 @@ func (c *ServiceBuilder) CreatePredictorService(name string, metadata metav1.Obj
 						Annotations: annotations,
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 							// we may need to expose this field in future
 							TimeoutSeconds: &constants.DefaultPredictorTimeout,
@@ -178,7 +178,7 @@ func (c *ServiceBuilder) CreateTransformerService(name string, metadata metav1.O
 						Annotations: annotations,
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 							// we may need to expose this field in future
 							TimeoutSeconds: &constants.DefaultTransformerTimeout,
@@ -235,7 +235,7 @@ func (c *ServiceBuilder) CreateExplainerService(name string, metadata metav1.Obj
 						Annotations: annotations,
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 							// we may need to expose this field in future
 							TimeoutSeconds: &constants.DefaultExplainerTimeout,

--- a/pkg/controller/inferenceservice/resources/knative/service_test.go
+++ b/pkg/controller/inferenceservice/resources/knative/service_test.go
@@ -19,7 +19,7 @@ package knative
 import (
 	"testing"
 
-	"knative.dev/serving/pkg/apis/serving/v1beta1"
+	knservingv1 "knative.dev/serving/pkg/apis/serving/v1"
 
 	"github.com/google/go-cmp/cmp"
 	"github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2"
@@ -99,7 +99,7 @@ var defaultService = &knservingv1alpha1.Service{
 					},
 				},
 				Spec: knservingv1alpha1.RevisionSpec{
-					RevisionSpec: v1beta1.RevisionSpec{
+					RevisionSpec: knservingv1.RevisionSpec{
 						TimeoutSeconds: &constants.DefaultPredictorTimeout,
 						PodSpec: v1.PodSpec{
 							ServiceAccountName: "testsvcacc",
@@ -145,7 +145,7 @@ var canaryService = &knservingv1alpha1.Service{
 					},
 				},
 				Spec: knservingv1alpha1.RevisionSpec{
-					RevisionSpec: v1beta1.RevisionSpec{
+					RevisionSpec: knservingv1.RevisionSpec{
 						TimeoutSeconds: &constants.DefaultPredictorTimeout,
 						PodSpec: v1.PodSpec{
 							Containers: []v1.Container{
@@ -264,7 +264,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 								},
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
-								RevisionSpec: v1beta1.RevisionSpec{
+								RevisionSpec: knservingv1.RevisionSpec{
 									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
@@ -320,7 +320,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 								},
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
-								RevisionSpec: v1beta1.RevisionSpec{
+								RevisionSpec: knservingv1.RevisionSpec{
 									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
@@ -376,7 +376,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 								},
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
-								RevisionSpec: v1beta1.RevisionSpec{
+								RevisionSpec: knservingv1.RevisionSpec{
 									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
@@ -447,7 +447,7 @@ func TestInferenceServiceToKnativeService(t *testing.T) {
 								},
 							},
 							Spec: knservingv1alpha1.RevisionSpec{
-								RevisionSpec: v1beta1.RevisionSpec{
+								RevisionSpec: knservingv1.RevisionSpec{
 									TimeoutSeconds: &constants.DefaultPredictorTimeout,
 									PodSpec: v1.PodSpec{
 										Containers: []v1.Container{
@@ -586,7 +586,7 @@ func TestTransformerToKnativeService(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultTransformerTimeout,
 							PodSpec: v1.PodSpec{
 								ServiceAccountName: "testsvcacc",
@@ -628,7 +628,7 @@ func TestTransformerToKnativeService(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultTransformerTimeout,
 							PodSpec: v1.PodSpec{
 								ServiceAccountName: "testsvcacc",
@@ -769,7 +769,7 @@ func TestExplainerToKnativeService(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultExplainerTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{
@@ -810,7 +810,7 @@ func TestExplainerToKnativeService(t *testing.T) {
 						},
 					},
 					Spec: knservingv1alpha1.RevisionSpec{
-						RevisionSpec: v1beta1.RevisionSpec{
+						RevisionSpec: knservingv1.RevisionSpec{
 							TimeoutSeconds: &constants.DefaultExplainerTimeout,
 							PodSpec: v1.PodSpec{
 								Containers: []v1.Container{


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This is an api migration pr for the Knative 0.9 vendor #543 


**Special notes for your reviewer**:

1. @animeshsingh @jinchihe I did some initial changes to migrate the necessary apis from v1beta1 to v1. However, I would like to get some help on some of the nil pointer errors since I'm not very familiar with the new apis. Thank you very much in advance. 

Below are the list of errors I got from my unit tests.
```
(py3) Tommys-MacBook-Pro:kfserving tommyli$ make test
go generate ./pkg/... ./cmd/...
hack/update-codegen.sh
Generating deepcopy funcs
Generating clientset for serving:v1alpha2 at github.com/kubeflow/kfserving/pkg/client/clientset
Generating listers for serving:v1alpha2 at github.com/kubeflow/kfserving/pkg/client/listers
Generating informers for serving:v1alpha2 at github.com/kubeflow/kfserving/pkg/client/informers
hack/update-openapigen.sh
go fmt ./pkg/... ./cmd/...
go vet ./pkg/... ./cmd/...
hack/verify-golint.sh
Congratulations!  All Go source files have been linted.
go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go crd --output-dir=config/default/crds
CRD files generated, files can be found under path config/default/crds.
kustomize build config/default/crds -o config/default/crds/serving_v1alpha2_inferenceservice.yaml
go run vendor/sigs.k8s.io/controller-tools/cmd/controller-gen/main.go rbac --output-dir=config/default/rbac
RBAC manifests generated under 'config/default/rbac' directory
go test ./pkg/... ./cmd/... -coverprofile cover.out
?   	github.com/kubeflow/kfserving/pkg/apis	[no test files]
?   	github.com/kubeflow/kfserving/pkg/apis/serving	[no test files]
F1114 16:21:24.233090    2511 v1alpha2_suite_test.go:61] failed to start the controlplane. retried 5 times
FAIL	github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha2	0.862s
?   	github.com/kubeflow/kfserving/pkg/client/clientset/versioned	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/clientset/versioned/fake	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/clientset/versioned/scheme	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/clientset/versioned/typed/serving/v1alpha2	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/clientset/versioned/typed/serving/v1alpha2/fake	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/informers/externalversions	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/informers/externalversions/internalinterfaces	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/informers/externalversions/serving	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/informers/externalversions/serving/v1alpha2	[no test files]
?   	github.com/kubeflow/kfserving/pkg/client/listers/serving/v1alpha2	[no test files]
?   	github.com/kubeflow/kfserving/pkg/constants	[no test files]
?   	github.com/kubeflow/kfserving/pkg/controller	[no test files]
F1114 16:21:25.283692    2515 suite_test.go:37] failed to start the controlplane. retried 5 times
FAIL	github.com/kubeflow/kfserving/pkg/controller/inferenceservice	1.471s
?   	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/reconcilers/istio	[no test files]
F1114 16:21:24.969130    2513 suite_test.go:34] failed to start the controlplane. retried 5 times
FAIL	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/reconcilers/knative	1.329s
--- FAIL: TestS3CredentialBuilder (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x18 pc=0x1e49003]

goroutine 58 [running]:
testing.tRunner.func1(0xc000752400)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:874 +0x3a3
panic(0x1f9bc20, 0x2f52ad0)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials.TestS3CredentialBuilder(0xc000752400)
	/Users/tommyli/go/src/github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials/service_account_credentials_test.go:151 +0x743
testing.tRunner(0xc000752400, 0x21da208)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:960 +0x350
FAIL	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials	1.154s
ok  	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials/azure	0.267s	coverage: 100.0% of statements
ok  	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials/gcs	0.345s	coverage: 100.0% of statements
ok  	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials/s3	0.607s	coverage: 96.3% of statements
ok  	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/istio	0.494s	coverage: 81.6% of statements
E1114 16:21:25.848751    2525 suite_test.go:37] failed to start the controlplane. retried 5 timesFailed to start testing panel
E1114 16:21:25.848863    2525 suite_test.go:41] must provide non-nil rest.Config to client.NewFailed to start client
--- FAIL: TestInferenceServiceToKnativeService (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1d154f6]

goroutine 105 [running]:
testing.tRunner.func1(0xc000478400)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:874 +0x3a3
panic(0x1f9e820, 0x2f57d80)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials.(*CredentialBuilder).CreateSecretVolumeAndEnv(0xc0000b53e0, 0x21484b7, 0x7, 0x214c9de, 0xa, 0xc00038f180, 0xc00011ace8, 0x0, 0x0)
	/Users/tommyli/go/src/github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials/service_account_credentials.go:80 +0x96
github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/knative.(*ServiceBuilder).CreatePredictorService(0xc0003fc480, 0xc0005ba560, 0x17, 0x2145ef1, 0x5, 0x0, 0x0, 0x21484b7, 0x7, 0x0, ...)
	/Users/tommyli/go/src/github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/knative/service.go:147 +0x431
github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/knative.TestInferenceServiceToKnativeService(0xc000478400)
	/Users/tommyli/go/src/github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/knative/service_test.go:477 +0x1ddb
testing.tRunner(0xc000478400, 0x21dcb78)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:960 +0x350
FAIL	github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/knative	1.276s
ok  	github.com/kubeflow/kfserving/pkg/logger	0.994s	coverage: 38.8% of statements
?   	github.com/kubeflow/kfserving/pkg/testing	[no test files]
ok  	github.com/kubeflow/kfserving/pkg/utils	0.141s	coverage: 100.0% of statements
?   	github.com/kubeflow/kfserving/pkg/webhook	[no test files]
?   	github.com/kubeflow/kfserving/pkg/webhook/admission/inferenceservice	[no test files]
E1114 16:21:26.140392    2536 suite_test.go:37] failed to start the controlplane. retried 5 timesFailed to start testing panel
E1114 16:21:26.140498    2536 suite_test.go:41] must provide non-nil rest.Config to client.NewFailed to start client
--- FAIL: TestStorageInitializerInjector (0.00s)
panic: runtime error: invalid memory address or nil pointer dereference [recovered]
	panic: runtime error: invalid memory address or nil pointer dereference
[signal SIGSEGV: segmentation violation code=0x1 addr=0x28 pc=0x1b49e36]

goroutine 66 [running]:
testing.tRunner.func1(0xc0003c4600)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:874 +0x3a3
panic(0x1fa2c20, 0x2f61e30)
	/usr/local/Cellar/go/1.13.4/libexec/src/runtime/panic.go:679 +0x1b2
github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials.(*CredentialBuilder).CreateSecretVolumeAndEnv(0xc00018f680, 0x0, 0x0, 0x0, 0x0, 0xc0007b5608, 0xc00036bd08, 0x1, 0x8)
	/Users/tommyli/go/src/github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/credentials/service_account_credentials.go:80 +0x96
github.com/kubeflow/kfserving/pkg/webhook/admission/pod.(*StorageInitializerInjector).InjectStorageInitializer(0xc0007b5b38, 0xc00036bc00, 0xc0007abe48, 0xc00018f680)
	/Users/tommyli/go/src/github.com/kubeflow/kfserving/pkg/webhook/admission/pod/storage_initializer_injector.go:203 +0xd52
github.com/kubeflow/kfserving/pkg/webhook/admission/pod.TestStorageInitializerInjector(0xc0003c4600)
	/Users/tommyli/go/src/github.com/kubeflow/kfserving/pkg/webhook/admission/pod/storage_initializer_injector_test.go:278 +0x116c
testing.tRunner(0xc0003c4600, 0x21e2280)
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:909 +0xc9
created by testing.(*T).Run
	/usr/local/Cellar/go/1.13.4/libexec/src/testing/testing.go:960 +0x350
FAIL	github.com/kubeflow/kfserving/pkg/webhook/admission/pod	1.167s
?   	github.com/kubeflow/kfserving/pkg/webhook/third_party	[no test files]
?   	github.com/kubeflow/kfserving/cmd/logger	[no test files]
?   	github.com/kubeflow/kfserving/cmd/manager	[no test files]
?   	github.com/kubeflow/kfserving/cmd/spec-gen	[no test files]
FAIL
make: *** [test] Error 1
```


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/550)
<!-- Reviewable:end -->
