### PR TITLE
Update KNative annotation when modifying minReplicas to 0

### DIFF
--- a/pkg/controller/inferenceservice/resources/knative/service.go
+++ b/pkg/controller/inferenceservice/resources/knative/service.go
@@ -377,7 +377,7 @@ func (c *ServiceBuilder) buildAnnotations(metadata metav1.ObjectMeta, minReplica
 
 	if minReplicas == nil {
 		annotations[autoscaling.MinScaleAnnotationKey] = fmt.Sprint(constants.DefaultMinReplicas)
-	} else if *minReplicas != 0 {
+	} else {
 		annotations[autoscaling.MinScaleAnnotationKey] = fmt.Sprint(*minReplicas)
 	}
 


### PR DESCRIPTION
**What this PR does / why we need it**:
As described in #962. The `minScale` annotation is never set to 0 when updating an existing `InferenceService`'s `minReplicas` from a positive number to zero. This will give the user the impression of scale-to-zero not working, and leave the KFServing administrator pulling his hair trying to figure out how KNative scale to zero can be broken for only this specific `InferenceService`.

**Which issue(s) this PR fixes**
Fixes #962

**Special notes for your reviewer**:


**Release note**:
```release-note
Fixes a bug where enabling Scale-To-Zero on an existing InferenceService did not take effect.
```
