### PR TITLE
Avoid duplicate hostnames in VirtualService when running in cluster-local domain

### DIFF
--- a/pkg/controller/inferenceservice/resources/istio/virtualservice.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice.go
@@ -266,6 +266,14 @@ func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceSer
 	// extract the virtual service hostname from the predictor hostname
 	serviceURL := fmt.Sprintf("%s://%s", "http", serviceHostname)
 
+	serviceInternalHostName := network.GetServiceHostname(isvc.Name, isvc.Namespace)
+	hosts := []string{
+		serviceHostname,
+	}
+	if serviceInternalHostName != hosts[0] {
+		hosts = append(hosts, serviceInternalHostName)
+	}
+
 	vs := v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:        isvc.Name,
@@ -274,10 +282,7 @@ func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceSer
 			Annotations: isvc.Annotations,
 		},
 		Spec: istiov1alpha3.VirtualService{
-			Hosts: []string{
-				serviceHostname,
-				network.GetServiceHostname(isvc.Name, isvc.Namespace),
-			},
+			Hosts: hosts,
 			Gateways: []string{
 				r.ingressConfig.IngressGateway,
 				constants.KnativeLocalGateway,

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice.go
@@ -268,10 +268,16 @@ func (r *VirtualServiceBuilder) CreateVirtualService(isvc *v1alpha2.InferenceSer
 
 	serviceInternalHostName := network.GetServiceHostname(isvc.Name, isvc.Namespace)
 	hosts := []string{
-		serviceHostname,
+		serviceInternalHostName,
 	}
-	if serviceInternalHostName != hosts[0] {
-		hosts = append(hosts, serviceInternalHostName)
+	isClusterLocal := false
+	if val, ok := isvc.Labels["serving.knative.dev/visibility"]; ok {
+		if val == "cluster-local" {
+			isClusterLocal = true
+		}
+	}
+	if serviceHostname != serviceInternalHostName && !isClusterLocal {
+		hosts = append(hosts, serviceHostname)
 	}
 
 	vs := v1alpha3.VirtualService{

--- a/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
+++ b/pkg/controller/inferenceservice/resources/istio/virtualservice_test.go
@@ -84,28 +84,28 @@ func TestCreateVirtualService(t *testing.T) {
 	}
 	cases := []struct {
 		name            string
-		labels			map[string]string
+		labels          map[string]string
 		defaultStatus   v1alpha2.ComponentStatusMap
 		canaryStatus    v1alpha2.ComponentStatusMap
 		expectedStatus  *v1alpha2.VirtualServiceStatus
 		expectedService *v1alpha3.VirtualService
 	}{{
 		name:            "nil status should not be ready",
-		labels:   		 nil,
+		labels:          nil,
 		defaultStatus:   nil,
 		canaryStatus:    nil,
 		expectedStatus:  createFailedStatus(PredictorStatusUnknown, PredictorMissingMessage),
 		expectedService: nil,
 	}, {
 		name:            "empty status should not be ready",
-		labels:   		 nil,
+		labels:          nil,
 		defaultStatus:   nil,
 		canaryStatus:    nil,
 		expectedStatus:  createFailedStatus(PredictorStatusUnknown, PredictorMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "predictor missing host name",
-		labels:   		 nil,
+		name:   "predictor missing host name",
+		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Predictor: v1alpha2.StatusConfigurationSpec{},
 		},
@@ -113,7 +113,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(PredictorHostnameUnknown, PredictorMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "found predictor",
+		name:   "found predictor",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Predictor: v1alpha2.StatusConfigurationSpec{
@@ -165,7 +165,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 	}, {
-		name: "avoid duplicate hostnames for predictor with globally configured cluster-local domain",
+		name:   "avoid duplicate hostnames for predictor with globally configured cluster-local domain",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Predictor: v1alpha2.StatusConfigurationSpec{
@@ -217,7 +217,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 	}, {
-		name: "avoid duplicate hostnames for predictor with cluster-local label",
+		name:   "avoid duplicate hostnames for predictor with cluster-local label",
 		labels: map[string]string{"serving.knative.dev/visibility": "cluster-local"},
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Predictor: v1alpha2.StatusConfigurationSpec{
@@ -269,7 +269,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 	}, {
-		name: "missing canary predictor",
+		name:   "missing canary predictor",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Predictor: v1alpha2.StatusConfigurationSpec{
@@ -282,7 +282,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(PredictorHostnameUnknown, PredictorMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "canary predictor no hostname",
+		name:   "canary predictor no hostname",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Predictor: v1alpha2.StatusConfigurationSpec{
@@ -295,7 +295,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(PredictorHostnameUnknown, PredictorMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "found default and canary predictor",
+		name:   "found default and canary predictor",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Predictor: v1alpha2.StatusConfigurationSpec{
@@ -362,7 +362,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 	}, {
-		name: "nil transformer status fails with status unknown",
+		name:   "nil transformer status fails with status unknown",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Transformer: v1alpha2.StatusConfigurationSpec{},
@@ -374,7 +374,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(TransformerHostnameUnknown, TransformerMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "transformer missing host name",
+		name:   "transformer missing host name",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Transformer: v1alpha2.StatusConfigurationSpec{},
@@ -386,7 +386,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(TransformerHostnameUnknown, TransformerMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "default transformer and predictor",
+		name:   "default transformer and predictor",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Transformer: v1alpha2.StatusConfigurationSpec{
@@ -442,7 +442,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 	}, {
-		name: "missing canary transformer",
+		name:   "missing canary transformer",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Transformer: v1alpha2.StatusConfigurationSpec{
@@ -461,7 +461,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(TransformerHostnameUnknown, TransformerMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "canary & default transformer and predictor",
+		name:   "canary & default transformer and predictor",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Transformer: v1alpha2.StatusConfigurationSpec{
@@ -532,7 +532,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 	}, {
-		name: "nil explainer status fails with status unknown",
+		name:   "nil explainer status fails with status unknown",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Explainer: v1alpha2.StatusConfigurationSpec{},
@@ -544,7 +544,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(ExplainerHostnameUnknown, ExplainerMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "explainer missing host name",
+		name:   "explainer missing host name",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Explainer: v1alpha2.StatusConfigurationSpec{},
@@ -556,7 +556,7 @@ func TestCreateVirtualService(t *testing.T) {
 		expectedStatus:  createFailedStatus(ExplainerHostnameUnknown, ExplainerMissingMessage),
 		expectedService: nil,
 	}, {
-		name: "default explainer and predictor",
+		name:   "default explainer and predictor",
 		labels: nil,
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Explainer: v1alpha2.StatusConfigurationSpec{


### PR DESCRIPTION
**What this PR does / why we need it**:
When KNative Serving default domain is set to be cluster-local by default (i.e. `svc.cluster.local`), the external host domain is not different from the internal one which creates duplicate hostnames in [virtualservice.go#L278](https://github.com/kubeflow/kfserving/blob/master/pkg/controller/inferenceservice/resources/istio/virtualservice.go#L278) and the created `VirtualService` fails Istio validation with:
```
admission webhook \"pilot.validation.istio.io\" denied the request: configuration is invalid:
duplicate hosts in virtual service: mnist.test.svc.cluster.local & mnist.test.svc.cluster.local
```

This PR adds a check in `virtualservice.go` to avoid duplicates when running cluster-local services.

This PR is a follow-up of https://github.com/kubeflow/kfserving/pull/954.

**Which issue(s) this PR fixes**:
Fixes https://github.com/kubeflow/kfserving/issues/948