### PR TITLE
Fix knative install issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Coverage Status](https://coveralls.io/repos/github/kubeflow/kfserving/badge.svg?branch=master)](https://coveralls.io/github/kubeflow/kfserving?branch=master)
+[![Go Report Card](https://goreportcard.com/badge/github.com/kubeflow/kfserving)](https://goreportcard.com/report/github.com/kubeflow/kfserving)
 # KFServing
 KFServing provides a Kubernetes [Custom Resource Definition](https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/) for serving machine learning (ML) models on arbitrary frameworks. It aims to solve production model serving use cases by providing performant, high abstraction interfaces for common ML frameworks like Tensorflow, XGBoost, ScikitLearn, PyTorch, and ONNX.
 

--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -68,7 +68,10 @@ helm template --namespace=istio-system \
 kubectl apply -f istio-local-gateway.yaml
 
 # Install Knative
-kubectl apply --selector knative.dev/crd-install=true \
+kubectl apply --wait=true --selector knative.dev/crd-install=true \
+--filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml \
+||
+kubectl apply --wait=true --selector knative.dev/crd-install=true \
 --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml \
 
 kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml \

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -143,8 +143,10 @@ echo "Waiting for istio started ..."
 waiting_pod_running "istio-system"
 
 echo "Installing knative serving ..."
-kubectl apply --selector knative.dev/crd-install=true --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
-sleep 2
+kubectl apply --wait=true --selector knative.dev/crd-install=true --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
+||
+kubectl apply --wait=true --selector knative.dev/crd-install=true --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
+
 kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
 
 echo "Waiting for knative started ..."


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix knative install issue in CI
```
error: unable to recognize "https://github.com/knative/serving/releases/download/v0.15.0/serving.yaml": no matches for kind "Image" in version "caching.internal.knative.dev/v1alpha1"
```
seems like hitting this issue https://github.com/knative/serving/issues/5722 and walkaround is to run twice..

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
