### PR TITLE
Enabled test_sklearn.py, etc. to run in an env without ext load balancer

### DIFF
--- a/test/e2e/common/utils.py
+++ b/test/e2e/common/utils.py
@@ -32,7 +32,10 @@ def predict(service_name, input_json):
     time.sleep(10)
     api_instance = client.CoreV1Api(client.ApiClient())
     service = api_instance.read_namespaced_service("istio-ingressgateway", "istio-system", exact='true')
-    cluster_ip = service.status.load_balancer.ingress[0].ip
+    if service.status.load_balancer.ingress is None:
+        cluster_ip = service.spec.cluster_ip
+    else:    
+        cluster_ip = service.status.load_balancer.ingress[0].ip
     host = urlparse(isvc['status']['url']).netloc
     url = "http://{}/v1/models/{}:predict".format(cluster_ip, service_name)
     headers = {'Host': host}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Currently, when running test_sklearn.py, test_tensorflow.py, test_xgboost.py, test_transformer.py in an environment without ext loadbalancer, it fails with :

_>       cluster_ip = service.status.load_balancer.ingress[0].ip
E       TypeError: 'NoneType' object is not subscriptable_

[As load balancer is not required](https://github.com/kubeflow/kfserving/issues/629#issuecomment-578401707), will use this PR to enable these to run in an environment w/o ext loadbalancer.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/649)
<!-- Reviewable:end -->
