### PR TITLE
Errors when running imagenet sample

### DIFF
--- a/docs/samples/explanation/alibi/imagenet/README.md
+++ b/docs/samples/explanation/alibi/imagenet/README.md
@@ -46,7 +46,7 @@ Set up some environment variables for the model name and cluster entrypoint. Use
 
 ```
 INGRESS_GATEWAY=istio-ingressgateway
-export CLUSTER_IP=$(kubectl -n istio-system get service INGRESS_GATEWAY -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+export CLUSTER_IP=$(kubectl -n istio-system get service $INGRESS_GATEWAY -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ```
 
 Test the predictor on an example image:

--- a/docs/samples/explanation/alibi/imagenet/imagenet.yaml
+++ b/docs/samples/explanation/alibi/imagenet/imagenet.yaml
@@ -2,7 +2,6 @@ apiVersion: "serving.kubeflow.org/v1alpha2"
 kind: "InferenceService"
 metadata:
   name: "imagenet"
-  namespace: default
 spec:
   default:
     predictor:


### PR DESCRIPTION
**What this PR does / why we need it**:
When trying to run the imagenet sample, I encountered the issues below which generate errors when executing the command `kubectl create -f imagenet.yaml` : 
- A typo in the documentation : INGRESS_GATEWAY is a variable 
- the inferenceservice must be deployed in the <user_namespace>  instead of  the default namespace 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
