### PR TITLE
add customized urls and sample

### DIFF
--- a/docs/samples/custom/customized-urls/Dockerfile
+++ b/docs/samples/custom/customized-urls/Dockerfile
@@ -1,0 +1,17 @@
+# Use the official lightweight Python image.
+# https://hub.docker.com/_/python
+FROM python:3.7-slim
+
+# Copy local code to the container image.
+ENV APP_HOME /app
+WORKDIR $APP_HOME
+COPY . ./
+
+# Install production dependencies.
+RUN pip install Flask gunicorn
+
+# Run the web service on container startup. Here we use the gunicorn
+# webserver, with one worker process and 8 threads.
+# For environments with multiple CPU cores, increase the number of workers
+# to be equal to the cores available.
+CMD exec gunicorn --bind :$PORT --workers 1 --threads 8 app:app

--- a/docs/samples/custom/customized-urls/Readme.md
+++ b/docs/samples/custom/customized-urls/Readme.md
@@ -1,0 +1,104 @@
+# Customized URLs Sample
+
+In some situations, you may have a `custom model image` but can not modify its server routes, this server may also have one or more predict endpoints. Here is a simple sample to show how to deploy this custom service.
+
+## A simple sample 
+
+* `app.py` is a simple flask server, it has two endpoints: `/customized/urls/demo/test/1` and `/v1/models/customized-sample:predict`
+
+```python
+import os
+
+from flask import Flask
+
+app = Flask(__name__)
+@app.route('/customized/urls/demo/test/1')
+def customized_urls_test():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}. Func customized_urls_test is called!\n'.format(target)
+
+@app.route('/v1/models/customized-sample:predict')
+def hello_world():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}!\n'.format(target)
+
+if __name__ == "__main__":
+    app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))
+```
+
+* Build custom image.
+
+  Run the build command to build your image.
+
+  ```shell
+  docker build -t ${your-dockerhub-id}/customized-urls:latest .
+  docker push ${your-dockerhub-id}/customized-urls:latest
+  ```
+
+* Config the `InferenceService` yaml
+
+```yaml
+apiVersion: serving.kubeflow.org/v1alpha2
+  kind: InferenceService
+  metadata:
+    name: customized-urls-sample
+  spec:
+    default:
+      predictor:
+        custom:
+          container:
+            name: hello
+            image: ${your-dockerhub-id}/customized-urls:latest
+```
+  
+* Deploy the `InferenceService`
+
+```shell
+  kubectl apply -f customized-urls.yaml
+  kubectl get inferenceservice customized-urls-sample
+```
+
+Expect output:
+
+```shell
+  NAME                     URL                                                          READY   DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
+  customized-urls-sample   http://customized-urls-sample.default.10.166.15.200.xip.io   True    100                                11m
+```
+  
+There will display the service host.
+  
+```
+  http://customized-urls-sample.default.10.166.15.200.xip.io
+```
+  
+Remember your endpoints:
+
+```
+  /customized/urls/demo/test/1
+  /v1/models/customized-sample:predict
+```
+  
+Append the endpoint after `host`, you can get the route of your endpoint
+  
+```
+  http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1
+  http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict
+```
+  
+  
+  
+Let's test the endpoints:
+  
+`curl http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1`
+  
+Expect Output: `Hello World. Func customized_urls_test is called!`
+
+`curl http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict`
+
+Expect Output: `Hello World!`
+  
+  
+  
+Job Done!
+  
+  

--- a/docs/samples/custom/customized-urls/app.py
+++ b/docs/samples/custom/customized-urls/app.py
@@ -1,0 +1,17 @@
+import os
+
+from flask import Flask
+
+app = Flask(__name__)
+@app.route('/customized/urls/demo/test/1')
+def customized_urls_test():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}. Func customized_urls_test is called!\n'.format(target)
+
+@app.route('/v1/models/customized-sample:predict')
+def hello_world():
+    target = os.environ.get('TARGET', 'World')
+    return 'Hello {}!\n'.format(target)
+
+if __name__ == "__main__":
+    app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))

