### PR TITLE
Remove the "file://" storage type

### DIFF
--- a/pkg/apis/serving/v1alpha2/explainer_alibi.go
+++ b/pkg/apis/serving/v1alpha2/explainer_alibi.go
@@ -31,7 +31,7 @@ func (s *AlibiExplainerSpec) CreateExplainerContainer(modelName string, predicto
 	}
 
 	if s.StorageURI != "" {
-		args = append(args, "--storage_uri", constants.DefaultModelLocalMountPath)
+		args = append(args, "--storage_uri", getModelPath(s.StorageURI))
 	}
 
 	args = append(args, string(s.Type))

--- a/pkg/apis/serving/v1alpha2/framework_onnx.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx.go
@@ -44,7 +44,7 @@ func (s *ONNXSpec) GetContainer(modelName string, config *InferenceServicesConfi
 		Name:      constants.InferenceServiceContainerName,
 		Resources: s.Resources,
 		Args: []string{
-			"--model_path", constants.DefaultModelLocalMountPath + "/" + ONNXModelFileName,
+			"--model_path", getModelPath(s.StorageURI) + "/" + ONNXModelFileName,
 			"--http_port", ONNXServingRestPort,
 			"--grpc_port", ONNXServingGRPCPort,
 		},

--- a/pkg/apis/serving/v1alpha2/framework_pytorch.go
+++ b/pkg/apis/serving/v1alpha2/framework_pytorch.go
@@ -46,7 +46,7 @@ func (s *PyTorchSpec) GetContainer(modelName string, config *InferenceServicesCo
 		Args: []string{
 			"--model_name=" + modelName,
 			"--model_class_name=" + s.ModelClassName,
-			"--model_dir=" + constants.DefaultModelLocalMountPath,
+			"--model_dir=" + getModelPath(s.StorageURI),
 			"--http_port=" + constants.InferenceServiceDefaultHttpPort,
 		},
 	}

--- a/pkg/apis/serving/v1alpha2/framework_scikit.go
+++ b/pkg/apis/serving/v1alpha2/framework_scikit.go
@@ -44,7 +44,7 @@ func (s *SKLearnSpec) GetContainer(modelName string, config *InferenceServicesCo
 		Resources: s.Resources,
 		Args: []string{
 			"--model_name=" + modelName,
-			"--model_dir=" + constants.DefaultModelLocalMountPath,
+			"--model_dir=" + getModelPath(s.StorageURI),
 			"--http_port=" + constants.InferenceServiceDefaultHttpPort,
 		},
 	}

--- a/pkg/apis/serving/v1alpha2/framework_tensorflow.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorflow.go
@@ -51,7 +51,7 @@ func (t *TensorflowSpec) GetContainer(modelName string, config *InferenceService
 			"--port=" + TensorflowServingGRPCPort,
 			"--rest_api_port=" + TensorflowServingRestPort,
 			"--model_name=" + modelName,
-			"--model_base_path=" + constants.DefaultModelLocalMountPath,
+			"--model_base_path=" + getModelPath(t.StorageURI),
 		},
 	}
 }

--- a/pkg/apis/serving/v1alpha2/framework_tensorrt.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorrt.go
@@ -46,7 +46,7 @@ func (t *TensorRTSpec) GetContainer(modelName string, config *InferenceServicesC
 		Resources: t.Resources,
 		Args: []string{
 			"trtserver",
-			"--model-store=" + constants.DefaultModelLocalMountPath,
+			"--model-store=" + getModelPath(t.StorageURI),
 			"--allow-poll-model-repository=false",
 			"--allow-grpc=true",
 			"--allow-http=true",

--- a/pkg/apis/serving/v1alpha2/framework_xgboost.go
+++ b/pkg/apis/serving/v1alpha2/framework_xgboost.go
@@ -43,7 +43,7 @@ func (x *XGBoostSpec) GetContainer(modelName string, config *InferenceServicesCo
 		Resources: x.Resources,
 		Args: []string{
 			"--model_name=" + modelName,
-			"--model_dir=" + constants.DefaultModelLocalMountPath,
+			"--model_dir=" + getModelPath(x.StorageURI),
 			"--http_port=" + constants.InferenceServiceDefaultHttpPort,
 			"--nthread=" + strconv.Itoa(x.NThread),
 		},

--- a/pkg/apis/serving/v1alpha2/utils.go
+++ b/pkg/apis/serving/v1alpha2/utils.go
@@ -18,6 +18,7 @@ var (
 		v1.ResourceCPU:    resource.MustParse("1"),
 		v1.ResourceMemory: resource.MustParse("2Gi"),
 	}
+	localURIPrefix = "file://"
 )
 
 func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
@@ -65,6 +66,18 @@ func validateResourceRequirements(rr *v1.ResourceRequirements) error {
 		return fmt.Errorf("Unexpected error: %v", errs)
 	}
 	return nil
+}
+
+// get the path of the model.
+func getModelPath(storageURI string) string {
+	if !regexp.MustCompile("\\w+?://").MatchString(storageURI) {
+		return storageURI
+	}
+	if strings.HasPrefix(storageURI, localURIPrefix) {
+		return strings.TrimPrefix(storageURI, localURIPrefix)
+	}
+	// return default path to go through stroage initializer
+	return constants.DefaultModelLocalMountPath
 }
 
 func validateStorageURI(storageURI string) error {

--- a/python/kfserving/test/test_storage.py
+++ b/python/kfserving/test/test_storage.py
@@ -20,20 +20,6 @@ import unittest.mock as mock
 
 STORAGE_MODULE = 'kfserving.storage'
 
-
-def test_storage_local_path():
-    abs_path = 'file:///'
-    relative_path = 'file://.'
-    assert kfserving.Storage.download(abs_path) == abs_path.replace("file://", "", 1)
-    assert kfserving.Storage.download(relative_path) == relative_path.replace("file://", "", 1)
-
-
-def test_storage_local_path_exception():
-    not_exist_path = 'file:///some/random/path'
-    with pytest.raises(Exception):
-        kfserving.Storage.download(not_exist_path)
-
-
 def test_no_prefix_local_path():
     abs_path = '/'
     relative_path = '.'


### PR DESCRIPTION
**What this PR does / why we need it**:
1: Remove the "file://" storage type so that the local path is not confusing any more and only means pvc 
2: Refine the message so that if the pvc path does not exist it will report "Local path %s does not exist." rather than the misleading message of storage type.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #621 

**Special notes for your reviewer**:
The python changes will take effect next time when we release kfserving sdk and storage-initializer image.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/622)
<!-- Reviewable:end -->
