### PR TITLE
Make KFServer HTTP requests asynchronous

### DIFF
--- a/python/alibiexplainer/alibiexplainer/__main__.py
+++ b/python/alibiexplainer/alibiexplainer/__main__.py
@@ -17,6 +17,7 @@ import kfserving
 import logging
 import os
 import sys
+import nest_asyncio
 from alibiexplainer import AlibiExplainer
 from alibiexplainer.explainer import ExplainerMethod  # pylint:disable=no-name-in-module
 from alibiexplainer.parser import parse_args
@@ -29,6 +30,9 @@ EXPLAINER_FILENAME = "explainer.dill"
 def main():
     args, extra = parse_args(sys.argv[1:])
     # Pretrained Alibi explainer
+
+    nest_asyncio.apply()
+
     alibi_model = None
     if args.storage_uri is not None:
         alibi_model = os.path.join(

--- a/python/alibiexplainer/alibiexplainer/explainer.py
+++ b/python/alibiexplainer/alibiexplainer/explainer.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 import logging
+import asyncio
 from enum import Enum
 from typing import List, Any, Mapping, Union, Dict
 
@@ -70,7 +71,8 @@ class AlibiExplainer(kfserving.KFModel):
                 instances.append(req_data.tolist())
             else:
                 instances.append(req_data)
-        resp = self.predict({"instances": instances})
+        loop = asyncio.get_running_loop()
+        resp = loop.run_until_complete(self.predict({"instances": instances}))
         return np.array(resp["predictions"])
 
     def explain(self, request: Dict) -> Any:

--- a/python/alibiexplainer/setup.py
+++ b/python/alibiexplainer/setup.py
@@ -42,7 +42,8 @@ setup(
         "pandas>=0.24.2",
         "numpy>=1.16.3",
         "dill>=0.3.0",
-        "spacy>=2.1.4"
+        "spacy>=2.1.4",
+        "nest_asyncio>=1.4.0"
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}

--- a/python/kfserving/kfserving/handlers/http.py
+++ b/python/kfserving/kfserving/handlers/http.py
@@ -56,7 +56,7 @@ class PredictHandler(HTTPHandler):
             )
         request = model.preprocess(body)
         request = self.validate(request)
-        response = await model.predict(request) if inspect.iscoroutinefunction(model.predict) else model.predict(request)
+        response = (await model.predict(request)) if inspect.iscoroutinefunction(model.predict) else model.predict(request)
         response = model.postprocess(response)
         self.write(response)
 
@@ -73,6 +73,6 @@ class ExplainHandler(HTTPHandler):
             )
         request = model.preprocess(body)
         request = self.validate(request)
-        response = await model.explain(request) if inspect.iscoroutinefunction(model.explain) else model.explain(request)
+        response = (await model.explain(request)) if inspect.iscoroutinefunction(model.explain) else model.explain(request)
         response = model.postprocess(response)
         self.write(response)

--- a/python/kfserving/kfserving/handlers/http.py
+++ b/python/kfserving/kfserving/handlers/http.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+import inspect
 import tornado.web
 import json
 from typing import Dict
@@ -55,7 +56,7 @@ class PredictHandler(HTTPHandler):
             )
         request = model.preprocess(body)
         request = self.validate(request)
-        response = await model.predict(request)
+        response = await model.predict(request) if inspect.iscoroutinefunction(model.predict) else model.predict(request)
         response = model.postprocess(response)
         self.write(response)
 
@@ -72,6 +73,6 @@ class ExplainHandler(HTTPHandler):
             )
         request = model.preprocess(body)
         request = self.validate(request)
-        response = await model.explain(request)
+        response = await model.explain(request) if inspect.iscoroutinefunction(model.explain) else model.explain(request)
         response = model.postprocess(response)
         self.write(response)

--- a/python/kfserving/kfserving/handlers/http.py
+++ b/python/kfserving/kfserving/handlers/http.py
@@ -44,7 +44,7 @@ class HTTPHandler(tornado.web.RequestHandler):
 
 
 class PredictHandler(HTTPHandler):
-    def post(self, name: str):
+    async def post(self, name: str):
         model = self.get_model(name)
         try:
             body = json.loads(self.request.body)
@@ -55,13 +55,13 @@ class PredictHandler(HTTPHandler):
             )
         request = model.preprocess(body)
         request = self.validate(request)
-        response = model.predict(request)
+        response = await model.predict(request)
         response = model.postprocess(response)
         self.write(response)
 
 
 class ExplainHandler(HTTPHandler):
-    def post(self, name: str):
+    async def post(self, name: str):
         model = self.get_model(name)
         try:
             body = json.loads(self.request.body)
@@ -72,6 +72,6 @@ class ExplainHandler(HTTPHandler):
             )
         request = model.preprocess(body)
         request = self.validate(request)
-        response = model.explain(request)
+        response = await model.explain(request)
         response = model.postprocess(response)
         self.write(response)

