### PR TITLE
Fix broken link in KFServing Autoscaling sample and typo in PVC sample

### DIFF
--- a/docs/samples/autoscaling/README.md
+++ b/docs/samples/autoscaling/README.md
@@ -24,9 +24,8 @@
 ## Setup
 1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md#deploy-kfserving).
 2. Your cluster's Istio Ingress gateway must be network accessible.
-3. Make sure your istio network policy [allow Google Cloud Storage](https://knative.dev/docs/serving/outbound-network-access/)
-4. [Metrics installation](https://knative.dev/docs/serving/installing-logging-metrics-traces) for viewing scaling graphs (optional).
-5. The [hey](https://github.com/rakyll/hey) load generator installed (go get -u github.com/rakyll/hey).
+3. [Metrics installation](https://knative.dev/docs/serving/installing-logging-metrics-traces) for viewing scaling graphs (optional).
+4. The [hey](https://github.com/rakyll/hey) load generator installed (go get -u github.com/rakyll/hey).
 
 ## Load your InferenceService with target concurrency
 

--- a/docs/samples/pvc/README.md
+++ b/docs/samples/pvc/README.md
@@ -12,7 +12,7 @@ Following the mnist example [guide](https://github.com/kubeflow/examples/tree/ma
 
 ## Create the InferenceService
 
-Update the ${PVC_NAME} to the created PVC name in the `mnis-pvc.yaml` and apply:
+Update the ${PVC_NAME} to the created PVC name in the `mnist-pvc.yaml` and apply:
 ```bash
 kubectl apply -f mnist-pvc.yaml
 ```


### PR DESCRIPTION
1. broken link in Autoscaling sample https://github.com/kubeflow/kfserving/tree/master/docs/samples/autoscaling
Under "Setup" #3
...allow Google Cloud Storage (-> https://knative.dev/docs/serving/outbound-network-access/ -> 404)
This should be fixed  in https://github.com/kubeflow/kfserving/pull/599, but unfortunately, we have missed this one at that time.

2. typo in PVC sample
https://github.com/kubeflow/kfserving/tree/master/docs/samples/pvc
Under " Create the InferenceService"
Update the ${PVC_NAME} to the created PVC name in the **mnis-pvc.yaml** and apply:

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/617)
<!-- Reviewable:end -->
