### PR TITLE
Set ContainerConcurrency to Parallelism

### DIFF
--- a/pkg/controller/inferenceservice/resources/knative/service.go
+++ b/pkg/controller/inferenceservice/resources/knative/service.go
@@ -148,7 +148,7 @@ func (c *ServiceBuilder) CreatePredictorService(name string, metadata metav1.Obj
 	if isCanary {
 		endpoint = constants.InferenceServiceCanary
 	}
-
+	concurrency := int64(predictorSpec.Parallelism)
 	service := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -170,7 +170,8 @@ func (c *ServiceBuilder) CreatePredictorService(name string, metadata metav1.Obj
 					Spec: knservingv1.RevisionSpec{
 						// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 						// we may need to expose this field in future
-						TimeoutSeconds: &constants.DefaultPredictorTimeout,
+						TimeoutSeconds:       &constants.DefaultPredictorTimeout,
+						ContainerConcurrency: &concurrency,
 						PodSpec: v1.PodSpec{
 							ServiceAccountName: predictorSpec.ServiceAccountName,
 							Containers: []v1.Container{
@@ -219,6 +220,7 @@ func (c *ServiceBuilder) CreateTransformerService(name string, metadata metav1.O
 		endpoint = constants.InferenceServiceCanary
 	}
 
+	concurrency := int64(transformerSpec.Parallelism)
 	service := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -240,7 +242,8 @@ func (c *ServiceBuilder) CreateTransformerService(name string, metadata metav1.O
 					Spec: knservingv1.RevisionSpec{
 						// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 						// we may need to expose this field in future
-						TimeoutSeconds: &constants.DefaultTransformerTimeout,
+						TimeoutSeconds:       &constants.DefaultTransformerTimeout,
+						ContainerConcurrency: &concurrency,
 						PodSpec: v1.PodSpec{
 							ServiceAccountName: transformerSpec.ServiceAccountName,
 							Containers: []v1.Container{
@@ -285,6 +288,7 @@ func (c *ServiceBuilder) CreateExplainerService(name string, metadata metav1.Obj
 		addLoggerContainerPort(container)
 	}
 
+	concurrency := int64(explainerSpec.Parallelism)
 	service := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
@@ -306,6 +310,7 @@ func (c *ServiceBuilder) CreateExplainerService(name string, metadata metav1.Obj
 						// Defaulting here since this always shows a diff with nil vs 300s(knative default)
 						// we may need to expose this field in future
 						TimeoutSeconds: &constants.DefaultExplainerTimeout,
+						ContainerConcurrency: &concurrency,
 						PodSpec: v1.PodSpec{
 							ServiceAccountName: explainerSpec.ServiceAccountName,
 							Containers: []v1.Container{


### PR DESCRIPTION
**What this PR does / why we need it**:
The Parallelism field introduced with #637 sets the KNative autoscaler annotation. It does however not set the KNative `ContainerConcurrency` field, which means that the logic in `queue-proxy` is mostly bypassed. It never manages timeouts nor the connection queue. This has a number of drawbacks:

1) The serving instance will receive all connections directly, and will not handle timeouts and queueing as gracefully as one wants (or at all).
2) The load balancing function of KNative Activator does not work as intended. Instead of intelligently directing requests to Pods that have resources available, it will emit them randomly. See https://github.com/knative/serving/issues/7792#issuecomment-622285173 for more detail.

KNative Activator, when correctly set up with `ContainerConcurrency` provides a remarkable latency improvement especially for multi-second inferences.

**Before this PR (Activator disabled)**
![](https://user-images.githubusercontent.com/192223/80790363-a2a20280-8b5c-11ea-9859-61ee234a1420.png)

**With this PR (Activator enabled)**
![](https://user-images.githubusercontent.com/192223/80790364-a33a9900-8b5c-11ea-8e13-4770de03e3f3.png)

**Special notes for your reviewer**:

I do not see any reason to have a separate configuration knob for this. The implicit intention of the `parallelism` field lines up well with the `ContainerConcurrency` field. I consider this a bug fix more than a new feature. I assumed for a long time that `parallelism` would have configured all relevant settings in the managed KNative resource regarding concurrency.

**Release note**:
```release-note
KNative ContainerConcurrency is now set based on the parallelism defined for the component in InferenceService. This allows queueing to be offloaded from the serving container, and KNative Activator to be used for managing high load situations.
```