### PR TITLE
Update quick_install.sh

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -1,3 +1,5 @@
+set -e 
+
 export ISTIO_VERSION=1.3.6
 export KNATIVE_VERSION=v0.12.0
 curl -L https://git.io/getLatestIstio | sh -


### PR DESCRIPTION
Add set -e to exit on first failure

**What this PR does / why we need it**:

Easier debugging on install / avoids potentially running commands out of order if early command fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/669)
<!-- Reviewable:end -->
