### PR TITLE
Fix check_sa_exists not checking all service accounts in python library

### DIFF
--- a/python/kfserving/kfserving/api/creds_utils.py
+++ b/python/kfserving/kfserving/api/creds_utils.py
@@ -179,9 +179,7 @@ def check_sa_exists(namespace, service_account):
     '''Check if the specified service account existing.'''
     sa_list = client.CoreV1Api().list_namespaced_service_account(namespace=namespace)
 
-    sa_name_list = []
-    for item in range(0, len(sa_list.items)-1):
-        sa_name_list.append(sa_list.items[item].metadata.name)
+    sa_name_list = [sa.metadata.name for sa in sa_list.items]
 
     if service_account in sa_name_list:
         return True

--- a/python/kfserving/test/test_cred_utils.py
+++ b/python/kfserving/test/test_cred_utils.py
@@ -1,0 +1,19 @@
+from unittest import mock
+
+from kubernetes.client import V1ServiceAccountList, V1ServiceAccount, V1ObjectMeta
+
+from kfserving.api.creds_utils import check_sa_exists
+
+
+@mock.patch('kubernetes.client.CoreV1Api.list_namespaced_service_account')
+def test_check_sa_exists(mock):
+    # Mock kubernetes client to return 2 accounts
+    accounts = V1ServiceAccountList(
+        items=[V1ServiceAccount(metadata=V1ObjectMeta(name=n)) for n in ['a', 'b']]
+    )
+    mock.return_value = accounts
+
+    # then a, b should exists, c should not exists
+    assert check_sa_exists('kubeflow', 'a') is True
+    assert check_sa_exists('kubeflow', 'b') is True
+    assert check_sa_exists('kubeflow', 'c') is False

--- a/python/kfserving/test/test_creds_utils.py
+++ b/python/kfserving/test/test_creds_utils.py
@@ -6,14 +6,14 @@ from kfserving.api.creds_utils import check_sa_exists
 
 
 @mock.patch('kubernetes.client.CoreV1Api.list_namespaced_service_account')
-def test_check_sa_exists(mock):
+def test_check_sa_exists(mock_client):
     # Mock kubernetes client to return 2 accounts
     accounts = V1ServiceAccountList(
         items=[V1ServiceAccount(metadata=V1ObjectMeta(name=n)) for n in ['a', 'b']]
     )
-    mock.return_value = accounts
+    mock_client.return_value = accounts
 
-    # then a, b should exists, c should not exists
+    # then a, b should exist, c should not
     assert check_sa_exists('kubeflow', 'a') is True
     assert check_sa_exists('kubeflow', 'b') is True
     assert check_sa_exists('kubeflow', 'c') is False


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
There is a minor bug in python library, the check_sa_exists function does not check the last service account that the api returns.
**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fixed bug in python library that was trying to recreate an existing service account
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/718)
<!-- Reviewable:end -->
