### PR TITLE
Initialize SecurityContext in injected containers and improve logging

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,9 +3,9 @@ FROM golang:1.10.3 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/kubeflow/kfserving
-COPY pkg/    pkg/
 COPY cmd/    cmd/
 COPY vendor/ vendor/
+COPY pkg/    pkg/
 # Build
 RUN if [ "$(uname -m)" = "ppc64le" ]; then \
         CGO_ENABLED=0 GOOS=linux GOARCH=ppc64le go build -a -o manager ./cmd/manager; \

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -71,6 +71,7 @@ var (
 	EnableWebhookNamespaceSelectorEnvName       = "ENABLE_WEBHOOK_NAMESPACE_SELECTOR"
 	EnableWebhookNamespaceSelectorEnvValue      = "enabled"
 	IsEnableWebhookNamespaceSelector            = isEnvVarMatched(EnableWebhookNamespaceSelectorEnvName, EnableWebhookNamespaceSelectorEnvValue)
+	PodMutatorWebhookName                       = KFServingName + "-pod-mutator-webhook"
 )
 
 // GPU Constants


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR implements 2 changes (please let me know if you want them as separate PRs)

1. Switch from `klog` to make logging consistent and add descriptive logging messages when mutator fails to make debugging of issues easier

If there is a problem with parsing the resources from the ConfigMap, it will produce error messages like

```
{"level":"error","ts":1576664278.7646105,"logger":"inferenceservice.kfserving-webhook-server.pod-mutator","msg":"Failed to mutate pod","name":"sklearn-iris-predictor-default-pvpmm","error":"Failed to parse resource configuration for \"storageInitializer\": \"quantities must match the regular expression '^([+-]?[0-9.]+)([eEinumkKMGTP]*[-+]?[0-9]*)$'\""
```

2. Initialize `securityContext` for injected containers. Current recommended solution is to initialize it with SC from already processed container in the pod. We can consider using `reinvocationPolicy` in the future (but neither OpenShift nor webhook builder recognizes the option yet)

I have this PR built and published as `quay.io/vpavlin/kfserving:openshift`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #611, Fixes #612

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

No changes to images

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/613)
<!-- Reviewable:end -->
