### PR TITLE
Fix tf2openapi dockerfile

### DIFF
--- a/tools/tf2openapi/Dockerfile
+++ b/tools/tf2openapi/Dockerfile
@@ -1,17 +1,19 @@
 # Build the manager binary
-FROM golang:1.10.3 as builder
+FROM golang:1.13.0 as builder
 
 # Copy in the go src
 WORKDIR /go/src/github.com/kubeflow/kfserving
-COPY vendor/ vendor/
 COPY tools/  tools/
 COPY pkg/    pkg/
+COPY go.mod  go.mod
+COPY go.sum  go.sum
 
 # Build
 RUN CGO_ENABLED=0 GOOS=linux GOARCH=amd64 go build -a -o tf2openapi ./tools/tf2openapi/cmd
 
 # Copy tf2openapi into a thin image
-FROM ubuntu:latest
+FROM gcr.io/distroless/static:latest 
 WORKDIR /
+COPY third_party/ third_party/
 COPY --from=builder /go/src/github.com/kubeflow/kfserving/tf2openapi .
 ENTRYPOINT ["/tf2openapi"]


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
- The triggered build for tf2openapi has been failing recently after migrating to go module

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
