### PR TITLE
Allow kfserving-ingressgateway in custom sample notebook

### DIFF
--- a/docs/samples/custom/kfserving-custom-model/kfserving_sdk_custom_image.ipynb
+++ b/docs/samples/custom/kfserving-custom-model/kfserving_sdk_custom_image.ipynb
@@ -188,7 +188,10 @@
    "outputs": [],
    "source": [
     "%%bash --out CLUSTER_IP\n",
-    "echo \"$(kubectl -n istio-system get service istio-ingressgateway -o jsonpath='{.status.loadBalancer.ingress[0].ip}')\""
+    "# Use \"kfserving-ingressgateway\" as your `INGRESS_GATEWAY` if you are deploying KFServing\n",
+    "# as part of Kubeflow install, and not independently.\n",
+    "INGRESS_GATEWAY=\"istio-ingressgateway\"\n",
+    "echo \"$(kubectl -n istio-system get service $INGRESS_GATEWAY -o jsonpath='{.status.loadBalancer.ingress[0].ip}')\""
    ]
   },
   {


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds a note in the custom sample jupyter notebook about using `kfserving-ingressgateway` vs `istio-ingressgateway` when running a prediction. 

**Which issue(s) this PR fixes** 
Related to #748 
