### PR TITLE
Add a note to install cluster local gateway for knative 0.9.0+

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -64,6 +64,8 @@ the following commands after downloading repository [kubeflow/manifests](https:/
 
   ``` kubeflow/manifests/knative/knative-serving-install/base$ kustomize build . | kubectl apply -f -```
 
+* You need follow the instructions on [Updating your install to use cluster local gateway](https://knative.dev/v0.9-docs/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway) to add cluster local gateway to your cluster if you are on knative serving 0.9.0+.
+
 ### Setup your environment
 
 To start your environment you'll need to set these environment variables (we


### PR DESCRIPTION
**What this PR does / why we need it**:
Add a note to install cluster local gateway for knative 0.9.0+, or there will be [issue](https://github.com/kubeflow/kfserving/pull/524#issuecomment-555433619) when using transformer or explainer.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/561)
<!-- Reviewable:end -->
