### PR TITLE
Tensorrt  specified container port, which will not work with logger 

### DIFF
--- a/pkg/apis/serving/v1alpha2/framework_tensorrt.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorrt.go
@@ -53,11 +53,6 @@ func (t *TensorRTSpec) GetContainer(modelName string, config *InferenceServicesC
 			"--grpc-port=" + fmt.Sprint(TensorRTISGRPCPort),
 			"--http-port=" + fmt.Sprint(TensorRTISRestPort),
 		},
-		Ports: []v1.ContainerPort{
-			{
-				ContainerPort: TensorRTISRestPort,
-			},
-		},
 	}
 }
 

--- a/pkg/apis/serving/v1alpha2/framework_tensorrt_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorrt_test.go
@@ -67,11 +67,6 @@ func TestCreateModelServingContainer(t *testing.T) {
 			"--grpc-port=9000",
 			"--http-port=8080",
 		},
-		Ports: []v1.ContainerPort{
-			{
-				ContainerPort: 8080,
-			},
-		},
 	}
 
 	// Test Create with config


### PR DESCRIPTION
**What this PR does / why we need it**:
Container port specified with logger will not work. For built in frameworks it's always 8080 so we need not specify it. For custom spec the correct solution would be issue #594 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/595)
<!-- Reviewable:end -->
