### PR TITLE
cleanup xgboost sample

### DIFF
--- a/docs/samples/xgboost/README.md
+++ b/docs/samples/xgboost/README.md
@@ -6,7 +6,6 @@ To test the XGBoost Server, first we need to generate a simple XGBoost model usi
 import xgboost as xgb
 from sklearn.datasets import load_iris
 import os
-from xgbserver import XGBoostModel
 
 model_dir = "."
 BST_FILE = "model.bst"
@@ -38,13 +37,8 @@ We can also use the inbuilt sklearn support for sample datasets and do some simp
 ```python
 from sklearn.datasets import load_iris
 import requests
-from xgbserver import XGBoostModel
-
-model_dir = "."
-BST_FILE = "model.bst"
 
 iris = load_iris()
-y = iris['target']
 X = iris['data']
 
 request = [X[0].tolist()]


### PR DESCRIPTION
**What this PR does / why we need it**:
Cleanup xgboost sample instructions. Removal of `xgbserver` dependency to train&save a model or invoke the inference endpoint.

**Special notes for your reviewer**:

`xgbserver` is used by `inferenceservice` to serve a saved model, we should not expect data scientists to have it installed in their environment.