### PR TITLE
Move KFServing to minimally require kubernetes 1.15

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,7 +42,7 @@ deploy: manifests
 	kustomize edit remove resource certmanager/certificate.yaml; \
 	else kustomize edit add resource certmanager/certificate.yaml; fi;
 
-	kustomize build config/default | kubectl apply -f -
+	kustomize build config/default | kubectl apply --validate=false -f -
 	if [ ${KFSERVING_ENABLE_SELF_SIGNED_CA} != false ]; then ./hack/self-signed-ca.sh; fi;
 
 deploy-dev: manifests
@@ -52,7 +52,7 @@ deploy-dev: manifests
 	kustomize edit remove resource certmanager/certificate.yaml; \
 	else kustomize edit add resource certmanager/certificate.yaml; fi;
 
-	kustomize build config/overlays/development | kubectl apply -f -
+	kustomize build config/overlays/development | kubectl apply --validate=false -f -
 	if [ ${KFSERVING_ENABLE_SELF_SIGNED_CA} != false ]; then ./hack/self-signed-ca.sh; fi;
 
 deploy-dev-sklearn: docker-push-sklearn

--- a/config/default/manager/manager.yaml
+++ b/config/default/manager/manager.yaml
@@ -21,7 +21,7 @@ spec:
       containers:
       - command:
         - /manager
-        image: github.com/kubeflow/kfserving/cmd/manager
+        image: ko://github.com/kubeflow/kfserving/cmd/manager
         imagePullPolicy: Always
         name: manager
         env:

--- a/config/default/webhook/manifests.yaml
+++ b/config/default/webhook/manifests.yaml
@@ -31,10 +31,10 @@ webhooks:
         path: /mutate-pods
     failurePolicy: Fail
     name: inferenceservice.kfserving-webhook-server.pod-mutator
-    namespaceSelector:
+    objectSelector:
       matchExpressions:
-        - key: control-plane
-          operator: DoesNotExist
+        - key: serving.kubeflow.org/inferenceservice
+          operator: Exists
     rules:
       - apiGroups:
           - ""

--- a/config/overlays/development/configmap/ko_resolve_logger
+++ b/config/overlays/development/configmap/ko_resolve_logger
@@ -1,1 +1,1 @@
-image: github.com/kubeflow/kfserving/cmd/logger
+image: ko://github.com/kubeflow/kfserving/cmd/logger

--- a/go.mod
+++ b/go.mod
@@ -31,10 +31,7 @@ require (
 	golang.org/x/net v0.0.0-20200226121028-0de0cce0169b
 	golang.org/x/sys v0.0.0-20191026070338-33540a1f6037 // indirect
 	golang.org/x/time v0.0.0-20191023065245-6d3f0bb11be5 // indirect
-	golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 // indirect
-	google.golang.org/api v0.15.0 // indirect
 	google.golang.org/genproto v0.0.0-20200108215221-bd8f9a0ef82f // indirect
-	google.golang.org/grpc v1.26.0 // indirect
 	istio.io/api v0.0.0-20191115173247-e1a1952e5b81
 	istio.io/client-go v0.0.0-20191120150049-26c62a04cdbc
 	istio.io/gogo-genproto v0.0.0-20191029161641-f7d19ec0141d // indirect

--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -68,10 +68,8 @@ helm template --namespace=istio-system \
 kubectl apply -f istio-local-gateway.yaml
 
 # Install Knative
-kubectl apply --selector knative.dev/crd-install=true \
---filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml \
-
-kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml \
+kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
+kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
 
 cd ..
 # Install KFServing

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -143,9 +143,9 @@ echo "Waiting for istio started ..."
 waiting_pod_running "istio-system"
 
 echo "Installing knative serving ..."
-kubectl apply --selector knative.dev/crd-install=true --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
-sleep 2
-kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving.yaml
+kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
+kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-core.yaml
+kubectl apply --filename https://github.com/knative/net-istio/releases/download/${KNATIVE_VERSION}/release.yaml
 
 echo "Waiting for knative started ..."
 waiting_pod_running "knative-serving"


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #891 

**Special notes for your reviewer**:

a couple of markers are generated by `controller-gen` but it is only supported by kubernetes 1.16 and 1.17, so we need to add `--validate=false` for installing KFServing on kubernetes 1.15.
https://kubernetes.io/docs/reference/using-api/api-concepts/#merge-strategy

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
KFServing now minimally requires kubernetes 1.15 to use the object selector for pod mutator
```
