### PR TITLE
Enable make to apply local changes of model servers, explainer and storage-initializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,6 +35,7 @@ bin
 # Ignore files for local deployment
 config/overlays/development/manager_image_patch.yaml
 config/overlays/development/configmap/inferenceservice_patch.yaml
+config/overlays/dev-image-config/inferenceservice_patch.yaml
 config/overlays/local/
 .ko.yaml
 

--- a/Makefile
+++ b/Makefile
@@ -4,6 +4,11 @@ HAS_LINT := $(shell command -v golint;)
 # Image URL to use all building/pushing image targets
 IMG ?= kfserving-controller:latest
 LOGGER_IMG ?= logger:latest
+SKLEARN_IMG ?= sklearnserver:latest
+XGB_IMG ?= xgbserver:latest
+PYTORCH_IMG ?= pytorchserver:latest
+ALIBI_IMG ?= alibi-explainer:latest
+STORAGE_INIT_IMG ?= storage-initializer:latest
 
 all: test manager logger
 
@@ -35,6 +40,26 @@ deploy-dev: manifests
 deploy-local: manifests
 	./hack/image_patch_dev.sh local
 	kustomize build config/overlays/local | kubectl apply -f -
+
+deploy-dev-sklearn: docker-push-sklearn
+	./hack/model_server_patch_dev.sh sklearn ${KO_DOCKER_REPO}/${SKLEARN_IMG}
+	kustomize build config/overlays/dev-image-config | kubectl apply -f -
+
+deploy-dev-xgb: docker-push-xgb
+	./hack/model_server_patch_dev.sh xgboost ${KO_DOCKER_REPO}/${XGB_IMG}
+	kustomize build config/overlays/dev-image-config | kubectl apply -f -
+
+deploy-dev-pytorch: docker-push-pytorch
+	./hack/model_server_patch_dev.sh pytorch ${KO_DOCKER_REPO}/${PYTORCH_IMG}
+	kustomize build config/overlays/dev-image-config | kubectl apply -f -
+
+deploy-dev-alibi: docker-push-alibi
+	./hack/alibi_patch_dev.sh ${KO_DOCKER_REPO}/${ALIBI_IMG}
+	kustomize build config/overlays/dev-image-config | kubectl apply -f -
+
+deploy-dev-storageInitializer: docker-push-storageInitializer
+	./hack/misc_patch_dev.sh storageInitializer ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG}
+	kustomize build config/overlays/dev-image-config | kubectl apply -f -
 
 deploy-ci: manifests
 	kustomize build config/overlays/test | kubectl apply -f -
@@ -97,6 +122,36 @@ docker-build-logger: test
 
 docker-push-logger:
 	docker push ${LOGGER_IMG}
+
+docker-build-sklearn: 
+	cd python && docker build -t ${KO_DOCKER_REPO}/${SKLEARN_IMG} -f sklearn.Dockerfile .
+
+docker-push-sklearn: docker-build-sklearn
+	docker push ${KO_DOCKER_REPO}/${SKLEARN_IMG}
+
+docker-build-xgb: 
+	cd python && docker build -t ${KO_DOCKER_REPO}/${XGB_IMG} -f xgb.Dockerfile .
+
+docker-push-xgb: docker-build-xgb
+	docker push ${KO_DOCKER_REPO}/${XGB_IMG}
+
+docker-build-pytorch: 
+	cd python && docker build -t ${KO_DOCKER_REPO}/${PYTORCH_IMG} -f pytorch.Dockerfile .
+
+docker-push-pytorch: docker-build-pytorch
+	docker push ${KO_DOCKER_REPO}/${PYTORCH_IMG}
+
+docker-build-alibi: 
+	cd python && docker build -t ${KO_DOCKER_REPO}/${ALIBI_IMG} -f alibiexplainer.Dockerfile .
+
+docker-push-alibi: docker-build-alibi
+	docker push ${KO_DOCKER_REPO}/${ALIBI_IMG}
+
+docker-build-storageInitializer: 
+	cd python && docker build -t ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG} -f storage-initializer.Dockerfile .
+
+docker-push-storageInitializer: docker-build-storageInitializer
+	docker push ${KO_DOCKER_REPO}/${STORAGE_INIT_IMG}
 
 apidocs:
 	docker build -f docs/apis/Dockerfile --rm -t apidocs-gen . && \

