### PR TITLE
Disable retries in Istio VirtualService

### DIFF
--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -23,7 +23,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/istio"
 	"knative.dev/pkg/network"
 
 	"github.com/kubeflow/kfserving/pkg/controller/inferenceservice/resources/knative"
@@ -274,8 +273,8 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 						},
 					},
 					Retries: &istiov1alpha3.HTTPRetry{
-						Attempts:      3,
-						PerTryTimeout: istio.RetryTimeout,
+						Attempts:      0,
+						PerTryTimeout: nil,
 					},
 				},
 			},
@@ -761,8 +760,8 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 						},
 					},
 					Retries: &istiov1alpha3.HTTPRetry{
-						Attempts:      3,
-						PerTryTimeout: istio.RetryTimeout,
+						Attempts:      0,
+						PerTryTimeout: nil,
 					},
 				},
 			},
@@ -1415,8 +1414,8 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 						},
 					},
 					Retries: &istiov1alpha3.HTTPRetry{
-						Attempts:      3,
-						PerTryTimeout: istio.RetryTimeout,
+						Attempts:      0,
+						PerTryTimeout: nil,
 					},
 				},
 			},
@@ -1981,8 +1980,8 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 						},
 					},
 					Retries: &istiov1alpha3.HTTPRetry{
-						Attempts:      3,
-						PerTryTimeout: istio.RetryTimeout,
+						Attempts:      0,
+						PerTryTimeout: nil,
 					},
 				},
 				{
@@ -2035,8 +2034,8 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 						},
 					},
 					Retries: &istiov1alpha3.HTTPRetry{
-						Attempts:      3,
-						PerTryTimeout: istio.RetryTimeout,
+						Attempts:      0,
+						PerTryTimeout: nil,
 					},
 				},
 			},

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice.go
@@ -228,8 +228,8 @@ func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceSer
 			},
 			Route: explainRouteDestinations,
 			Retries: &istiov1alpha3.HTTPRetry{
-				Attempts:      3,
-				PerTryTimeout: RetryTimeout,
+				Attempts:      0,
+				PerTryTimeout: nil,
 			},
 		}
 		httpRoutes = append(httpRoutes, explainRoute)
@@ -257,8 +257,8 @@ func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceSer
 		},
 		Route: predictRouteDestinations,
 		Retries: &istiov1alpha3.HTTPRetry{
-			Attempts:      3,
-			PerTryTimeout: RetryTimeout,
+			Attempts:      0,
+			PerTryTimeout: nil,
 		},
 	}
 	httpRoutes = append(httpRoutes, predictRoute)

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
@@ -130,8 +130,8 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 						},
 						Retries: &istiov1alpha3.HTTPRetry{
-							Attempts:      3,
-							PerTryTimeout: RetryTimeout,
+							Attempts:      0,
+							PerTryTimeout: nil,
 						},
 					},
 				},
@@ -220,8 +220,8 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 						},
 						Retries: &istiov1alpha3.HTTPRetry{
-							Attempts:      3,
-							PerTryTimeout: RetryTimeout,
+							Attempts:      0,
+							PerTryTimeout: nil,
 						},
 					},
 				},
@@ -297,8 +297,8 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 						},
 						Retries: &istiov1alpha3.HTTPRetry{
-							Attempts:      3,
-							PerTryTimeout: RetryTimeout,
+							Attempts:      0,
+							PerTryTimeout: nil,
 						},
 					},
 				},
@@ -385,8 +385,8 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 						},
 						Retries: &istiov1alpha3.HTTPRetry{
-							Attempts:      3,
-							PerTryTimeout: RetryTimeout,
+							Attempts:      0,
+							PerTryTimeout: nil,
 						},
 					},
 				},
@@ -489,8 +489,8 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 						},
 						Retries: &istiov1alpha3.HTTPRetry{
-							Attempts:      3,
-							PerTryTimeout: RetryTimeout,
+							Attempts:      0,
+							PerTryTimeout: nil,
 						},
 					},
 					{
@@ -507,8 +507,8 @@ func TestCreateVirtualService(t *testing.T) {
 							},
 						},
 						Retries: &istiov1alpha3.HTTPRetry{
-							Attempts:      3,
-							PerTryTimeout: RetryTimeout,
+							Attempts:      0,
+							PerTryTimeout: nil,
 						},
 					},
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:
Currently, the retires in the VirtualService are setup to retry three times on all errors. KNative will also retry three times on all errors between a Transformer and Predictor. These settings, combined with default high timeouts can easily lead to a self-DDoS in an overload condition. See screenshot.

![Screen Shot 2020-04-30 at 16 35 04](https://user-images.githubusercontent.com/192223/81032658-aab0b980-8e5e-11ea-85f2-fd0afba4854c.png)

KNative has removed the retries in their VirtualServices: https://github.com/knative/serving/issues/6549#issuecomment-623800315

KFserving should do one of the following:
1) Disable retries completely (which is what this PR does)
2) Allow retries, but not on the 502/504 that are thrown on timeouts. Retrying on `connect-failure` should be safe.
3) Make the behavior configurable, as users might have different requirements for if they want KFServing to handle retrying or they already have a mechanism to do that higher up in the stack.


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```