### PR TITLE
Alibi explainer fix

### DIFF
--- a/python/alibiexplainer.Dockerfile
+++ b/python/alibiexplainer.Dockerfile
@@ -5,8 +5,5 @@ COPY kfserving kfserving
 COPY third_party third_party
 
 RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN git clone https://github.com/SeldonIO/alibi.git && \
-    cd alibi && \
-    pip install .
 RUN pip install -e ./alibiexplainer
 ENTRYPOINT ["python", "-m", "alibiexplainer"]

--- a/python/alibiexplainer/setup.py
+++ b/python/alibiexplainer/setup.py
@@ -33,7 +33,7 @@ setup(
     packages=find_packages("alibiexplainer"),
     install_requires=[
         "kfserving>=0.3.0",
-        "alibi>=0.3",
+        "alibi==0.3.2",
         "scikit-learn>=0.20.3",
         "argparse>=1.4.0",
         "requests>=2.22.0",

--- a/python/pytorch.Dockerfile
+++ b/python/pytorch.Dockerfile
@@ -11,7 +11,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          libpng-dev && \
      rm -rf /var/lib/apt/lists/*
 
-RUN curl -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh  && \
+RUN curl -L -o ~/miniconda.sh -O  https://repo.continuum.io/miniconda/Miniconda3-4.2.12-Linux-x86_64.sh  && \
      chmod +x ~/miniconda.sh && \
      ~/miniconda.sh -b -p /opt/conda && \
      rm ~/miniconda.sh && \


### PR DESCRIPTION
Fixes #859

This is a fix to v0.3.0 branch as the original code built from master alibi repo. When we did v0.3.0 image build in March this year the image created for alibiexplainer was not compatible.

We could retag a new image for alibiexplainer 0.3.0 from this fix to branch?