### PR TITLE
fix missing patch file in config/overlays/development

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,7 @@ deploy-dev: manifests
 	kustomize edit remove resource certmanager/certificate.yaml; \
 	else kustomize edit add resource certmanager/certificate.yaml; fi;
 
+	cp config/default/manager_auth_proxy_patch.yaml config/overlays/development/
 	kustomize build config/overlays/development | kubectl apply -f -
 	if [ ${KFSERVING_ENABLE_SELF_SIGNED_CA} != false ]; then ./hack/self-signed-ca.sh; fi;
 

--- a/Makefile
+++ b/Makefile
@@ -53,7 +53,6 @@ deploy-dev: manifests
 	kustomize edit remove resource certmanager/certificate.yaml; \
 	else kustomize edit add resource certmanager/certificate.yaml; fi;
 
-	cp config/default/manager_auth_proxy_patch.yaml config/overlays/development/
 	kustomize build config/overlays/development | kubectl apply -f -
 	if [ ${KFSERVING_ENABLE_SELF_SIGNED_CA} != false ]; then ./hack/self-signed-ca.sh; fi;
 

--- a/config/overlays/development/kustomization.yaml
+++ b/config/overlays/development/kustomization.yaml
@@ -4,4 +4,3 @@ bases:
 patches:
   - configmap/inferenceservice_patch.yaml
   - manager_image_patch.yaml
-  - manager_auth_proxy_patch.yaml


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
`make deploy-dev` will fail because `config/overlays/development` is missing `manager_auth_proxy_patch.yaml`. Makefile should copy the patch file from `config/default`

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #779

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