--- a/docs/samples/custom/customized-urls/customized-urls.yaml
+++ b/docs/samples/custom/customized-urls/customized-urls.yaml
@@ -1,0 +1,11 @@
+apiVersion: serving.kubeflow.org/v1alpha2
+kind: InferenceService
+metadata:
+  name: customized-urls-sample
+spec:
+  default:
+    predictor:
+      custom:
+        container:
+          name: hello
+          image: ${your-dockerhub-id}/customized-urls:latest

--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -213,7 +213,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 	updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 	updateDefault.Status.LatestReadyRevisionName = "revision-v1"
 	updateDefault.Status.URL, _ = apis.ParseURL(
-		constants.InferenceServiceURL("http", constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+		"http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
 	updateDefault.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1.ServiceConditionReady,
@@ -241,11 +241,6 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 				{
 					Match: []*istiov1alpha3.HTTPMatchRequest{
 						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
 							Gateways: []string{constants.KnativeIngressGateway},
 							Authority: &istiov1alpha3.StringMatch{
 								MatchType: &istiov1alpha3.StringMatch_Regex{
@@ -254,11 +249,6 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 							},
 						},
 						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
 							Gateways: []string{constants.KnativeLocalGateway},
 							Authority: &istiov1alpha3.StringMatch{
 								MatchType: &istiov1alpha3.StringMatch_Regex{
@@ -311,7 +301,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 				},
 			},
 		},
-		URL: constants.InferenceServiceURL("http", serviceKey.Name, serviceKey.Namespace, domain),
+		URL: "http://" + constants.InferenceServiceHostName(serviceKey.Name, serviceKey.Namespace, domain),
 		Address: &duckv1beta1.Addressable{
 			URL: &apis.URL{
 				Scheme: "http",
@@ -395,7 +385,7 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 	succedingService.Status.LatestCreatedRevisionName = "revision-v3"
 	succedingService.Status.LatestReadyRevisionName = "revision-v3"
 	succedingService.Status.URL, _ = apis.ParseURL(
-		constants.InferenceServiceURL("http", constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
+		"http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace, domain))
 	succedingService.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1.ServiceConditionReady,
@@ -624,7 +614,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 	updateDefault := defaultService.DeepCopy()
 	updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 	updateDefault.Status.LatestReadyRevisionName = "revision-v1"
-	updateDefault.Status.URL, _ = apis.ParseURL(constants.InferenceServiceURL("http", constants.DefaultPredictorServiceName(canaryServiceKey.Name),
+	updateDefault.Status.URL, _ = apis.ParseURL("http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(canaryServiceKey.Name),
 		canaryServiceKey.Namespace, domain))
 	updateDefault.Status.Conditions = duckv1.Conditions{
 		{
@@ -639,7 +629,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 	updateCanary.Status.LatestCreatedRevisionName = "revision-v2"
 	updateCanary.Status.LatestReadyRevisionName = "revision-v2"
 	updateCanary.Status.URL, _ = apis.ParseURL(
-		constants.InferenceServiceURL("http", constants.CanaryPredictorServiceName(canaryServiceKey.Name), canaryServiceKey.Namespace, domain))
+		"http://" + constants.InferenceServiceHostName(constants.CanaryPredictorServiceName(canaryServiceKey.Name), canaryServiceKey.Namespace, domain))
 	updateCanary.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1.ServiceConditionReady,
@@ -672,7 +662,7 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 				},
 			},
 		},
-		URL: constants.InferenceServiceURL("http", canaryServiceKey.Name,
+		URL: "http://" + constants.InferenceServiceHostName(canaryServiceKey.Name,
 			canaryService.Namespace, domain),
 		Address: &duckv1beta1.Addressable{
 			URL: &apis.URL{
@@ -724,11 +714,6 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 				{
 					Match: []*istiov1alpha3.HTTPMatchRequest{
 						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
 							Gateways: []string{constants.KnativeIngressGateway},
 							Authority: &istiov1alpha3.StringMatch{
 								MatchType: &istiov1alpha3.StringMatch_Regex{
@@ -737,11 +722,6 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 							},
 						},
 						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
 							Gateways: []string{constants.KnativeLocalGateway},
 							Authority: &istiov1alpha3.StringMatch{
 								MatchType: &istiov1alpha3.StringMatch_Regex{
@@ -891,7 +871,7 @@ func TestCanaryDelete(t *testing.T) {
 	updateDefault.Status.LatestCreatedRevisionName = "revision-v1"
 	updateDefault.Status.LatestReadyRevisionName = "revision-v1"
 	updateDefault.Status.URL, _ = apis.ParseURL(
-		constants.InferenceServiceURL("http", constants.DefaultPredictorServiceName(serviceName), namespace, domain))
+		"http://" + constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceName), namespace, domain))
 	updateDefault.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1.ServiceConditionReady,
@@ -905,7 +885,7 @@ func TestCanaryDelete(t *testing.T) {
 	updateCanary.Status.LatestCreatedRevisionName = "revision-v2"
 	updateCanary.Status.LatestReadyRevisionName = "revision-v2"
 	updateCanary.Status.URL, _ = apis.ParseURL(
-		constants.InferenceServiceURL("http", constants.CanaryPredictorServiceName(serviceName), namespace, domain))
+		"http://" + constants.InferenceServiceHostName(constants.CanaryPredictorServiceName(serviceName), namespace, domain))
 	updateCanary.Status.Conditions = duckv1.Conditions{
 		{
 			Type:   knservingv1.ServiceConditionReady,
@@ -938,7 +918,7 @@ func TestCanaryDelete(t *testing.T) {
 				},
 			},
 		},
-		URL: constants.InferenceServiceURL("http", serviceName, namespace, domain),
+		URL: "http://" + constants.InferenceServiceHostName(serviceName, namespace, domain),
 		Address: &duckv1beta1.Addressable{
 			URL: &apis.URL{
 				Scheme: "http",
@@ -1024,7 +1004,7 @@ func TestCanaryDelete(t *testing.T) {
 				},
 			},
 		},
-		URL: constants.InferenceServiceURL("http", serviceName, namespace, domain),
+		URL: "http://" + constants.InferenceServiceHostName(serviceName, namespace, domain),
 		Address: &duckv1beta1.Addressable{
 			URL: &apis.URL{
 				Scheme: "http",
@@ -1332,7 +1312,7 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 		},
 		Traffic:       80,
 		CanaryTraffic: 20,
-		URL:           constants.InferenceServiceURL("http", serviceKey.Name, serviceKey.Namespace, domain),
+		URL:           "http://" + constants.InferenceServiceHostName(serviceKey.Name, serviceKey.Namespace, domain),
 		Address: &duckv1beta1.Addressable{
 			URL: &apis.URL{
 				Scheme: "http",
@@ -1388,11 +1368,6 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 				{
 					Match: []*istiov1alpha3.HTTPMatchRequest{
 						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
 							Gateways: []string{constants.KnativeIngressGateway},
 							Authority: &istiov1alpha3.StringMatch{
 								MatchType: &istiov1alpha3.StringMatch_Regex{
@@ -1401,11 +1376,6 @@ func TestInferenceServiceWithTransformer(t *testing.T) {
 							},
 						},
 						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
 							Gateways: []string{constants.KnativeLocalGateway},
 							Authority: &istiov1alpha3.StringMatch{
 								MatchType: &istiov1alpha3.StringMatch_Regex{
@@ -1831,7 +1801,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		updateCanary.Status.LatestCreatedRevisionName = "revision-v2"
 		updateCanary.Status.LatestReadyRevisionName = "revision-v2"
 		updateCanary.Status.URL, _ = apis.ParseURL(
-			constants.InferenceServiceURL("http", constants.CanaryPredictorServiceName(serviceName), namespace, domain))
+			"http://" + constants.InferenceServiceHostName(constants.CanaryPredictorServiceName(serviceName), namespace, domain))
 		updateCanary.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1.ServiceConditionReady,
@@ -1848,7 +1818,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		updateDefault.Status.LatestCreatedRevisionName = "e-revision-v1"
 		updateDefault.Status.LatestReadyRevisionName = "e-revision-v1"
 		updateDefault.Status.URL, _ = apis.ParseURL(
-			constants.InferenceServiceURL("http", constants.DefaultExplainerServiceName(serviceName), namespace, domain))
+			"http://" + constants.InferenceServiceHostName(constants.DefaultExplainerServiceName(serviceName), namespace, domain))
 		updateDefault.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1.ServiceConditionReady,
@@ -1862,7 +1832,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		updateCanary.Status.LatestCreatedRevisionName = "e-revision-v2"
 		updateCanary.Status.LatestReadyRevisionName = "e-revision-v2"
 		updateCanary.Status.URL, _ = apis.ParseURL(
-			constants.InferenceServiceURL("http", constants.CanaryExplainerServiceName(serviceName), namespace, domain))
+			"http://" + constants.InferenceServiceHostName(constants.CanaryExplainerServiceName(serviceName), namespace, domain))
 		updateCanary.Status.Conditions = duckv1.Conditions{
 			{
 				Type:   knservingv1.ServiceConditionReady,
@@ -1910,7 +1880,7 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 		},
 		Traffic:       80,
 		CanaryTraffic: 20,
-		URL:           constants.InferenceServiceURL("http", serviceKey.Name, serviceKey.Namespace, domain),
+		URL:           "http://" + constants.InferenceServiceHostName(serviceKey.Name, serviceKey.Namespace, domain),
 		Address: &duckv1beta1.Addressable{
 			URL: &apis.URL{
 				Scheme: "http",
@@ -1968,70 +1938,6 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 						{
 							Uri: &istiov1alpha3.StringMatch{
 								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
-							Gateways: []string{constants.KnativeIngressGateway},
-							Authority: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.HostRegExp(constants.InferenceServiceHostName(serviceKey.Name, serviceKey.Namespace, domain)),
-								},
-							},
-						},
-						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.PredictPrefix(),
-								},
-							},
-							Gateways: []string{constants.KnativeLocalGateway},
-							Authority: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
-									Regex: constants.HostRegExp(network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace)),
-								},
-							},
-						},
-					},
-					Route: []*istiov1alpha3.HTTPRouteDestination{
-						{
-							Headers: &istiov1alpha3.Headers{
-								Request: &istiov1alpha3.Headers_HeaderOperations{
-									Set: map[string]string{
-										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), serviceKey.Namespace),
-									},
-								},
-							},
-							Destination: &istiov1alpha3.Destination{
-								Host: constants.LocalGatewayHost,
-								Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort},
-							},
-							Weight: 80,
-						},
-						{
-							Headers: &istiov1alpha3.Headers{
-								Request: &istiov1alpha3.Headers_HeaderOperations{
-									Set: map[string]string{
-										"Host": network.GetServiceHostname(constants.CanaryPredictorServiceName(serviceName), serviceKey.Namespace),
-									},
-								},
-							},
-							Destination: &istiov1alpha3.Destination{
-								Host: constants.LocalGatewayHost,
-								Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort},
-							},
-							Weight: 20,
-						},
-					},
-					Retries: &istiov1alpha3.HTTPRetry{
-						Attempts:      3,
-						PerTryTimeout: istio.RetryTimeout,
-					},
-				},
-				{
-					Match: []*istiov1alpha3.HTTPMatchRequest{
-						{
-							Uri: &istiov1alpha3.StringMatch{
-								MatchType: &istiov1alpha3.StringMatch_Regex{
 									Regex: constants.ExplainPrefix(),
 								},
 							},
@@ -2072,6 +1978,60 @@ func TestInferenceServiceWithExplainer(t *testing.T) {
 								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
 									"Host": network.GetServiceHostname(constants.CanaryExplainerServiceName(serviceName), serviceKey.Namespace)}},
 							},
+						},
+					},
+					Retries: &istiov1alpha3.HTTPRetry{
+						Attempts:      3,
+						PerTryTimeout: istio.RetryTimeout,
+					},
+				},
+				{
+					Match: []*istiov1alpha3.HTTPMatchRequest{
+						{
+							Gateways: []string{constants.KnativeIngressGateway},
+							Authority: &istiov1alpha3.StringMatch{
+								MatchType: &istiov1alpha3.StringMatch_Regex{
+									Regex: constants.HostRegExp(constants.InferenceServiceHostName(serviceKey.Name, serviceKey.Namespace, domain)),
+								},
+							},
+						},
+						{
+							Gateways: []string{constants.KnativeLocalGateway},
+							Authority: &istiov1alpha3.StringMatch{
+								MatchType: &istiov1alpha3.StringMatch_Regex{
+									Regex: constants.HostRegExp(network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace)),
+								},
+							},
+						},
+					},
+					Route: []*istiov1alpha3.HTTPRouteDestination{
+						{
+							Headers: &istiov1alpha3.Headers{
+								Request: &istiov1alpha3.Headers_HeaderOperations{
+									Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), serviceKey.Namespace),
+									},
+								},
+							},
+							Destination: &istiov1alpha3.Destination{
+								Host: constants.LocalGatewayHost,
+								Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort},
+							},
+							Weight: 80,
+						},
+						{
+							Headers: &istiov1alpha3.Headers{
+								Request: &istiov1alpha3.Headers_HeaderOperations{
+									Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.CanaryPredictorServiceName(serviceName), serviceKey.Namespace),
+									},
+								},
+							},
+							Destination: &istiov1alpha3.Destination{
+								Host: constants.LocalGatewayHost,
+								Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort},
+							},
+							Weight: 20,
 						},
 					},
 					Retries: &istiov1alpha3.HTTPRetry{

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
@@ -34,7 +34,7 @@ func TestCreateVirtualService(t *testing.T) {
 	serviceName := "my-model"
 	namespace := "test"
 	domain := "example.com"
-	expectedURL := constants.InferenceServiceURL("http", serviceName, namespace, domain)
+	expectedURL := "http://" + constants.InferenceServiceHostName(serviceName, namespace, domain)
 	serviceHostName := constants.InferenceServiceHostName(serviceName, namespace, domain)
 	serviceInternalHostName := network.GetServiceHostname(serviceName, namespace)
 	predictorHostname := constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceName), namespace, domain)