--- a/config/overlays/dev-image-config/kustomization.yaml
+++ b/config/overlays/dev-image-config/kustomization.yaml
@@ -1,0 +1,5 @@
+bases:
+  - ../../default
+
+patches:
+  - inferenceservice_patch.yaml

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -158,6 +158,19 @@ make deploy-dev
 - **Note**: `deploy-dev` builds the image from your local code, publishes to `KO_DOCKER_REPO`
 and deploys the `kfserving-controller-manager` and `logger` with the image digest to your cluster for testing. Please also ensure you are logged in to `KO_DOCKER_REPO` from your client machine.
 
+There's also commands to build and deploy the image from your local code for the models, explainer and storage-initializer, you can choose to use one of below commands for your development purpose.
+```bash
+make deploy-dev-sklearn
+
+make deploy-dev-xgb
+
+make deploy-dev-pytorch
+
+make deploy-dev-alibi
+
+make deploy-dev-storageInitializer
+```
+- **Note**: These commands also publishes to `KO_DOCKER_REPO` with the image of version 'latest', and change the configmap of your cluster to point to the new built images. It's just for development and testing purpose so you need to do it one by one. In configmap, for predictors it will just keep the one in development, for exlainer and storage initializer will just change the item impacted and set all others images including the `kfserving-controller-manager` and `logger` to be default. 
 
 ### Smoke test after deployment
 ```bash

--- a/hack/alibi_patch_dev.sh
+++ b/hack/alibi_patch_dev.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+# Usage: image_patch_dev.sh [OVERLAY]
+set -u
+IMG=$1
+if [ -z ${IMG} ]; then exit; fi
+cat > config/overlays/dev-image-config/inferenceservice_patch.yaml << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inferenceservice-config
+  namespace: kfserving-system
+data:
+  explainers: |-
+    {
+        "alibi": {
+          "image" : "${IMG}",
+          "defaultImageVersion": "latest",
+          "allowedImageVersions": [
+               "latest"
+            ]
+        }
+    }
+EOF

--- a/hack/misc_patch_dev.sh
+++ b/hack/misc_patch_dev.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+set -u
+CONFIG_NAME=$1
+IMG=$2
+if [ -z ${IMG} -o -z ${CONFIG_NAME} ]; then exit; fi
+cat > config/overlays/dev-image-config/inferenceservice_patch.yaml << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inferenceservice-config
+  namespace: kfserving-system
+data:
+    ${CONFIG_NAME}: |-
+      {
+        "image" : "${IMG}"
+      }
+EOF

--- a/hack/model_server_patch_dev.sh
+++ b/hack/model_server_patch_dev.sh
@@ -1,0 +1,23 @@
+#!/bin/bash
+set -u
+CONFIG_NAME=$1
+IMG=$2
+if [ -z ${IMG} -o -z ${CONFIG_NAME} ]; then exit; fi
+cat > config/overlays/dev-image-config/inferenceservice_patch.yaml << EOF
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: inferenceservice-config
+  namespace: kfserving-system
+data:
+  predictors: |-
+    {
+      "${CONFIG_NAME}": {
+          "image" : "${IMG}",
+          "defaultImageVersion": "latest",
+          "allowedImageVersions": [
+               "latest"
+            ]
+      }
+    }
+EOF


### PR DESCRIPTION
**What this PR does / why we need it**:
In roadmap there's
```
* Automated Image Injection for Model Servers.
    * Implement new developer commands to deploy kfserving with local images.
```
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #590 

**Special notes for your reviewer**:
- Use KO_DOCKER_REPO to push the image
- Always use latest as the version
- Support only one model sever each time, after apply other model servers will be deleted from configmap.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/591)
<!-- Reviewable:end -->
