### PR TITLE
enhance make deploy-dev to also include logger image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,7 @@ bin
 
 # Ignore files for local deployment
 config/overlays/development/manager_image_patch.yaml
+config/overlays/development/configmap/inferenceservice_patch.yaml
 config/overlays/local/
 .ko.yaml
 

--- a/config/overlays/development/configmap/ko_resolve_logger
+++ b/config/overlays/development/configmap/ko_resolve_logger
@@ -1,0 +1,1 @@
+image: github.com/kubeflow/kfserving/cmd/logger

--- a/config/overlays/development/kustomization.yaml
+++ b/config/overlays/development/kustomization.yaml
@@ -2,4 +2,5 @@ bases:
   - ../../default
 
 patches:
+  - configmap/inferenceservice_patch.yaml
   - manager_image_patch.yaml

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -156,7 +156,7 @@ kfserving-controller-manager-0   2/2     Running   0          13m
 make deploy-dev
 ```
 - **Note**: `deploy-dev` builds the image from your local code, publishes to `KO_DOCKER_REPO`
-and deploys the `kfserving-controller-manager` with the image digest to your cluster for testing. Please also ensure you are logged in to `KO_DOCKER_REPO` from your client machine.
+and deploys the `kfserving-controller-manager` and `logger` with the image digest to your cluster for testing. Please also ensure you are logged in to `KO_DOCKER_REPO` from your client machine.
 
 
 ### Smoke test after deployment

--- a/hack/image_patch_dev.sh
+++ b/hack/image_patch_dev.sh
@@ -18,3 +18,22 @@ spec:
           command:
           image: ${IMG}
 EOF
+
+LOGGER_IMG=$(ko resolve -f config/overlays/development/configmap/ko_resolve_logger| grep 'image:' | awk '{print $2}')
+if [ -z ${LOGGER_IMG} ]; then exit; fi
+cat > config/overlays/${OVERLAY}/configmap/inferenceservice_patch.yaml << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inferenceservice-config
+  namespace: kfserving-system
+data:
+  logger: |-
+    {
+        "image" : "${LOGGER_IMG}",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }
+EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
Enhance "make deploy-dev" to also use logger image built by user.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #572

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/573)
<!-- Reviewable:end -->
