### PR TITLE
add customized urls and sample

### DIFF
--- a/docs/samples/custom/customized-urls/Dockerfile
+++ b/docs/samples/custom/customized-urls/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.7-slim
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install production dependencies.
+RUN pip install Flask gunicorn
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app

--- a/docs/samples/custom/customized-urls/Readme.md
+++ b/docs/samples/custom/customized-urls/Readme.md
@@ -1,0 +1,91 @@
+# Customized URLs Sample
+
+In some situations, we want to deploy the inference service under `custom model`, and we just have the custom image but can not modify its server routes, this server may have one or more predict endpoints. In this case, we can add a custom predictor annotation to configure the routing.
+
+## A simple sample 
+
+* `app.py` is a simple flask server, it has tow endpoints: `customized_urls_test` and `hello_world`
+
+```yaml
+import os
+
+from flask import Flask
+
+app = Flask(__name__)
+@app.route('/customized/urls/demo/test/1')
+def customized_urls_test():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}. Func customized_urls_test is called!\n'.format(target)
+
+@app.route('/v1/models/customized-sample:predict')
+def hello_world():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}!\n'.format(target)
+
+if __name__ == "__main__":
+    app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))
+```
+
+* Build custom image.
+
+  Run the build command to build your image. Or you can use the the prebuild image:`iamlovingit/customized-urls:latest` 
+
+  ```shell
+  docker build -t ${your-dockerhub-id}/customized-urls:latest .
+  docker push ${your-dockerhub-id}/customized-urls:latest
+  ```
+
+* Config the Yaml
+
+  If you have more than one endpoints in your server, you can use `,` to split them.
+
+  ```yaml
+  apiVersion: serving.kubeflow.org/v1alpha2
+  kind: InferenceService
+  metadata:
+    labels:
+      controller-tools.k8s.io: "1.0"
+    name: customized-urls-sample
+    annotations:
+      serving.kubeflow.org/custom-predictor-urlpaths: "/customized/urls/demo/test/1,/v1/models/customized-sample:predict"
+  spec:
+    default:
+      predictor:
+        custom:
+          container:
+            image: iamlovingit/customized-urls:latest
+            container_port: 5000
+  ```
+
+* Deploy the  yaml and check the Inference service status
+
+  ```shel
+  kubectl apply -f customized-urls.yaml
+  kubectl get inferenceservice customized-urls-sample
+  ```
+
+  Expect output:
+
+  ```shell
+  NAME                     URL                                                                               
+                                                 READY   DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
+  customized-urls-sample   http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1,http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict   True    100                                17m
+  ```
+
+  There will display two URLs for this service.
+
+  ```
+  http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1
+  http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict
+  ```
+
+  Test the endpoints:
+
+  `curl http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1`
+
+  Expect Output: `Hello World. Func customized_urls_test is called!`
+  `curl http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict`
+  Expect Output: `Hello World!`
+
+  
+

--- a/docs/samples/custom/customized-urls/app.py
+++ b/docs/samples/custom/customized-urls/app.py
@@ -1,0 +1,17 @@
+import os
+
+from flask import Flask
+
+app = Flask(__name__)
+@app.route('/customized/urls/demo/test/1')
+def customized_urls_test():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}. Func customized_urls_test is called!\n'.format(target)
+
+@app.route('/v1/models/customized-sample:predict')
+def hello_world():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}!\n'.format(target)
+
+if __name__ == "__main__":
+    app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))

