### PR TITLE
Remove executor in makefile and add logger/Add logger test configmap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@ HAS_LINT := $(shell command -v golint;)
 
 # Image URL to use all building/pushing image targets
 IMG ?= kfserving-controller:latest
-EXECUTOR_IMG ?= kfserving-executor:latest
+LOGGER_IMG ?= logger:latest
 
 all: test manager logger
 
@@ -91,11 +91,11 @@ docker-build: test
 docker-push:
 	docker push ${IMG}
 
-docker-build-executor: test
-	docker build -f executor.Dockerfile . -t ${EXECUTOR_IMG}
+docker-build-logger: test
+	docker build -f logger.Dockerfile . -t ${LOGGER_IMG}
 
-docker-push-executor:
-	docker push ${EXECUTOR_IMG}
+docker-push-logger:
+	docker push ${LOGGER_IMG}
 
 apidocs:
 	docker build -f docs/apis/Dockerfile --rm -t apidocs-gen . && \

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -93,3 +93,11 @@ data:
         "ingressGateway" : "knative-ingress-gateway.knative-serving",
         "ingressService" : "istio-ingressgateway.istio-system.svc.cluster.local"
     }
+  logger: |-
+    {
+        "image" : "gcr.io/kubeflow-ci/kfserving/logger",
+        "memoryRequest": "100Mi",
+        "memoryLimit": "1Gi",
+        "cpuRequest": "100m",
+        "cpuLimit": "1"
+    }


### PR DESCRIPTION
**What this PR does / why we need it**:
Remove executor in makefile and add logger
Add logger in test configmap since it's already built for that, or will still use the one released

BTW, thought for test we build the newest logger, but I did not see cases for that. Need add e2e test 
for that later.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/575)
<!-- Reviewable:end -->
