### PR TITLE
Add LivenessProbe to Tensorflow Predictor

### DIFF
--- a/pkg/apis/serving/v1alpha2/framework_tensorflow.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorflow.go
@@ -49,11 +49,23 @@ func (t *TensorflowSpec) GetContainer(modelName string, parallelism int, config 
 	}
 
 	return &v1.Container{
-		Image:     config.Predictors.Tensorflow.ContainerImage + ":" + t.RuntimeVersion,
-		Name:      constants.InferenceServiceContainerName,
-		Command:   []string{TensorflowEntrypointCommand},
-		Resources: t.Resources,
-		Args:      arguments,
+		Image:     		config.Predictors.Tensorflow.ContainerImage + ":" + t.RuntimeVersion,
+		Name:      		constants.InferenceServiceContainerName,
+		Command:   		[]string{TensorflowEntrypointCommand},
+		Resources: 		t.Resources,
+		Args:      		arguments,
+		LivenessProbe:  &v1.Probe{
+			Handler: v1.Handler {
+				HTTPGet: &v1.HTTPGetAction{
+					Path: "/v1/models/" + modelName,
+				},
+			},
+			InitialDelaySeconds: 180,
+			PeriodSeconds: 10,
+			FailureThreshold: 3,
+			SuccessThreshold: 1,
+			TimeoutSeconds: 1,
+		},
 	}
 }
 

--- a/pkg/apis/serving/v1alpha2/framework_tensorflow.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorflow.go
@@ -49,22 +49,22 @@ func (t *TensorflowSpec) GetContainer(modelName string, parallelism int, config 
 	}
 
 	return &v1.Container{
-		Image:     		config.Predictors.Tensorflow.ContainerImage + ":" + t.RuntimeVersion,
-		Name:      		constants.InferenceServiceContainerName,
-		Command:   		[]string{TensorflowEntrypointCommand},
-		Resources: 		t.Resources,
-		Args:      		arguments,
-		LivenessProbe:  &v1.Probe{
-			Handler: v1.Handler {
+		Image:     config.Predictors.Tensorflow.ContainerImage + ":" + t.RuntimeVersion,
+		Name:      constants.InferenceServiceContainerName,
+		Command:   []string{TensorflowEntrypointCommand},
+		Resources: t.Resources,
+		Args:      arguments,
+		LivenessProbe: &v1.Probe{
+			Handler: v1.Handler{
 				HTTPGet: &v1.HTTPGetAction{
 					Path: "/v1/models/" + modelName,
 				},
 			},
-			InitialDelaySeconds: 180,
-			PeriodSeconds: 10,
-			FailureThreshold: 3,
-			SuccessThreshold: 1,
-			TimeoutSeconds: 1,
+			InitialDelaySeconds: constants.DefaultReadinessTimeout,
+			PeriodSeconds:       10,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      1,
 		},
 	}
 }

--- a/pkg/apis/serving/v1alpha2/framework_tensorflow_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_tensorflow_test.go
@@ -111,6 +111,18 @@ func TestTensorflowContainer(t *testing.T) {
 			"--model_name=someName",
 			"--model_base_path=/mnt/models",
 		},
+		LivenessProbe: &v1.Probe{
+			Handler: v1.Handler{
+				HTTPGet: &v1.HTTPGetAction{
+					Path: "/v1/models/someName",
+				},
+			},
+			InitialDelaySeconds: constants.DefaultReadinessTimeout,
+			PeriodSeconds:       10,
+			FailureThreshold:    3,
+			SuccessThreshold:    1,
+			TimeoutSeconds:      1,
+		},
 	}
 
 	// Test Create with config

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -67,6 +67,7 @@ var (
 	DefaultPredictorTimeout   int64 = 60
 	DefaultTransformerTimeout int64 = 120
 	DefaultExplainerTimeout   int64 = 300
+	DefaultReadinessTimeout	  int32 = 180
 	DefaultScalingTarget            = "1"
 	DefaultMinReplicas              = 1
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -67,7 +67,7 @@ var (
 	DefaultPredictorTimeout   int64 = 60
 	DefaultTransformerTimeout int64 = 120
 	DefaultExplainerTimeout   int64 = 300
-	DefaultReadinessTimeout	  int32 = 180
+	DefaultReadinessTimeout	  int32 = 600
 	DefaultScalingTarget            = "1"
 	DefaultMinReplicas              = 1
 )

--- a/pkg/controller/inferenceservice/controller_test.go
+++ b/pkg/controller/inferenceservice/controller_test.go
@@ -191,6 +191,18 @@ func TestInferenceServiceWithOnlyPredictor(t *testing.T) {
 										"--model_name=" + defaultInstance.Name,
 										"--model_base_path=" + constants.DefaultModelLocalMountPath,
 									},
+									LivenessProbe: &v1.Probe{
+										Handler: v1.Handler{
+											HTTPGet: &v1.HTTPGetAction{
+												Path: "/v1/models/"+ defaultInstance.Name,
+											},
+										},
+										InitialDelaySeconds: constants.DefaultReadinessTimeout,
+										PeriodSeconds:       10,
+										FailureThreshold:    3,
+										SuccessThreshold:    1,
+										TimeoutSeconds:      1,
+									},
 								},
 							},
 						},
