### PR TITLE
Configure memory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ KFSERVING_ENABLE_SELF_SIGNED_CA ?= false
 # CPU/Memory limits for controller-manager
 CPU_LIMIT ?= 100m
 MEMORY_LIMIT ?= 300Mi
-$(shell sed -i 's/cpu:.*/cpu: $(CPU_LIMIT)/' config/default/patch.yaml)
-$(shell sed -i 's/memory:.*/memory: $(MEMORY_LIMIT)/' config/default/patch.yaml)
+$(shell sed -i 's/cpu:.*/cpu: $(CPU_LIMIT)/' config/default/manager_resources_patch.yaml)
+$(shell sed -i 's/memory:.*/memory: $(MEMORY_LIMIT)/' config/default/manager_resources_patch.yaml)
 
 all: test manager logger
 

--- a/Makefile
+++ b/Makefile
@@ -12,6 +12,12 @@ STORAGE_INIT_IMG ?= storage-initializer:latest
 CRD_OPTIONS ?= "crd:trivialVersions=true"
 KFSERVING_ENABLE_SELF_SIGNED_CA ?= false
 
+# CPU/Memory limits for controller-manager
+CPU_LIMIT ?= 100m
+MEMORY_LIMIT ?= 300Mi
+$(shell sed -i '0,/cpu:.*/{s/cpu:.*/cpu: $(CPU_LIMIT)/}' config/default/patch.yaml)
+$(shell sed -i '0,/memory:.*/{s/memory:.*/memory: $(MEMORY_LIMIT)/}' config/default/patch.yaml)
+
 all: test manager logger
 
 # Run tests

--- a/Makefile
+++ b/Makefile
@@ -13,10 +13,10 @@ CRD_OPTIONS ?= "crd:trivialVersions=true"
 KFSERVING_ENABLE_SELF_SIGNED_CA ?= false
 
 # CPU/Memory limits for controller-manager
-CPU_LIMIT ?= 100m
-MEMORY_LIMIT ?= 300Mi
-$(shell perl -pi -e 's/cpu:.*/cpu: $(CPU_LIMIT)/' config/default/manager_resources_patch.yaml)
-$(shell perl -pi -e 's/memory:.*/memory: $(MEMORY_LIMIT)/' config/default/manager_resources_patch.yaml)
+KFSERVING_CONTROLLER_CPU_LIMIT ?= 100m
+KFSERVING_CONTROLLER_MEMORY_LIMIT ?= 300Mi
+$(shell perl -pi -e 's/cpu:.*/cpu: $(KFSERVING_CONTROLLER_CPU_LIMIT)/' config/default/manager_resources_patch.yaml)
+$(shell perl -pi -e 's/memory:.*/memory: $(KFSERVING_CONTROLLER_MEMORY_LIMIT)/' config/default/manager_resources_patch.yaml)
 
 all: test manager logger
 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ KFSERVING_ENABLE_SELF_SIGNED_CA ?= false
 # CPU/Memory limits for controller-manager
 CPU_LIMIT ?= 100m
 MEMORY_LIMIT ?= 300Mi
-$(shell sed -i '0,/cpu:.*/{s/cpu:.*/cpu: $(CPU_LIMIT)/}' config/default/patch.yaml)
-$(shell sed -i '0,/memory:.*/{s/memory:.*/memory: $(MEMORY_LIMIT)/}' config/default/patch.yaml)
+$(shell sed -i 's/cpu:.*/cpu: $(CPU_LIMIT)/' config/default/patch.yaml)
+$(shell sed -i 's/memory:.*/memory: $(MEMORY_LIMIT)/' config/default/patch.yaml)
 
 all: test manager logger
 

--- a/Makefile
+++ b/Makefile
@@ -15,8 +15,8 @@ KFSERVING_ENABLE_SELF_SIGNED_CA ?= false
 # CPU/Memory limits for controller-manager
 CPU_LIMIT ?= 100m
 MEMORY_LIMIT ?= 300Mi
