### PR TITLE
Use pip 19.3.1 instead of 20.x for installing xgboost wheel

### DIFF
--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -5,6 +5,8 @@ RUN apt-get update && apt-get install libgomp1
 COPY xgbserver xgbserver
 COPY kfserving kfserving
 
-RUN pip install --upgrade pip && pip install -e ./kfserving
+# pip 20.x breaks xgboost wheels https://github.com/dmlc/xgboost/issues/5221
+# RUN pip install --upgrade pip && pip install -e ./kfserving
+RUN pip install -e ./kfserving
 RUN pip install -e ./xgbserver
 ENTRYPOINT ["python", "-m", "xgbserver"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Recent pip release 20.x breaks a lot of the python wheels including xgboost (https://github.com/dmlc/xgboost/issues/5221), need to fallback to 19.x for now.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #639

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/641)
<!-- Reviewable:end -->
