### PR TITLE
Fix Test KFServing Installation in the main README

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,15 +99,15 @@ sklearn-iris   http://sklearn-iris.kfserving-test.example.com/v1/models/sklearn-
 ```
 4) Curl the `InferenceService`
 ```bash
-kubectl port-forward --namespace istio-system $(kubectl get pod --namespace istio-system --selector="app=istio-ingressgateway" --output jsonpath='{.items[0].metadata.name}') 8080:80
+kubectl port-forward --namespace istio-system $(kubectl get pod --namespace istio-system --selector="app=istio-ingressgateway" --output jsonpath='{.items[0].metadata.name}') 8080:80 &
 SERVICE_HOSTNAME=$(kubectl get inferenceservice sklearn-iris -n kfserving-test -o jsonpath='{.status.url}' | cut -d "/" -f 3)
 curl -v -H "Host: ${SERVICE_HOSTNAME}" http://localhost:8080/v1/models/sklearn-iris:predict -d @./docs/samples/sklearn/iris-input.json
 ```
 5) Run Performance Test
 ```bash
-kubectl create -f docs/samples/sklearn/perf.test
+kubectl create -f docs/samples/sklearn/perf.yaml -n kfserving-test
 # wait the job to be done and check the log
-kubectl logs load-test8b58n-rgfxr 
+kubectl logs load-test8b58n-rgfxr -n kfserving-test
 Requests      [total, rate, throughput]         30000, 500.02, 499.99
 Duration      [total, attack, wait]             1m0s, 59.998s, 3.336ms
 Latencies     [min, mean, 50, 90, 95, 99, max]  1.743ms, 2.748ms, 2.494ms, 3.363ms, 4.091ms, 7.749ms, 46.354ms

--- a/docs/samples/sklearn/perf.yaml
+++ b/docs/samples/sklearn/perf.yaml
@@ -10,6 +10,7 @@ spec:
       annotations:
         sidecar.istio.io/inject: "false"
     spec:
+      restartPolicy: OnFailure
       containers:
       - args:
         - vegeta -cpus=5 attack -duration=1m -rate=500/1s -targets=/var/vegeta/cfg
@@ -32,7 +33,7 @@ spec:
 apiVersion: v1
 data:
   cfg: |
-    POST http://sklearn-iris.default.svc.cluster.local/v1/models/sklearn-iris:predict
+    POST http://sklearn-iris.kfserving-test.svc.cluster.local/v1/models/sklearn-iris:predict
     @/var/vegeta/payload
   payload: |
     {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fix the Test KFServing Installation in the main README
- In order to run `port-forward` and the rest of the commands in the same shell, port-forward needs to run as background process.
- Run perf.yaml under the same testing namespace
- Update perf.yaml payload to the testing namespace and add `restartPolicy` to fix the below bug https://github.com/kubernetes/kubernetes/issues/41194
   ```
   The Job "load-test284zn" is invalid: spec.template.spec.restartPolicy: Unsupported value: "Always": supported values: "OnFailure", "Never"
   ```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
