### PR TITLE
correct shasum algorithm

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -213,7 +213,7 @@ You can also use [Knative CLI (`knctl`)](https://github.com/cppforlife/knctl) to
 
 ```
 # compare checksum output to what's included in the release notes
-$ shasum -a 265 ~/Downloads/knctl-*
+$ shasum -a 256 ~/Downloads/knctl-*
 
 # move binary to your system’s /usr/local/bin -- might require root password
 $ mv ~/Downloads/knctl-* /usr/local/bin/knctl


### PR DESCRIPTION
Following instruction in https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#knative-cli-knctl to compare checksum output of knctl and get following error:

shasum -a 265 ./knctl-*
shasum: Unrecognized algorithm
Type shasum -h for help

265 is incorrect which cause this error.  Use this PR to correct this.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/593)
<!-- Reviewable:end -->
