### PR TITLE
Set queue proxy limit to 20% resource of main container

### DIFF
--- a/pkg/controller/inferenceservice/resources/knative/service.go
+++ b/pkg/controller/inferenceservice/resources/knative/service.go
@@ -42,9 +42,9 @@ var serviceAnnotationDisallowedList = []string{
 }
 
 const (
-	// Use a very small percentage here so the minimum bound defined at
+	// Set to 20% of the resource for main container, InferenceService defaults to 1CPU which is 200m for queue-proxy
 	// https://github.com/knative/serving/blob/1d263950f9f2fea85a4dd394948a029c328af9d9/pkg/reconciler/revision/resources/resourceboundary.go#L30
-	DefaultQueueSideCarResourcePercentage = "0.2"
+	DefaultQueueSideCarResourcePercentage = "20"
 )
 
 type ServiceBuilder struct {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently queue-proxy cpu limit is set too small(40m) and affects performance when doing load testing with sklearn example using following command. 
```
hey -z 300s -c 30 -m POST -host "sklearn-iris.default.example.com" -H "Content-Type: application/json" -D ./input.json "http://localhost:8080/v1/models/sklearn-iris:predict"
``` 
The average latency goes up to 100ms despite the actual prediction only takes 1ms.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes https://github.com/kubeflow/kfserving/issues/606

**Special notes for your reviewer**:

After the fix the latency is now average 5ms as expected.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/608)
<!-- Reviewable:end -->
