### PR TITLE
Added prefixing http for the fix to work

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -208,8 +208,8 @@ The path or model %s does not exist." % (uri))
 
     @staticmethod
     def _create_minio_client():
-        # Remove possible http scheme for Minio
-        url = urlparse(os.getenv("AWS_ENDPOINT_URL", "s3.amazonaws.com"))
+        # Adding prefixing "http" in urlparse is necessary for it to be the netloc
+        url = urlparse(os.getenv("AWS_ENDPOINT_URL", "http://s3.amazonaws.com"))
         use_ssl = url.scheme == 'https' if url.scheme else bool(os.getenv("S3_USE_HTTPS", "true"))
         return Minio(url.netloc,
                      access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),


### PR DESCRIPTION
Fixes #632

# Context:
When urlparse is called on "s3.amazonaws.com", it's prased as "path" not as "netloc" resulting in an error where hostname is not provided. By adding the prefixed http, the url now stores the "s3.amazonaws.com" in its "netloc" instead of the "path" and works as expected.