### PR TITLE
Update pvc example accordingly

### DIFF
--- a/docs/samples/pvc/README.md
+++ b/docs/samples/pvc/README.md
@@ -8,7 +8,7 @@ Refer to the [document](https://kubernetes.io/docs/concepts/storage/persistent-v
 
 ## Training model
 
-Following the mnist example [guide](https://github.com/kubeflow/examples/tree/master/mnist#local-storage) to train mnist model and store to PVC. In the example, the relative path of model will be `./export/` on the PVC.
+Follow the mnist example [guide](https://github.com/kubeflow/fairing/blob/master/examples/mnist/mnist_e2e_on_prem.ipynb) to train a mnist model and store it to PVC. The InferenceService is deployed in the notebook example by `Kubeflow Fairing` that uses `kfserving` SDK. If you want to apply the InferenceService via kubectl by using the YAML format as below, no need to run the deployment step in the notebook. In this example, the relative path of model will be `./export/` on the PVC.
 
 ## Create the InferenceService
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

In the kfserving PVC examples, we mentioned training model and store into PVC by following kubeflow/examples mnist example, recently the mnist example has been updated removed related parts. The PR is going to update readme to reasonable place for training and store model to PVC and then using KFServing to deploy InferenceService.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/713)
<!-- Reviewable:end -->