--- a/docs/samples/custom/customized-urls/customized-urls.yaml
+++ b/docs/samples/custom/customized-urls/customized-urls.yaml
@@ -1,0 +1,15 @@
+apiVersion: serving.kubeflow.org/v1alpha2
+kind: InferenceService
+metadata:
+  labels:
+    controller-tools.k8s.io: "1.0"
+  name: customized-urls-sample
+  annotations:
+    serving.kubeflow.org/custom-predictor-urlpaths: "/customized/urls/demo/test/1,/v1/models/customized-sample:predict"
+spec:
+  default:
+    predictor:
+      custom:
+        container:
+          image: iamlovingit/customized-urls:latest
+          container_port: 5000

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -46,6 +46,7 @@ var (
 // InferenceService Annotations
 var (
 	InferenceServiceGKEAcceleratorAnnotationKey = KFServingAPIGroupName + "/gke-accelerator"
+	InferenceServiceCustomizedPredictorPathAnnotationKey = KFServingAPIGroupName + "/custom-predictor-urlpaths"
 )
 
 // InferenceService Internal Annotations
@@ -113,6 +114,11 @@ const (
 const (
 	Predict InferenceServiceVerb = "predict"
 	Explain InferenceServiceVerb = "explain"
+)
+
+// Customized Predictor Url Path Separator
+const (
+        CustomPredictorUrlPathSeparator = ","
 )
 
 // InferenceService Endpoint Ports
@@ -215,6 +221,14 @@ func DefaultServiceName(name string, component InferenceServiceComponent) string
 
 func CanaryServiceName(name string, component InferenceServiceComponent) string {
 	return name + "-" + component.String() + "-" + InferenceServiceCanary
+}
+
+func GetServiceURL(urlpaths string, serviceHostname string) string {
+	urls := strings.Split(urlpaths, CustomPredictorUrlPathSeparator)
+        for i := 0; i < len(urls); i++ {
+                urls[i] = fmt.Sprintf("http://%s%s", serviceHostname, urls[i])
+        }   
+        return strings.Join(urls, CustomPredictorUrlPathSeparator)
 }
 
 func InferenceServicePrefix(name string) string {

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice.go
@@ -157,9 +157,75 @@ func (r *VirtualServiceBuilder) getExplainerRouteDestination(meta metav1.Object,
 	return nil, nil
 }
 
-func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceService) (*v1alpha3.VirtualService, *v1alpha2.VirtualServiceStatus) {
+func makeUriMatch(annotationFlag bool, s string) *istiov1alpha3.StringMatch{
+	if annotationFlag {
+		uri := istiov1alpha3.StringMatch{
+			MatchType: &istiov1alpha3.StringMatch_Prefix{
+				Prefix: s,
+			},
+		}
+		return &uri
+	} else {
+		uri := istiov1alpha3.StringMatch{
+			MatchType: &istiov1alpha3.StringMatch_Regex{
+				Regex: s,
+			},
+		}
+		return &uri
+	}
+}
 
+func makeHttpMatchRequest(annotationFlag bool, s string, serviceHostname string, ingressGateway string) (*istiov1alpha3.HTTPMatchRequest) {
+	uri := makeUriMatch(annotationFlag, s)
+	httpMatchRequest := &istiov1alpha3.HTTPMatchRequest{
+		Uri: uri,
+		Authority: &istiov1alpha3.StringMatch{
+			MatchType: &istiov1alpha3.StringMatch_Regex{
+				Regex: constants.HostRegExp(serviceHostname),
+			},
+		},
+		Gateways: []string{ingressGateway},
+	}
+	return httpMatchRequest
+}
+
+func makeHttpRoutes(isvc *v1alpha2.InferenceService, serviceHostname string, ingressGateway string, predictRouteDestinations []*istiov1alpha3.HTTPRouteDestination) ([]*istiov1alpha3.HTTPRoute) {
 	httpRoutes := []*istiov1alpha3.HTTPRoute{}
+	annotations := isvc.GetAnnotations()
+	if v, ok := annotations[constants.InferenceServiceCustomizedPredictorPathAnnotationKey]; ok {
+		urls := strings.Split(v, constants.CustomPredictorUrlPathSeparator)
+		for _, s := range urls {
+			predictRoute := &istiov1alpha3.HTTPRoute{
+				Match: []*istiov1alpha3.HTTPMatchRequest{
+					makeHttpMatchRequest(true, s, serviceHostname, ingressGateway),
+					makeHttpMatchRequest(true, s, constants.HostRegExp(network.GetServiceHostname(isvc.Name, isvc.Namespace)), constants.KnativeLocalGateway),
+				},
+				Route: predictRouteDestinations,
+				Retries: &istiov1alpha3.HTTPRetry{
+					Attempts:      3,
+					PerTryTimeout: RetryTimeout,
+				},
+			}
+			httpRoutes = append(httpRoutes, predictRoute)
+		}
+	} else {
+		predictRoute := &istiov1alpha3.HTTPRoute{
+			Match: []*istiov1alpha3.HTTPMatchRequest{
+				makeHttpMatchRequest(false, constants.PredictPrefix(), serviceHostname, ingressGateway),
+				makeHttpMatchRequest(false, constants.PredictPrefix(), constants.HostRegExp(network.GetServiceHostname(isvc.Name, isvc.Namespace)), constants.KnativeLocalGateway),
+			},
+			Route: predictRouteDestinations,
+			Retries: &istiov1alpha3.HTTPRetry{
+				Attempts:      3,
+				PerTryTimeout: RetryTimeout,
+			},
+		}
+		httpRoutes = append(httpRoutes, predictRoute)
+	}
+	return httpRoutes
+}
+
+func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceService) (*v1alpha3.VirtualService, *v1alpha2.VirtualServiceStatus) {
 	predictRouteDestinations := []*istiov1alpha3.HTTPRouteDestination{}
 	serviceHostname, _ := getServiceHostname(isvc)
 
@@ -179,42 +245,7 @@ func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceSer
 		}
 	}
 	// prepare the predict route
-	predictRoute := &istiov1alpha3.HTTPRoute{
-		Match: []*istiov1alpha3.HTTPMatchRequest{
-			{
-				Uri: &istiov1alpha3.StringMatch{
-					MatchType: &istiov1alpha3.StringMatch_Regex{
-						Regex: constants.PredictPrefix(),
-					},
-				},
-				Authority: &istiov1alpha3.StringMatch{
-					MatchType: &istiov1alpha3.StringMatch_Regex{
-						Regex: constants.HostRegExp(serviceHostname),
-					},
-				},
-				Gateways: []string{r.ingressConfig.IngressGateway},
-			},
-			{
-				Uri: &istiov1alpha3.StringMatch{
-					MatchType: &istiov1alpha3.StringMatch_Regex{
-						Regex: constants.PredictPrefix(),
-					},
-				},
-				Authority: &istiov1alpha3.StringMatch{
-					MatchType: &istiov1alpha3.StringMatch_Regex{
-						Regex: constants.HostRegExp(network.GetServiceHostname(isvc.Name, isvc.Namespace)),
-					},
-				},
-				Gateways: []string{constants.KnativeLocalGateway},
-			},
-		},
-		Route: predictRouteDestinations,
-		Retries: &istiov1alpha3.HTTPRetry{
-			Attempts:      3,
-			PerTryTimeout: RetryTimeout,
-		},
-	}
-	httpRoutes = append(httpRoutes, predictRoute)
+	httpRoutes := makeHttpRoutes(isvc, serviceHostname, r.ingressConfig.IngressGateway, predictRouteDestinations)
 
 	// optionally add the explain route
 	explainRouteDestinations := []*istiov1alpha3.HTTPRouteDestination{}
@@ -271,8 +302,17 @@ func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceSer
 		}
 		httpRoutes = append(httpRoutes, explainRoute)
 	}
