### PR TITLE
Update test KFServing installation documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,18 +79,20 @@ Please refer to our [troubleshooting section](docs/DEVELOPER_GUIDE.md#troublesho
 2) Wait all pods to be ready then launch KFServing `InferenceService`.(wait 1 min for everything to be ready and 40s to
 launch the `InferenceService`)
 ```bash
-kubectl apply -f docs/samples/sklearn/sklearn.yaml
+kubectl create namespace kfserving-test
+kubectl apply -f docs/samples/sklearn/sklearn.yaml -n kfserving-test
 ```
 3) Check KFServing `InferenceService` status.
 ```bash
-kubectl get inferenceservices sklearn-iris
+kubectl get inferenceservices sklearn-iris -n kfserving-test
 NAME           URL                                                              READY   DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
-sklearn-iris   http://sklearn-iris.default.example.com/v1/models/sklearn-iris   True    100                                109s
+sklearn-iris   http://sklearn-iris.kfserving-test.example.com/v1/models/sklearn-iris   True    100                                109s
 ```
 4) Curl the `InferenceService`
 ```bash
 kubectl port-forward --namespace istio-system $(kubectl get pod --namespace istio-system --selector="app=istio-ingressgateway" --output jsonpath='{.items[0].metadata.name}') 8080:80
-curl -v -H "Host: sklearn-iris.default.example.com" http://localhost:8080/v1/models/sklearn-iris:predict -d @./docs/samples/sklearn/iris-input.json
+SERVICE_HOSTNAME=$(kubectl get inferenceservice sklearn-iris -n kfserving-test -o jsonpath='{.status.url}' | cut -d "/" -f 3)
+curl -v -H "Host: ${SERVICE_HOSTNAME}" http://localhost:8080/v1/models/sklearn-iris:predict -d @./docs/samples/sklearn/iris-input.json
 ```
 ### Use KFServing SDK
 * Install the SDK


### PR DESCRIPTION
**What this PR does / why we need it**:
Update test KFServing installation documentation with the following changes:
1. Avoid using namespace with control panel label and use a dedicated namespace for inferenceservice test
2. Kubectl command to Fetch hostname to be used in the header curl since hostname consists namespace (sklearn-iris.default.example.com) it might be misleading to document it explicitly since users might use other namespaces than default

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
