### PR TITLE
Update example usage in README

### DIFF
--- a/docs/samples/pytorch/README.md
+++ b/docs/samples/pytorch/README.md
@@ -53,7 +53,7 @@ images, labels = dataiter.next()
 formData = {
     'instances': images[0:1].tolist()
 }
-res = requests.post('http://localhost:8080/models/pytorchmodel:predict', json=formData)
+res = requests.post('http://localhost:8080/v1/models/pytorchmodel:predict', json=formData)
 print(res)
 print(res.text)
 ```

--- a/docs/samples/xgboost/README.md
+++ b/docs/samples/xgboost/README.md
@@ -51,7 +51,7 @@ request = [X[0].tolist()]
 formData = {
     'instances': request
 }
-res = requests.post('http://localhost:8080/models/xgb:predict', json=formData)
+res = requests.post('http://localhost:8080/v1/models/xgb:predict', json=formData)
 print(res)
 print(res.text)
 ```


### PR DESCRIPTION
Endpoint in kfserver changed to include v1. Updated example to reflect the api change.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Example README for xgbserver and pytorch is outdated.
Updated to v1/ for the new endpoint. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

No

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/716)
<!-- Reviewable:end -->
