### PR TITLE
enhance creds if cannot get data secret data key from configmap

### DIFF
--- a/python/kfserving/kfserving/api/creds_utils.py
+++ b/python/kfserving/kfserving/api/creds_utils.py
@@ -231,9 +231,11 @@ def get_creds_name_from_config_map(creds):
         isvc_config_map = client.CoreV1Api().read_namespaced_config_map(
             constants.INFERENCESERVICE_CONFIG_MAP_NAME,
             constants.INFERENCESERVICE_SYSTEM_NAMESPACE)
-    except client.rest.ApiException as e:
-        raise RuntimeError(
-            "Exception when calling CoreV1Api->read_namespaced_config_map: %s\n" % e)
+    except client.rest.ApiException:
+        logging.warning('Cannot get configmap %s in namespace %s.',
+                        constants.INFERENCESERVICE_CONFIG_MAP_NAME,
+                        constants.INFERENCESERVICE_SYSTEM_NAMESPACE)
+        return None
 
     isvc_creds_str = isvc_config_map.data['credentials']
     isvc_creds_json = json.loads(isvc_creds_str)


### PR DESCRIPTION

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
For some case, user cannot get configmap from other namespace, if so we should allow user get the data key from constants.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #693 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/701)
<!-- Reviewable:end -->
