### PR TITLE
Add storage uri for transformer

### DIFF
--- a/pkg/apis/serving/v1alpha2/transformer.go
+++ b/pkg/apis/serving/v1alpha2/transformer.go
@@ -17,8 +17,18 @@ const (
 // Transformer interface is implemented by all Transformers
 type Transformer interface {
 	GetContainerSpec() *v1.Container
+	GetStorageUri() string
 	ApplyDefaults(config *InferenceServicesConfig)
 	Validate(config *InferenceServicesConfig) error
+}
+
+// Returns a URI to the model. This URI is passed to the storage-initializer via the StorageInitializerSourceUriInternalAnnotationKey
+func (t *TransformerSpec) GetStorageUri() string {
+	transformer, err := getTransformer(t)
+	if err != nil {
+		return ""
+	}
+	return transformer.GetStorageUri()
 }
 
 // GetContainerSpec for the transformer

--- a/pkg/controller/inferenceservice/resources/knative/service.go
+++ b/pkg/controller/inferenceservice/resources/knative/service.go
@@ -196,6 +196,11 @@ func (c *ServiceBuilder) CreateTransformerService(name string, metadata metav1.O
 		return nil, err
 	}
 
+	// KNative does not support INIT containers or mounting, so we add annotations that trigger the
+	// StorageInitializer injector to mutate the underlying deployment to provision model data
+	if sourceURI := transformerSpec.GetStorageUri(); sourceURI != "" {
+		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = sourceURI
+	}
 	// Knative does not support multiple containers so we add an annotation that triggers pod
 	// mutator to add it
 	hasInferenceLogging := addLoggerAnnotations(transformerSpec.Logger, annotations)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add storage uri for transformer to inject the storage initializer, the use case here is to download a vocabulary file from cloud storage for bert tokenization.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/643)
<!-- Reviewable:end -->
