### PR TITLE
Added default amazon endpoint to support standard AWS endpoints by default (and public buckets)

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -209,7 +209,7 @@ The path or model %s does not exist." % (uri))
     @staticmethod
     def _create_minio_client():
         # Remove possible http scheme for Minio
-        url = urlparse(os.getenv("AWS_ENDPOINT_URL", ""))
+        url = urlparse(os.getenv("AWS_ENDPOINT_URL", "s3.amazonaws.com"))
         use_ssl = url.scheme == 'https' if url.scheme else bool(os.getenv("S3_USE_HTTPS", "true"))
         return Minio(url.netloc,
                      access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),


### PR DESCRIPTION
There are currently issues reported when public S3 buckets are being requested (especially when no default AWS_ENDPOINT is provided). These issues appear in the form of " string index out of range".

This can be addressed in the python library by providing a default S3 bucket, in this case "s3.amazonaws.com", which is the default that will allow access to public S3 buckets without the need to provide any credentials.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/589)
<!-- Reviewable:end -->
