### PR TITLE
Enhance SDK watch API to avoid traceback

### DIFF
--- a/python/kfserving/kfserving/api/kf_serving_watch.py
+++ b/python/kfserving/kfserving/api/kf_serving_watch.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import time
 from kubernetes import client
 from kubernetes import watch as k8s_watch
 from table_logger import TableLogger
@@ -45,14 +46,20 @@ def watch(name=None, namespace=None, timeout_seconds=600):
         if name and name != isvc_name:
             continue
         else:
-            url = isvc['status'].get('url', '')
-            default_traffic = isvc['status'].get('traffic', '')
-            canary_traffic = isvc['status'].get('canaryTraffic', '')
-            status = 'Unknown'
-            for condition in isvc['status'].get('conditions', {}):
-                if condition.get('type', '') == 'Ready':
-                    status = condition.get('status', 'Unknown')
-            tbl(isvc_name, status, default_traffic, canary_traffic, url)
+            if isvc.get('status', ''):
+                url = isvc['status'].get('url', '')
+                default_traffic = isvc['status'].get('traffic', '')
+                canary_traffic = isvc['status'].get('canaryTraffic', '')
+                status = 'Unknown'
+                for condition in isvc['status'].get('conditions', {}):
+                    if condition.get('type', '') == 'Ready':
+                        status = condition.get('status', 'Unknown')
+                tbl(isvc_name, status, default_traffic, canary_traffic, url)
+            else:
+                tbl(isvc_name, 'Unknown', '', '', '')
+                # Sleep 2 to avoid status section is not generated within a very short time.
+                time.sleep(2)
+                continue
 
             if name == isvc_name and status == 'True':
                 break


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Sometimes, there is a traceback while watching a created inferenceservice. see #884 for details, the PR is going to enhance watch API to avoid that, even if that cannot be 100% reproduced.

**Which issue(s) this PR fixes**:
Fixes #884 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