@@ -44,11 +44,6 @@ func TestCreateVirtualService(t *testing.T) {
 	canaryTransformerHostname := constants.InferenceServiceHostName(constants.CanaryTransformerServiceName(serviceName), namespace, domain)
 	predictorRouteMatch := []*istiov1alpha3.HTTPMatchRequest{
 		{
-			Uri: &istiov1alpha3.StringMatch{
-				MatchType: &istiov1alpha3.StringMatch_Regex{
-					Regex: constants.PredictPrefix(),
-				},
-			},
 			Authority: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Regex{
 					Regex: constants.HostRegExp(constants.InferenceServiceHostName(serviceName, namespace, domain)),
@@ -57,11 +52,6 @@ func TestCreateVirtualService(t *testing.T) {
 			Gateways: []string{constants.KnativeIngressGateway},
 		},
 		{
-			Uri: &istiov1alpha3.StringMatch{
-				MatchType: &istiov1alpha3.StringMatch_Regex{
-					Regex: constants.PredictPrefix(),
-				},
-			},
 			Authority: &istiov1alpha3.StringMatch{
 				MatchType: &istiov1alpha3.StringMatch_Regex{
 					Regex: constants.HostRegExp(network.GetServiceHostname(serviceName, namespace)),
@@ -459,24 +449,6 @@ func TestCreateVirtualService(t *testing.T) {
 				Gateways: []string{constants.KnativeIngressGateway, constants.KnativeLocalGateway},
 				Http: []*istiov1alpha3.HTTPRoute{
 					{
-						Match: predictorRouteMatch,
-						Route: []*istiov1alpha3.HTTPRouteDestination{
-							{
-								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
-								Weight:      100,
-								Headers: &istiov1alpha3.Headers{
-									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)},
-									},
-								},
-							},
-						},
-						Retries: &istiov1alpha3.HTTPRetry{
-							Attempts:      3,
-							PerTryTimeout: RetryTimeout,
-						},
-					},
-					{
 						Match: []*istiov1alpha3.HTTPMatchRequest{
 							{
 								Uri: &istiov1alpha3.StringMatch{
@@ -512,6 +484,24 @@ func TestCreateVirtualService(t *testing.T) {
 								Headers: &istiov1alpha3.Headers{
 									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
 										"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(serviceName), namespace)},
+									},
+								},
+							},
+						},
+						Retries: &istiov1alpha3.HTTPRetry{
+							Attempts:      3,
+							PerTryTimeout: RetryTimeout,
+						},
+					},
+					{
+						Match: predictorRouteMatch,
+						Route: []*istiov1alpha3.HTTPRouteDestination{
+							{
+								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
+								Weight:      100,
+								Headers: &istiov1alpha3.Headers{
+									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)},
 									},
 								},
 							},


### PR DESCRIPTION
Fix #733

# Customized URLs Sample

In some situations, you may have a `custom model image` but can not modify its server routes, this server may also have one or more predict endpoints. Here is a simple sample to show how to deploy this custom service.

## A simple sample 

* `app.py` is a simple flask server, it has two endpoints: `customized_urls_test` and `hello_world`

```python
import os

from flask import Flask

app = Flask(__name__)
@app.route('/customized/urls/demo/test/1')
def customized_urls_test():
    target = os.environ.get('TARGET', 'World')
    return 'Hello {}. Func customized_urls_test is called!\n'.format(target)

@app.route('/v1/models/customized-sample:predict')
def hello_world():
    target = os.environ.get('TARGET', 'World')
    return 'Hello {}!\n'.format(target)

if __name__ == "__main__":
    app.run(debug=True,host='0.0.0.0',port=int(os.environ.get('PORT', 8080)))
```

* Build custom image.

  Run the build command to build your image. Or you can use the the prebuild image:`iamlovingit/customized-urls:latest` 

  ```shell
  docker build -t ${your-dockerhub-id}/customized-urls:latest .
  docker push ${your-dockerhub-id}/customized-urls:latest
  ```

* Config the Yaml

```yaml
apiVersion: serving.kubeflow.org/v1alpha2
  kind: InferenceService
  metadata:
    labels:
      controller-tools.k8s.io: "1.0"
    name: customized-urls-sample
  spec:
    default:
      predictor:
        custom:
          container:
            name: hello
            image: ${your-dockerhub-id}/customized-urls:latest
```
  
* Deploy the  yaml and check the Inference service status

```shel
  kubectl apply -f customized-urls.yaml
  kubectl get inferenceservice customized-urls-sample
```

Expect output:

```shell
  NAME                     URL                                                          READY   DEFAULT TRAFFIC   CANARY TRAFFIC   AGE
  customized-urls-sample   http://customized-urls-sample.default.10.166.15.200.xip.io   True    100                                11m
```
  
There will display the service host.
  
```
  http://customized-urls-sample.default.10.166.15.200.xip.io
```
  
Remember your endpoints:

```
  /customized/urls/demo/test/1
  /v1/models/customized-sample:predict
```
  
Append the endpoint after `host`, you can get the route of your endpoint
  
```
  http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1
  http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict
```
  
  
  
Let's test the endpoints:
  
`curl http://customized-urls-sample.default.10.166.15.200.xip.io/customized/urls/demo/test/1`
  
Expect Output: `Hello World. Func customized_urls_test is called!`

`curl http://customized-urls-sample.default.10.166.15.200.xip.io/v1/models/customized-sample:predict`

Expect Output: `Hello World!`
  
  
  
Job Done!
  