@@ -510,6 +522,18 @@ func TestInferenceServiceWithDefaultAndCanaryPredictor(t *testing.T) {
 										"--rest_api_port=" + kfserving.TensorflowServingRestPort,
 										"--model_name=" + canary.Name,
 										"--model_base_path=" + constants.DefaultModelLocalMountPath,
+									},
+									LivenessProbe: &v1.Probe{
+										Handler: v1.Handler{
+											HTTPGet: &v1.HTTPGetAction{
+												Path: "/v1/models/"+ canary.Name,
+											},
+										},
+										InitialDelaySeconds: constants.DefaultReadinessTimeout,
+										PeriodSeconds:       10,
+										FailureThreshold:    3,
+										SuccessThreshold:    1,
+										TimeoutSeconds:      1,
 									},
 								},
 							},

--- a/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
+++ b/pkg/controller/inferenceservice/reconcilers/knative/service_reconciler_test.go
@@ -145,6 +145,18 @@ func TestKnativeServiceReconcile(t *testing.T) {
 												"--model_name=mnist",
 												"--model_base_path=" + constants.DefaultModelLocalMountPath,
 											},
+											LivenessProbe: &v1.Probe{
+												Handler: v1.Handler{
+													HTTPGet: &v1.HTTPGetAction{
+														Path: "/v1/models/mnist",
+													},
+												},
+												InitialDelaySeconds: constants.DefaultReadinessTimeout,
+												PeriodSeconds:       10,
+												FailureThreshold:    3,
+												SuccessThreshold:    1,
+												TimeoutSeconds:      1,
+											},
 										},
 									},
 								},
@@ -188,6 +200,18 @@ func TestKnativeServiceReconcile(t *testing.T) {
 												"--rest_api_port=" + v1alpha2.TensorflowServingRestPort,
 												"--model_name=mnist",
 												"--model_base_path=" + constants.DefaultModelLocalMountPath,
+											},
+											LivenessProbe: &v1.Probe{
+												Handler: v1.Handler{
+													HTTPGet: &v1.HTTPGetAction{
+														Path: "/v1/models/mnist",
+													},
+												},
+												InitialDelaySeconds: constants.DefaultReadinessTimeout,
+												PeriodSeconds:       10,
+												FailureThreshold:    3,
+												SuccessThreshold:    1,
+												TimeoutSeconds:      1,
 											},
 										},
 									},
@@ -250,6 +274,18 @@ func TestKnativeServiceReconcile(t *testing.T) {
 												"--rest_api_port=" + v1alpha2.TensorflowServingRestPort,
 												"--model_name=mnist",
 												"--model_base_path=" + constants.DefaultModelLocalMountPath,
+											},
+											LivenessProbe: &v1.Probe{
+												Handler: v1.Handler{
+													HTTPGet: &v1.HTTPGetAction{
+														Path: "/v1/models/mnist",
+													},
+												},
+												InitialDelaySeconds: constants.DefaultReadinessTimeout,
+												PeriodSeconds:       10,
+												FailureThreshold:    3,
+												SuccessThreshold:    1,
+												TimeoutSeconds:      1,
 											},
 										},
 									},

--- a/pkg/controller/inferenceservice/resources/knative/service_test.go
+++ b/pkg/controller/inferenceservice/resources/knative/service_test.go
@@ -119,6 +119,18 @@ var defaultService = &knservingv1.Service{
 									"--model_name=mnist",
 									"--model_base_path=" + constants.DefaultModelLocalMountPath,
 								},
+								LivenessProbe: &v1.Probe{
+									Handler: v1.Handler{
+										HTTPGet: &v1.HTTPGetAction{
+											Path: "/v1/models/mnist",
+										},
+									},
+									InitialDelaySeconds: constants.DefaultReadinessTimeout,
+									PeriodSeconds:       10,
+									FailureThreshold:    3,
+									SuccessThreshold:    1,
+									TimeoutSeconds:      1,
+								},
 							},
 						},
 					},
@@ -165,6 +177,18 @@ var canaryService = &knservingv1.Service{
 									"--rest_api_port=" + v1alpha2.TensorflowServingRestPort,
 									"--model_name=mnist",
 									"--model_base_path=" + constants.DefaultModelLocalMountPath,
+								},
+								LivenessProbe: &v1.Probe{
+									Handler: v1.Handler{
+										HTTPGet: &v1.HTTPGetAction{
+											Path: "/v1/models/mnist",
+										},
+									},
+									InitialDelaySeconds: constants.DefaultReadinessTimeout,
+									PeriodSeconds:       10,
+									FailureThreshold:    3,
+									SuccessThreshold:    1,
+									TimeoutSeconds:      1,
 								},
 							},
 						},


### PR DESCRIPTION
**What this PR does / why we need it**:
TensorFlow can in some cases, at least on GPU, end up in a OOM condition at runtime that it never recovers from. This means that each request to the predictor ends up failing. We're observing this sporadically with the 11B T5 model on 16GB GPUs. This shouldn't really happen, but something inside either the model or TensorFlow after several hours of runtime can decide to allocate more input tensors than there is GPU memory.

To manage this, a `LivenessProbe` is added on the Tensorflow Predictor. The probe is fairly generous, requiring three consecutive failures 10 seconds apart.

**Special notes for your reviewer**:

A constant for the `InitialDelaySeconds` is defined and set to 180s. This is longer than KNative allows a revision to deploy in KNative < 15.0, so it should be safe for every current user of KFServing. KNative 15.0 allows the `progressDeadline` to be configured above the default of 120s so hardcoding it to 180s is not necessarily future proof. 180s is quite a while though to load a model, but it can be debated if it is a good idea to add a hardcoded time limit.

**Release note**
```release-note
Liveness probes will now be configured on TensorFlow predictors. A TensorFlow instance will be declared dead and restarted if it doesn't respond to its internal models metadata endpoint for 30s.
```
