### PR TITLE
make default req log url more flexible

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -72,7 +72,8 @@ data:
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
-        "cpuLimit": "1"
+        "cpuLimit": "1",
+        "defaultUrl": "http://default-broker"
     }
   batcher: |-
     {

--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -101,7 +101,8 @@ data:
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
-        "cpuLimit": "1"
+        "cpuLimit": "1",
+        "defaultUrl": "http://default-broker"
     }
   batcher: |-
     {

--- a/docs/samples/logger/basic/README.md
+++ b/docs/samples/logger/basic/README.md
@@ -40,6 +40,8 @@ spec:
         storageUri: "gs://kfserving-samples/models/sklearn/iris"
 ```
 
+(Here we set the url explicitly. otherwise it defaults to the namespace knative broker or the value of the controller's REQUEST_LOGGING_DEFAULT_ENDPOINT env var.)
+
 Let's apply this yaml:
 
 ```

--- a/docs/samples/logger/basic/README.md
+++ b/docs/samples/logger/basic/README.md
@@ -40,7 +40,7 @@ spec:
         storageUri: "gs://kfserving-samples/models/sklearn/iris"
 ```
 
-(Here we set the url explicitly. otherwise it defaults to the namespace knative broker or the value of the controller's REQUEST_LOGGING_DEFAULT_ENDPOINT env var.)
+(Here we set the url explicitly. otherwise it defaults to the namespace knative broker or the value of DefaultUrl in the logger section of the controller configmap.)
 
 Let's apply this yaml:
 

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -80,6 +80,11 @@ var (
 	PodMutatorWebhookName                  = KFServingName + "-pod-mutator-webhook"
 )
 
+// Request Logging Constants
+var (
+	LoggerDefaultUrl = getEnvOrDefault("REQUEST_LOGGING_DEFAULT_ENDPOINT", "default-broker")
+)
+
 // GPU Constants
 const (
 	NvidiaGPUResourceType = "nvidia.com/gpu"
@@ -261,10 +266,6 @@ func TransformerURL(metadata v1.ObjectMeta, isCanary bool) string {
 		serviceName = CanaryTransformerServiceName(metadata.Name)
 	}
 	return fmt.Sprintf("%s.%s", serviceName, metadata.Namespace)
-}
-
-func GetLoggerDefaultUrl(namespace string) string {
-	return "http://default-broker." + namespace
 }
 
 // Should only match 1..65535, but for simplicity it matches 0-99999.

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -82,7 +82,7 @@ var (
 
 // Request Logging Constants
 var (
-	LoggerDefaultUrl = getEnvOrDefault("REQUEST_LOGGING_DEFAULT_ENDPOINT", "default-broker")
+	LoggerDefaultUrl = getEnvOrDefault("REQUEST_LOGGING_DEFAULT_ENDPOINT", "http://default-broker")
 )
 
 // GPU Constants

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -80,11 +80,6 @@ var (
 	PodMutatorWebhookName                  = KFServingName + "-pod-mutator-webhook"
 )
 
-// Request Logging Constants
-var (
-	LoggerDefaultUrl = getEnvOrDefault("REQUEST_LOGGING_DEFAULT_ENDPOINT", "http://default-broker")
-)
-
 // GPU Constants
 const (
 	NvidiaGPUResourceType = "nvidia.com/gpu"

--- a/pkg/webhook/admission/pod/logger_injector.go
+++ b/pkg/webhook/admission/pod/logger_injector.go
@@ -28,6 +28,7 @@ type LoggerConfig struct {
 	CpuLimit      string `json:"cpuLimit"`
 	MemoryRequest string `json:"memoryRequest"`
 	MemoryLimit   string `json:"memoryLimit"`
+	DefaultUrl    string `json:"defaultUrl"`
 }
 
 type LoggerInjector struct {
@@ -68,7 +69,7 @@ func (il *LoggerInjector) InjectLogger(pod *v1.Pod) error {
 
 	logUrl, ok := pod.ObjectMeta.Annotations[constants.LoggerSinkUrlInternalAnnotationKey]
 	if !ok {
-		logUrl = constants.LoggerDefaultUrl
+		logUrl = il.config.DefaultUrl
 	}
 
 	logMode, ok := pod.ObjectMeta.Annotations[constants.LoggerModeInternalAnnotationKey]

--- a/pkg/webhook/admission/pod/logger_injector.go
+++ b/pkg/webhook/admission/pod/logger_injector.go
@@ -68,7 +68,7 @@ func (il *LoggerInjector) InjectLogger(pod *v1.Pod) error {
 
 	logUrl, ok := pod.ObjectMeta.Annotations[constants.LoggerSinkUrlInternalAnnotationKey]
 	if !ok {
-		logUrl = constants.GetLoggerDefaultUrl(pod.Namespace)
+		logUrl = constants.LoggerDefaultUrl
 	}
 
 	logMode, ok := pod.ObjectMeta.Annotations[constants.LoggerModeInternalAnnotationKey]


### PR DESCRIPTION
fixes https://github.com/kubeflow/kfserving/issues/836

Don't need to set namespace in the url as the short-form url 'default-broker' will find current namespace. To hit a specific namespace the env var could be set to 'default-broker.specificnamespace'

Parallel to https://github.com/SeldonIO/seldon-core/pull/1861