### PR TITLE
[Predict Protocol V2] Change type for GRPC string parameter to 'string'

### DIFF
--- a/docs/predict-api/v2/required_api.md
+++ b/docs/predict-api/v2/required_api.md
@@ -1,8 +1,8 @@
 # Predict Protocol - Version 2
 
 This document proposes a predict/inference API independent of any
-specific ML/DL framework and model server. The proposed APIs are 
-able to support both easy-to-use and high-performance use cases. 
+specific ML/DL framework and model server. The proposed APIs are
+able to support both easy-to-use and high-performance use cases.
 By implementing this protocol both
 inference clients and servers will increase their utility and
 portability by being able to operate seamlessly on platforms that have
@@ -718,7 +718,7 @@ server-specific parameters to provide non-standard capabilities.
         int64 int64_param = 2;
 
         // A string parameter value.
-        bytes string_param = 3;
+        string string_param = 3;
       }
     }
 


### PR DESCRIPTION
In parameters a string value should be an actual string, not a
collection of arbitrary bytes. So change the GRPC type from "bytes" ->
"string".

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/735)
<!-- Reviewable:end -->
