### PR TITLE
Upgrade knative to v0.10.0 in CI tests

### DIFF
--- a/test/scripts/create-cluster.sh
+++ b/test/scripts/create-cluster.sh
@@ -32,7 +32,7 @@ echo "Creating cluster ${CLUSTER_NAME} ... "
 gcloud --project ${PROJECT} beta container clusters create ${CLUSTER_NAME} \
     --addons=HorizontalPodAutoscaling,HttpLoadBalancing \
     --machine-type=n1-standard-4 \
-    --cluster-version 1.13 --zone ${ZONE} \
+    --cluster-version 1.14 --zone ${ZONE} \
     --enable-stackdriver-kubernetes --enable-ip-alias \
     --enable-autoscaling --min-nodes=3 --max-nodes=10 \
     --enable-autorepair \

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -26,7 +26,8 @@ PROJECT="${GCP_PROJECT}"
 NAMESPACE="${DEPLOY_NAMESPACE}"
 REGISTRY="${GCP_REGISTRY}"
 ISTIO_VERSION="1.3.1"
-KNATIVE_VERSION="v0.9.0"
+KNATIVE_VERSION="v0.10.0"
+KUBECTL_VERSION="v1.14.0"
 
 # Check and wait for istio/knative/kfserving pod started normally.
 waiting_pod_running(){
@@ -63,6 +64,11 @@ waiting_for_kfserving_controller(){
 
 echo "Activating service-account ..."
 gcloud auth activate-service-account --key-file=${GOOGLE_APPLICATION_CREDENTIALS}
+
+echo "Upgrading kubectl ..."
+# The kubectl need to be upgraded to 1.14.0 to avoid dismatch issue.
+wget -q -O /usr/local/bin/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBECTL_VERSION}/bin/linux/amd64/kubectl
+chmod a+x /usr/local/bin/kubectl
 
 echo "Configuring kubectl ..."
 gcloud --project ${PROJECT} container clusters get-credentials ${CLUSTER_NAME} --zone ${ZONE}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

As required in https://github.com/kubeflow/kfserving/pull/586, u pgrade knative to v0.10.0 in CI tests.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/587)
<!-- Reviewable:end -->