-$(shell sed -i 's/cpu:.*/cpu: $(CPU_LIMIT)/' config/default/manager_resources_patch.yaml)
-$(shell sed -i 's/memory:.*/memory: $(MEMORY_LIMIT)/' config/default/manager_resources_patch.yaml)
+$(shell perl -pi -e 's/cpu:.*/cpu: $(CPU_LIMIT)/' config/default/manager_resources_patch.yaml)
+$(shell perl -pi -e 's/memory:.*/memory: $(MEMORY_LIMIT)/' config/default/manager_resources_patch.yaml)
 
 all: test manager logger
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -42,3 +42,4 @@ patchesStrategicMerge:
   # manager_prometheus_metrics_patch.yaml should be enabled.
 #- manager_prometheus_metrics_patch.yaml
 - webhookcainjection_patch.yaml
+- manager_resources_patch.yaml

--- a/config/default/manager_resources_patch.yaml
+++ b/config/default/manager_resources_patch.yaml
@@ -7,11 +7,7 @@ spec:
   template:
     spec:
       containers:
-      - command:
-        - /manager
-        image: github.com/kubeflow/kfserving/cmd/manager
-        imagePullPolicy: Always
-        name: manager
+      - name: manager
         resources:
           limits:
             cpu: 100m

--- a/config/default/manager_resources_patch.yaml
+++ b/config/default/manager_resources_patch.yaml
@@ -1,0 +1,21 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kfserving-controller-manager
+  namespace: kfserving-system
+spec:
+  template:
+    spec:
+      containers:
+      - command:
+        - /manager
+        image: github.com/kubeflow/kfserving/cmd/manager
+        imagePullPolicy: Always
+        name: manager
+        resources:
+          limits:
+            cpu: 100m
+            memory: 300Mi
+          requests:
+            cpu: 100m
+            memory: 200Mi

--- a/config/default/manager_resources_patch.yaml
+++ b/config/default/manager_resources_patch.yaml
@@ -16,6 +16,4 @@ spec:
           limits:
             cpu: 100m
             memory: 300Mi
-          requests:
-            cpu: 100m
-            memory: 200Mi
+            

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -150,10 +150,11 @@ After that you can run following command to deploy `KFServing`, you can skip abo
 make deploy
 ```
 
-Optionally, you can set CPU and memory limits when deploying `KFServing`.
+**Optional**: you can set CPU and memory limits when deploying `KFServing`.
 ```bash
 make deploy CPU_LIMIT=<cpu_limit> MEMORY_LIMIT=<memory_limit>
 ```
+
 or
 ```bash
 export CPU_LIMIT=<cpu_limit>

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -152,13 +152,13 @@ make deploy
 
 **Optional**: you can set CPU and memory limits when deploying `KFServing`.
 ```bash
-make deploy CPU_LIMIT=<cpu_limit> MEMORY_LIMIT=<memory_limit>
+make deploy KFSERVING_CONTROLLER_CPU_LIMIT=<cpu_limit> KFSERVING_CONTROLLER_MEMORY_LIMIT=<memory_limit>
 ```
 
 or
 ```bash
-export CPU_LIMIT=<cpu_limit>
-export MEMORY_LIMIT=<memory_limit>
+export KFSERVING_CONTROLLER_CPU_LIMIT=<cpu_limit>
+export KFSERVING_CONTROLLER_MEMORY_LIMIT=<memory_limit>
 make deploy
 ```
 

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -150,6 +150,17 @@ After that you can run following command to deploy `KFServing`, you can skip abo
 make deploy
 ```
 
+Optionally, you can set CPU and memory limits when deploying `KFServing`.
+```bash
+make deploy CPU_LIMIT=<cpu_limit> MEMORY_LIMIT=<memory_limit>
+```
+or
+```bash
+export CPU_LIMIT=<cpu_limit>
+export MEMORY_LIMIT=<memory_limit>
+make deploy
+```
+
 After above step you can see things running with:
 ```console
 $ kubectl get pods -n kfserving-system -l control-plane=kfserving-controller-manager


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Allow configurable CPU and memory limits for the controller manager before deploying.

This PR causes minimal change to the current deploy process with a Makefile. To use this new **optional** addition, simply set environment variables, `CPU_LIMIT` and `MEMORY_LIMIT`. Or run make targets with those variables specified, e.g.
```
make deploy CPU_LIMIT=800m MEMORY_LIMIT=2000Mi
```


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #681

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/kubeflow/kfserving/743)
<!-- Reviewable:end -->
