### PR TITLE
Use public slack link

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -44,6 +44,6 @@ The following should be viewed as Best Practices unless you know better ones (pl
 
 ## Get involved
 
-* [Slack](http://kubeflow.slack.com/)
+* [Slack](https://kubeflow.slack.com/join/shared_invite/zt-cpr020z4-PfcAue_2nw67~iIDy7maAQ)
 * [Twitter](http://twitter.com/kubeflow)
 * [Mailing List](https://groups.google.com/forum/#!forum/kubeflow-discuss)


### PR DESCRIPTION
Slack link in CONTRIBUTING.md only allows people with a `@google.com`, `@caicloud.io`, or `@microsoft.com` email address to sign up.

![image](https://user-images.githubusercontent.com/16768710/79585586-ff51e780-809d-11ea-8229-75ecca126b78.png)

Update the link with link from kubeflow.org which allows anyone to sign up.