### PR TITLE
Record Events when InferenceService goes in and out of readiness

### DIFF
--- a/pkg/controller/inferenceservice/controller.go
+++ b/pkg/controller/inferenceservice/controller.go
@@ -145,7 +145,7 @@ func (r *ReconcileService) Reconcile(request reconcile.Request) (reconcile.Resul
 	}
 
 	reconcilers := []Reconciler{
-		knative.NewServiceReconciler(r.Client, r.scheme, configMap),
+		knative.NewServiceReconciler(r.Client, r.scheme, r.Recorder, configMap),
 		istio.NewVirtualServiceReconciler(r.Client, r.scheme, configMap),
 	}
 

--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -357,6 +357,37 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 		}
 		return fmt.Errorf("Test %q failed: events [%v] did not contain ready", serviceName, events.Items)
 	}, timeout).Should(gomega.Succeed())
+	// Testing that when service fails, that an event is thrown
+	failingService := &knservingv1.Service{}
+	g.Eventually(func() error { return c.Get(context.TODO(), predictorService, failingService) }, timeout).
+		Should(gomega.Succeed())
+	failingService.Status.LatestCreatedRevisionName = "revision-v2"
+	failingService.Status.LatestReadyRevisionName = "revision-v2"
+	failingService.Status.URL = nil
+	failingService.Status.Conditions = duckv1.Conditions{
+		{
+			Type:   knservingv1.ServiceConditionReady,
+			Status: "False",
+		},
+	}
+	g.Expect(c.Status().Update(context.TODO(), failingService)).NotTo(gomega.HaveOccurred())
+	g.Eventually(requests, timeout).Should(gomega.Receive(gomega.Equal(expectedRequest)))
+	g.Eventually(func() error {
+		events := &v1.EventList{}
+		if err := c.List(context.TODO(), events); err != nil {
+			return fmt.Errorf("Test %q failed: returned error: %v", serviceName, err)
+		}
+		if len(events.Items) == 0 {
+			return fmt.Errorf("Test %q failed: no events were created", serviceName)
+		}
+		for _, event := range events.Items {
+			if event.Reason == string(kfserving.InferenceServiceNotReadyState) &&
+				event.Type == v1.EventTypeWarning {
+				return nil
+			}
+		}
+		return fmt.Errorf("Test %q failed: events [%v] did not contain warning", serviceName, events.Items)
+	}, timeout).Should(gomega.Succeed())
 }
 
 func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {

--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -125,13 +125,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 	mgr, err := manager.New(cfg, manager.Options{MetricsBindAddress: "0"})
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	c = mgr.GetClient()
-	recorder := mgr.GetEventRecorderFor(fmt.Sprintf("InferenceReconciler"))
-	controller := &ReconcileService{
-		Client:   mgr.GetClient(),
-		scheme:   mgr.GetScheme(),
-		Recorder: recorder,
-	}
-	recFn, requests := SetupTestReconcile(controller)
+	recFn, requests := SetupTestReconcile(newReconciler(mgr))
 	g.Expect(add(mgr, recFn)).NotTo(gomega.HaveOccurred())
 
 	stopMgr, mgrStopped := StartTestManager(mgr, g)

--- a/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
+++ b/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
@@ -53,6 +53,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	stopMgr, mgrStopped := testutils.StartTestManager(mgr, g)
 	c := mgr.GetClient()
+	recorder := mgr.GetEventRecorderFor(fmt.Sprintf("ServiceReconciler"))
 
 	defer func() {
 		close(stopMgr)
@@ -78,7 +79,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
         }`,
 	}
 
-	serviceReconciler := NewServiceReconciler(c, mgr.GetScheme(), &v1.ConfigMap{
+	serviceReconciler := NewServiceReconciler(c, mgr.GetScheme(), recorder, &v1.ConfigMap{
 		Data: configs,
 	})
 	scenarios := map[string]struct {

--- a/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
+++ b/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
@@ -53,7 +53,7 @@ func TestKnativeServiceReconcile(t *testing.T) {
 	g.Expect(err).NotTo(gomega.HaveOccurred())
 	stopMgr, mgrStopped := testutils.StartTestManager(mgr, g)
 	c := mgr.GetClient()
-	recorder := mgr.GetEventRecorderFor(fmt.Sprintf("ServiceReconciler"))
+	recorder := mgr.GetEventRecorderFor("InferenceServiceEventRecorder")
 
 	defer func() {
 		close(stopMgr)


### PR DESCRIPTION
**What this PR does / why we need it**:

Adds logic to record events when the `InferenceService` moves from 
`non-Ready --> Ready`
and 
`Ready --> non-Ready`


**Which issue(s) this PR fixes**:
Fixes #881 

**Special notes for your reviewer**:

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Record Events when InferenceService goes in and out of readiness
```
