### PR TITLE
Upgrade test-worker to use new Python for testing

### DIFF
--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -79,6 +79,14 @@ kubectl create clusterrolebinding cluster-admin-binding \
   --clusterrole=cluster-admin \
   --user=$(gcloud config get-value core/account)
 
+# Install and Initialize Helm
+wget -O /tmp/get_helm.sh \
+    https://raw.githubusercontent.com/kubernetes/helm/master/scripts/get && \
+    chmod 700 /tmp/get_helm.sh && \
+    /tmp/get_helm.sh && \
+    rm /tmp/get_helm.sh
+helm init --client-only
+
 echo "Install istio ..."
 mkdir istio_tmp
 pushd istio_tmp >/dev/null
@@ -148,27 +156,12 @@ kubectl create namespace kfserving-ci-e2e-test
 
 echo "Istio, Knative and KFServing have been installed and started."
 
-echo "Upgrading Python to 3.6 to install KFServing SDK ..."
-apt-get update -yqq
-apt-get install -y build-essential checkinstall >/dev/null
-apt-get install -y libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev >/dev/null
-wget https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz >/dev/null
-tar xvf Python-3.6.9.tar.xz >/dev/null
-pushd Python-3.6.9  >/dev/null
-  ./configure >/dev/null
-  make altinstall >/dev/null
-popd
-
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
-update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 2
-# Work around the issue https://github.com/pypa/pip/issues/4924
-mv /usr/bin/lsb_release /usr/bin/lsb_release.bak
-
 echo "Installing KFServing Python SDK ..."
 python3 -m pip install --upgrade pip
 pip3 install --upgrade pytest pytest-xdist
 pip3 install --upgrade pytest-tornasync
 pip3 install urllib3==1.24.2
+pip3 install --upgrade setuptools
 pushd python/kfserving >/dev/null
     pip3 install -r requirements.txt
     python3 setup.py install --force

--- a/test/scripts/sdk-test.sh
+++ b/test/scripts/sdk-test.sh
@@ -20,22 +20,6 @@ set -o errexit
 set -o nounset
 set -o pipefail
 
-echo "Upgrading to python 3.6 for testing ..."
-apt-get update -yqq
-apt-get install -y build-essential checkinstall >/dev/null
-apt-get install -y libreadline-gplv2-dev libncursesw5-dev libssl-dev libsqlite3-dev tk-dev libgdbm-dev libc6-dev libbz2-dev >/dev/null
-wget https://www.python.org/ftp/python/3.6.9/Python-3.6.9.tar.xz >/dev/null
-tar xvf Python-3.6.9.tar.xz >/dev/null
-pushd Python-3.6.9  >/dev/null
-  ./configure >/dev/null
-  make altinstall >/dev/null
-popd
-
-update-alternatives --install /usr/bin/python3 python3 /usr/bin/python3.5 1
-update-alternatives --install /usr/bin/python3 python3 /usr/local/bin/python3.6 2
-# Work around the issue https://github.com/pypa/pip/issues/4924
-mv /usr/bin/lsb_release /usr/bin/lsb_release.bak
-
 echo "Installing requirement pacakges ..."
 python3 -m pip install --upgrade pip
 pip3 install --upgrade pytest

--- a/test/workflows/components/workflows.libsonnet
+++ b/test/workflows/components/workflows.libsonnet
@@ -49,7 +49,7 @@
       // The directory containing the kubeflow/kfserving repo
       local srcDir = srcRootDir + "/kubeflow/kfserving";
       local pylintSrcDir = srcDir + "/python";
-      local testWorkerImage = "gcr.io/kubeflow-ci/test-worker:v20191212-b0ec604-e3b0c4";
+      local testWorkerImage = "gcr.io/kubeflow-ci/test-worker-py3@sha256:b679ce5d7edbcc373fd7d28c57454f4f22ae987f200f601252b6dcca1fd8823b";
       local golangImage = "golang:1.9.4-stretch";
       // TODO(jose5918) Build our own helm image
       local pythonImage = "python:3.6-jessie";


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

I updated the test-worker image that's used Python 3.8, and removed some code that upgrading Python from 3.5 to 3.6 in test script. Thanks.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #813 