--- a/python/kfserving/kfserving/kfmodel.py
+++ b/python/kfserving/kfserving/kfmodel.py
@@ -73,7 +73,7 @@ class KFModel:
             raise NotImplementedError
 
         response = await self._http_client.fetch(
-            url=PREDICTOR_URL_FORMAT.format(self.explainer_host, self.name),
+            url=EXPLAINER_URL_FORMAT.format(self.explainer_host, self.name),
             method='POST',
             request_timeout=self.timeout,
             body=json.dumps(request)

--- a/python/kfserving/kfserving/kfmodel.py
+++ b/python/kfserving/kfserving/kfmodel.py
@@ -13,10 +13,11 @@
 # limitations under the License.
 
 from typing import Dict
+import sys
 
 import json
-import requests
 import tornado.web
+from tornado.httpclient import AsyncHTTPClient
 
 PREDICTOR_URL_FORMAT = "http://{0}/v1/models/{1}:predict"
 EXPLAINER_URL_FORMAT = "http://{0}/v1/models/{1}:explain"
@@ -30,6 +31,17 @@ class KFModel:
         self.ready = False
         self.predictor_host = None
         self.explainer_host = None
+        # The timeout matches what is set in generated Istio resorurces.
+        # We generally don't want things to time out at the request level here,
+        # timeouts should be handled elsewhere in the system.
+        self.timeout = 600
+        self._http_client_instance = None
+
+    @property
+    def _http_client(self):
+        if self._http_client_instance is None:
+            self._http_client_instance = AsyncHTTPClient(max_clients=sys.maxsize)
+        return self._http_client_instance
 
     def load(self):
         self.ready = True
@@ -40,30 +52,34 @@ class KFModel:
     def postprocess(self, request: Dict) -> Dict:
         return request
 
-    def predict(self, request: Dict) -> Dict:
+    async def predict(self, request: Dict) -> Dict:
         if not self.predictor_host:
             raise NotImplementedError
 
-        response = requests.post(
+        response = await self._http_client.fetch(
             PREDICTOR_URL_FORMAT.format(self.predictor_host, self.name),
-            json.dumps(request)
+            method='POST',
+            request_timeout=self.timeout,
+            body=json.dumps(request)
         )
-        if response.status_code != 200:
+        if response.code != 200:
             raise tornado.web.HTTPError(
-                status_code=response.status_code,
-                reason=response.content)
-        return response.json()
+                status_code=response.code,
+                reason=response.body)
+        return json.loads(response.body)
 
-    def explain(self, request: Dict) -> Dict:
+    async def explain(self, request: Dict) -> Dict:
         if self.explainer_host is None:
             raise NotImplementedError
 
-        response = requests.post(
-            EXPLAINER_URL_FORMAT.format(self.explainer_host, self.name),
-            json.dumps(request)
+        response = await self._http_client.fetch(
+            url=PREDICTOR_URL_FORMAT.format(self.explainer_host, self.name),
+            method='POST',
+            request_timeout=self.timeout,
+            body=json.dumps(request)
         )
-        if response.status_code != 200:
+        if response.code != 200:
             raise tornado.web.HTTPError(
-                status_code=response.status_code,
-                reason=response.content)
-        return response.json()
+                status_code=response.code,
+                reason=response.body)
+        return json.loads(response.body)

--- a/python/kfserving/test/test_server.py
+++ b/python/kfserving/test/test_server.py
@@ -26,10 +26,10 @@ class DummyModel(kfserving.KFModel):
     def load(self):
         self.ready = True
 
-    def predict(self, request):
+    async def predict(self, request):
         return {"predictions": request["instances"]}
 
-    def explain(self, request):
+    async def explain(self, request):
         return {"predictions": request["instances"]}
 
 


### PR DESCRIPTION
This is a re-open of #791. Please check discussion in #791.

**What this PR does / why we need it**:

Requests from KFServer are currently block. This leads to a transformer not being able to make more than number of Tornado workers concurrent requests to the predictor.

As predictors are usually the bottleneck, and transformers are fast, the transformer becomes an unnecessarily bottleneck.

This PR applies Tornado best practices, making HTTP requests async. This drastically improves the transformer performance.

**Before**
Here we scale transformer instances with 40 worker threads each, to handle a total of 300 requests
![Screen Shot 2020-04-21 at 14 40 29](https://user-images.githubusercontent.com/192223/79901681-2da52f00-83de-11ea-9b1a-fff525e201db.png)

**After**
On one transformer instance, with 1 thread. The target number of concurrent requests is much quicker achieved on the predictor, while consuming less resources.
![Screen Shot 2020-04-21 at 14 39 08](https://user-images.githubusercontent.com/192223/79901772-59281980-83de-11ea-8bb4-6530417e950c.png)


**Which issue(s) this PR fixes** *
Fixes #789

**Special notes for your reviewer**:


**Release note**:
```release-note
Improve transformer concurrency and performance by making Asynchronous HTTP calls.
```