### PR TITLE
Updated S3 credential variable names to commonly used en var names

### DIFF
--- a/config/default/configmap/inferenceservice.yaml
+++ b/config/default/configmap/inferenceservice.yaml
@@ -18,7 +18,7 @@ data:
                "1.13.0",
                "1.13.0-gpu",
                "1.14.0",
-               "1.14.0-gpu"
+               "1.14.0-gpu"       
             ]
         },
         "onnx": {
@@ -86,8 +86,8 @@ data:
            "gcsCredentialFileName": "gcloud-application-credentials.json"
        },
        "s3": {
-           "s3AccessKeyIDName": "awsAccessKeyID",
-           "s3SecretAccessKeyName": "awsSecretAccessKey"
+           "s3AccessKeyIDName": "AWS_ACCESS_KEY_ID",
+           "s3SecretAccessKeyName": "AWS_SECRET_ACCESS_KEY"
        }
     }
   ingress: |-

--- a/python/kfserving/kfserving/constants/constants.py
+++ b/python/kfserving/kfserving/constants/constants.py
@@ -30,8 +30,8 @@ DEFAULT_SECRET_NAME = "kfserving-secret-"
 DEFAULT_SA_NAME = "kfserving-service-credentials"
 
 # S3 credentials constants
-S3_ACCESS_KEY_ID_DEFAULT_NAME = "awsAccessKeyID"
-S3_SECRET_ACCESS_KEY_DEFAULT_NAME = "awsSecretAccessKey"
+S3_ACCESS_KEY_ID_DEFAULT_NAME = "AWS_ACCESS_KEY_ID"
+S3_SECRET_ACCESS_KEY_DEFAULT_NAME = "AWS_SECRET_ACCESS_KEY"
 S3_DEFAULT_CREDS_FILE = '~/.aws/credentials'
 
 # GCS credentials constants


### PR DESCRIPTION
...and added support for TensorFlow Serving versions 2.0.0 and 2.1.0

**What this PR does / why we need it**:
This makes two small changes to the default config:
1. The default names used for the variables that store S3 credentials deviate from the convention that is normally followed, leading to confusion when interacting with KFServing. Currently it expects
awsAccessKeyID and awsSecretAccessKey. This PR changes that to AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #696 

**Special notes for your reviewer**:
Will probably need to update a few examples to reflect the change

**Release note**:
None

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/704)
<!-- Reviewable:end -->