+
 	// extract the virtual service hostname from the predictor hostname
-	serviceURL := fmt.Sprintf("%s://%s%s", "http", serviceHostname, constants.InferenceServicePrefix(isvc.Name))
+	annotations := isvc.GetAnnotations()
+	var paths string
+	var serviceURL string
+	if v, ok := annotations[constants.InferenceServiceCustomizedPredictorPathAnnotationKey]; ok {
+		paths = v
+	} else {
+		paths = constants.InferenceServicePrefix(isvc.Name)
+	}
+	serviceURL = constants.GetServiceURL(paths, serviceHostname)
 
 	vs := v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
@@ -76,7 +76,9 @@ func TestCreateVirtualService(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      serviceName,
 			Namespace: namespace,
-			Annotation: {constants.InferenceServiceCustomizedPredictorPathAnnotationKey: URLPaths},
+			Annotations: map[string]string{
+				constants.InferenceServiceCustomizedPredictorPathAnnotationKey: URLPaths,
+			},
 		},
 	}
 	predictDestination := []*istiov1alpha3.HTTPRouteDestination{
@@ -585,7 +587,9 @@ func TestCreateVirtualService(t *testing.T) {
 			metadata = metav1.ObjectMeta{
 				Name:      serviceName,
 				Namespace: namespace,
-				Annotation: {constants.InferenceServiceCustomizedPredictorPathAnnotationKey: URLPaths},
+				Annotations: map[string]string{
+					constants.InferenceServiceCustomizedPredictorPathAnnotationKey: URLPaths,
+				},
 			}
 		} else {
 			metadata = metav1.ObjectMeta{

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
@@ -105,7 +105,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedService: nil,
 	}, {
 		name:            "empty status should not be ready",
-		defaultStatus:   &v1alpha2.ComponentStatusMap{},
+		defaultStatus:   nil,
 		canaryStatus:    nil,
 		expectedStatus:  createFailedStatus(PredictorStatusUnknown, PredictorMissingMessage),
 		expectedService: nil,


### PR DESCRIPTION
Fixes #733

# Customized URLs Sample

In some situations, we want to deploy the inference service under `custom model`, and we just have the custom image, can not modify it's server route, this server maybe have one more endpoints. For these situations, we can use adding an annotation to solve this problem.

## A simple sample 

* `app.py` is a simple flask server, it has tow endpoints: `customized_urls_test` and `hello_world`

```yaml
import os

from flask import Flask

app = Flask(__name__)
@app.route('/customized/urls/demo/test/1')
def customized_urls_test():
    target = os.environ.get('TARGET', 'World')
    return 'Hello {}. Func customized_urls_test is called!\n'.format(target)

@app.route('/v1/models/customized-sample:predict')
def hello_world():
    target = os.environ.get('TARGET', 'World')
    return 'Hello {}!\n'.format(target)

if __name__ == "__main__":
    app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))
```

* Build custom image.

  Run the build command to build your image. Or you can use the the prebuild image:`iamlovingit/customized-urls:latest` 

  ```shell
  docker build -t ${your-dockerhub-id}/customized-urls:latest .
  docker push ${your-dockerhub-id}/customized-urls:latest
  ```

* Config the Yaml

  If you have more than one endpoints in your server, you can use `,` to split them.

  ```yaml
  apiVersion: serving.kubeflow.org/v1alpha2
  kind: InferenceService
  metadata:
    labels:
      controller-tools.k8s.io: "1.0"
    name: customized-urls-sample
    annotations:
      custom.urls: "/customized/urls/demo/test/1,/v1/models/customized-sample:predict"
  spec:
    default:
      predictor:
        custom:
          container:
            image: iamlovingit/customized-urls:latest
            container_port: 5000
  ```

* Deploy the  yaml and check the Inference service status

  ```shel
  kubectl apply -f customized-urls.yaml
  kubectl get inferenceservice customized-urls-sample
  ```

  Expect output:

  ```shell
  NAME                     URL                                                                               
                                                 READY   DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
  customized-urls-sample   http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1,http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict   True    100                                17m
  ```

  There will display two URLs for this service.

  ```
  http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1
  http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict
  ```

  Test the endpoints:

  `curl http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1`

  Expect Output: `Hello World. Func customized_urls_test is called!`
  `curl http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict`
  Expect Output: `Hello World!`

  