### PR TITLE
Add Max Kelsen to ADOPTERS.md

### DIFF
--- a/ADOPTERS.md
+++ b/ADOPTERS.md
@@ -9,6 +9,7 @@ This page contains a list of organizations who are using KFServing either in pro
 | [CoreWeave](https://coreweave.com/) | [Peter Salanki](https://github.com/salanki) |
 | [Gojek](https://www.gojek.com/) | [Willem Pienaar](https://github.com/woop) |
 | [IBM](https://www.ibm.com/) | [Animesh Singh](https://github.com/animeshsingh) |
+| [Max Kelsen](https://www.maxkelsen.com/) | [Jacob O'Farrell](https://github.com/ofaz) |
 | [NVIDIA](https://www.nvidia.com/en-us/) | [David Goodwin](deadeyegoodwin) |
 | [Seldon](https://www.seldon.io/) | [Clive Cox](https://github.com/cliveseldon) |
 | [Inspur](https://www.inspur.com/) | [Qingshan Chen](https://github.com/iamlovingit) |


### PR DESCRIPTION
Update to add Max Kelsen to Adopters file. Max Kelsen is currently using KFserving to support a number of production workloads.
