### PR TITLE
add custom default conainer name

### DIFF
--- a/pkg/apis/serving/v1alpha2/framework_custom.go
+++ b/pkg/apis/serving/v1alpha2/framework_custom.go
@@ -46,6 +46,7 @@ func (c *CustomSpec) CreateExplainerContainer(modelName string, parallelism int,
 }
 
 func (c *CustomSpec) ApplyDefaults(config *InferenceServicesConfig) {
+	c.Container.Name = constants.InferenceServiceContainerName
 	setResourceRequirementDefaults(&c.Container.Resources)
 }
 


### PR DESCRIPTION
Fixes #937 
add custom default conainer name for resolve the `ValidationError`.
```
ValidationError(InferenceService.spec.default.predictor.custom.container): missing required field "name" in org.kubeflow.serving.v1alpha2.InferenceService.spec.default.predictor.custom.container
```