### PR TITLE
Genericized component logic; cleaned up valdation and other interfaces

### DIFF
--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -1,15 +1,162 @@
 package v1beta1
 
 import (
+	"fmt"
+	"reflect"
+	"regexp"
+	"strings"
+
+	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-// Components interface is implemented by predictor, transformer and explainer
+// Known error messages
+const (
+	MinReplicasShouldBeLessThanMaxError = "MinReplicas cannot be greater than MaxReplicas."
+	MinReplicasLowerBoundExceededError  = "MinReplicas cannot be less than 0."
+	MaxReplicasLowerBoundExceededError  = "MaxReplicas cannot be less than 0."
+	ParallelismLowerBoundExceededError  = "Parallelism cannot be less than 0."
+	UnsupportedStorageURIFormatError    = "storageUri, must be one of: [%s] or match https://{}.blob.core.windows.net/{}/{} or be an absolute or relative local path. StorageUri [%s] is not supported."
+	InvalidLoggerType                   = "Invalid logger type"
+)
+
+// Constants
+var (
+	SupportedStorageURIPrefixList = []string{"gs://", "s3://", "pvc://", "file://"}
+	AzureBlobURIRegEx             = "https://(.+?).blob.core.windows.net/(.+)"
+)
+
+// ComponentImplementation interface is implemented by predictor, transformer, and explainer implementations
 // +kubebuilder:object:generate=false
-type Component interface {
-	GetContainer(metadata metav1.ObjectMeta, containerConcurrency *int64, config *InferenceServicesConfig) *v1.Container
-	GetStorageUri() *string
+type ComponentImplementation interface {
 	Default(config *InferenceServicesConfig)
 	Validate() error
+	GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container
+	GetStorageUri() *string
+}
+
+// Component interface is implemented by all specs that contain component implentations, e.g. PredictorSpec, ExplainerSpec, TransformerSpec.
+// +kubebuilder:object:generate=false
+type Component interface {
+	GetImplementation() ComponentImplementation
+	GetImplementations() []ComponentImplementation
+	GetExtensions() *ComponentExtensionSpec
+}
+
+// ComponentExtensionSpec defines the deployment configuration for a given InferenceService component
+type ComponentExtensionSpec struct {
+	// Minimum number of replicas, defaults to 1 but can be set to 0 to enable scale-to-zero.
+	// +optional
+	MinReplicas *int `json:"minReplicas,omitempty"`
+	// Maximum number of replicas for autoscaling.
+	// +optional
+	MaxReplicas int `json:"maxReplicas,omitempty"`
+	// ContainerConcurrency specifies how many requests can be processed concurrently, this sets the hard limit of the container
+	// concurrency(https://knative.dev/docs/serving/autoscaling/concurrency).
+	// +optional
+	ContainerConcurrency *int64 `json:"containerConcurrency,omitempty"`
+	// TimeoutSeconds specifies the number of seconds to wait before timing out a request to the component.
+	// +optional
+	TimeoutSeconds *int64 `json:"timeout,omitempty"`
+	// CanaryTrafficPercent defines the traffic split percentage between the candidate revision and the last ready revision
+	// +optional
+	CanaryTrafficPercent *int `json:"canaryTrafficPercent,omitempty"`
+	// Activate request/response logging and logger configurations
+	// +optional
+	LoggerSpec *LoggerSpec `json:"logger,omitempty"`
+	// Activate request batching and batching configurations
+	// +optional
+	Batcher *Batcher `json:"batcher,omitempty"`
+}
+
+// Default the ComponentExtensionSpec
+func (s *ComponentExtensionSpec) Default(config *InferenceServicesConfig) {}
+
+// Validate the ComponentExtensionSpec
+func (s *ComponentExtensionSpec) Validate() error {
+	return utils.FirstNonNilError([]error{
+		validateContainerConcurrency(s.ContainerConcurrency),
+		validateReplicas(s.MinReplicas, s.MaxReplicas),
+		validateLogger(s.LoggerSpec),
+	})
+}
+
+func validateStorageURI(storageURI *string) error {
+	if storageURI == nil {
+		return nil
+	}
+
+	// local path (not some protocol?)
+	if !regexp.MustCompile("\\w+?://").MatchString(*storageURI) {
+		return nil
+	}
+
+	// one of the prefixes we know?
+	for _, prefix := range SupportedStorageURIPrefixList {
+		if strings.HasPrefix(*storageURI, prefix) {
+			return nil
+		}
+	}
+
+	azureURIMatcher := regexp.MustCompile(AzureBlobURIRegEx)
+	if parts := azureURIMatcher.FindStringSubmatch(*storageURI); parts != nil {
+		return nil
+	}
+
+	return fmt.Errorf(UnsupportedStorageURIFormatError, strings.Join(SupportedStorageURIPrefixList, ", "), *storageURI)
+}
+
+func validateReplicas(minReplicas *int, maxReplicas int) error {
+	if minReplicas == nil {
+		minReplicas = &constants.DefaultMinReplicas
+	}
+	if *minReplicas < 0 {
+		return fmt.Errorf(MinReplicasLowerBoundExceededError)
+	}
+	if maxReplicas < 0 {
+		return fmt.Errorf(MaxReplicasLowerBoundExceededError)
+	}
+	if *minReplicas > maxReplicas && maxReplicas != 0 {
+		return fmt.Errorf(MinReplicasShouldBeLessThanMaxError)
+	}
+	return nil
+}
+
+func validateContainerConcurrency(containerConcurrency *int64) error {
+	if containerConcurrency == nil {
+		return nil
+	}
+	if *containerConcurrency < 0 {
+		return fmt.Errorf(ParallelismLowerBoundExceededError)
+	}
+	return nil
+}
+
+func validateLogger(logger *LoggerSpec) error {
+	if logger != nil {
+		if !(logger.Mode == LogAll || logger.Mode == LogRequest || logger.Mode == LogResponse) {
+			return fmt.Errorf(InvalidLoggerType)
+		}
+	}
+	return nil
+}
+
+// FirstNonNilComponent returns the first non nil object or returns nil
+func FirstNonNilComponent(objects []ComponentImplementation) ComponentImplementation {
+	if results := NonNilComponents(objects); len(results) > 0 {
+		return results[0]
+	}
+	return nil
+}
+
+// NonNilComponents returns components that are not nil
+func NonNilComponents(objects []ComponentImplementation) (results []ComponentImplementation) {
+	for _, object := range objects {
+		if !reflect.ValueOf(object).IsNil() {
+			results = append(results, object)
+		}
+	}
+	return results
 }

--- a/pkg/apis/serving/v1beta1/explainer_alibi_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi_test.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -8,7 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestAlibiValidation(t *testing.T) {
@@ -80,7 +81,7 @@ func TestAlibiValidation(t *testing.T) {
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
 			scenario.spec.Alibi.Default(&config)
-			res := scenario.spec.Validate()
+			res := scenario.spec.Alibi.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -334,9 +335,9 @@ func TestCreateAlibiModelServingContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			explainer := scenario.isvc.Spec.Explainer.GetExplainer()[0]
+			explainer := scenario.isvc.Spec.Explainer.GetImplementation()
 			explainer.Default(&config)
-			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, scenario.isvc.Spec.Explainer.ContainerConcurrency, &config)
+			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/explainer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom_test.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -8,7 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestCustomExplainerValidation(t *testing.T) {
@@ -117,7 +118,7 @@ func TestCustomExplainerValidation(t *testing.T) {
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
 			scenario.spec.CustomExplainer.Default(&config)
-			res := scenario.spec.Validate()
+			res := scenario.spec.CustomExplainer.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -345,9 +346,9 @@ func TestCreateCustomExplainerContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			explainer := scenario.isvc.Spec.Explainer.GetExplainer()[0]
+			explainer := scenario.isvc.Spec.Explainer.GetImplementation()
 			explainer.Default(&config)
-			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, scenario.isvc.Spec.Explainer.ContainerConcurrency, &config)
+			res := explainer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Explainer.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/inference_service.go
+++ b/pkg/apis/serving/v1beta1/inference_service.go
@@ -35,32 +35,6 @@ type InferenceServiceSpec struct {
 	Transformer *TransformerSpec `json:"transformer,omitempty"`
 }
 
-// ComponentExtensionSpec defines the deployment configuration for a given InferenceService component
-type ComponentExtensionSpec struct {
-	// Minimum number of replicas, defaults to 1 but can be set to 0 to enable scale-to-zero.
-	// +optional
-	MinReplicas *int `json:"minReplicas,omitempty"`
-	// Maximum number of replicas for autoscaling.
-	// +optional
-	MaxReplicas int `json:"maxReplicas,omitempty"`
-	// ContainerConcurrency specifies how many requests can be processed concurrently, this sets the hard limit of the container
-	// concurrency(https://knative.dev/docs/serving/autoscaling/concurrency).
-	// +optional
-	ContainerConcurrency *int64 `json:"containerConcurrency,omitempty"`
-	// TimeoutSeconds specifies the number of seconds to wait before timing out a request to the component.
-	// +optional
-	TimeoutSeconds *int64 `json:"timeout,omitempty"`
-	// CanaryTrafficPercent defines the traffic split percentage between the candidate revision and the last ready revision
-	// +optional
-	CanaryTrafficPercent *int `json:"canaryTrafficPercent,omitempty"`
-	// Activate request/response logging and logger configurations
-	// +optional
-	LoggerSpec *LoggerSpec `json:"logger,omitempty"`
-	// Activate request batching and batching configurations
-	// +optional
-	Batcher *Batcher `json:"batcher,omitempty"`
-}
-
 // LoggerType controls the scope of log publishing
 // +kubebuilder:validation:Enum=all;request;response
 type LoggerType string

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -17,9 +17,7 @@ limitations under the License.
 package v1beta1
 
 import (
-	"fmt"
 	"reflect"
-	"strings"
 
 	"github.com/kubeflow/kfserving/pkg/utils"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -75,37 +73,4 @@ func (isvc *InferenceService) ValidateDelete() error {
 func GetIntReference(number int) *int {
 	num := number
 	return &num
-}
-
-func validateExactlyOneImplementation(component Component) error {
-	implementations := NonNilComponents(component.GetImplementations())
-	count := len(implementations)
-	if count == 2 { // If two implementations, allow if one of them is custom overrides
-		for _, implementation := range implementations {
-			switch reflect.ValueOf(implementation).Type().Elem().Name() {
-			case
-				reflect.ValueOf(CustomPredictor{}).Type().Name(),
-				reflect.ValueOf(CustomExplainer{}).Type().Name(),
-				reflect.ValueOf(CustomTransformer{}).Type().Name():
-				return nil
-			}
-		}
-	} else if count == 1 {
-		return nil
-	}
-	return ExactlyOneErrorFor(component)
-}
-
-// ExactlyOneErrorFor creates an error for the component's one-of semantic.
-func ExactlyOneErrorFor(component Component) error {
-	componentType := reflect.ValueOf(component).Type().Elem()
-	implementationTypes := []string{}
-	for i := 0; i < componentType.NumField()-1; i++ {
-		implementationTypes = append(implementationTypes, componentType.Field(i).Type.Elem().Name())
-	}
-	return fmt.Errorf(
-		"Exactly one of [%s] must be specified in %s",
-		strings.Join(implementationTypes, ", "),
-		componentType.Name(),
-	)
 }

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -18,29 +18,16 @@ package v1beta1
 
 import (
 	"fmt"
-	"github.com/kubeflow/kfserving/pkg/constants"
-	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/runtime"
 	"reflect"
-	"regexp"
+	"strings"
+
+	"github.com/kubeflow/kfserving/pkg/utils"
+	"k8s.io/apimachinery/pkg/runtime"
 	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
 	"sigs.k8s.io/controller-runtime/pkg/webhook"
-	"strings"
-)
-
-// Known error messages
-const (
-	MinReplicasShouldBeLessThanMaxError = "MinReplicas cannot be greater than MaxReplicas."
-	MinReplicasLowerBoundExceededError  = "MinReplicas cannot be less than 0."
-	MaxReplicasLowerBoundExceededError  = "MaxReplicas cannot be less than 0."
-	ParallelismLowerBoundExceededError  = "Parallelism cannot be less than 0."
-	UnsupportedStorageURIFormatError    = "storageUri, must be one of: [%s] or match https://{}.blob.core.windows.net/{}/{} or be an absolute or relative local path. StorageUri [%s] is not supported."
-	InvalidLoggerType                   = "Invalid logger type"
 )
 
 var (
-	SupportedStorageURIPrefixList = []string{"gs://", "s3://", "pvc://", "file://"}
-	AzureBlobURIRegEx             = "https://(.+?).blob.core.windows.net/(.+)"
 	// logger for the validation webhook.
 	validatorLogger = logf.Log.WithName("inferenceservice-v1beta1-validation-webhook")
 )
@@ -51,30 +38,19 @@ var _ webhook.Validator = &InferenceService{}
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type
 func (isvc *InferenceService) ValidateCreate() error {
 	validatorLogger.Info("validate create", "name", isvc.Name)
-
-	predictors := isvc.Spec.Predictor.GetPredictor()
-	if len(predictors) != 1 {
-		return fmt.Errorf(ExactlyOnePredictorViolatedError)
-	}
-	if isvc.Spec.Transformer != nil {
-		transformers := isvc.Spec.Transformer.GetTransformer()
-		if len(transformers) != 1 {
-			return fmt.Errorf(ExactlyOneTransformerViolatedError)
-		}
-	}
-	if isvc.Spec.Explainer != nil {
-		explainers := isvc.Spec.Explainer.GetExplainer()
-		if len(explainers) != 1 {
-			return fmt.Errorf(ExactlyOneExplainerViolatedError)
-		}
-	}
 	for _, component := range []Component{
 		&isvc.Spec.Predictor,
 		isvc.Spec.Transformer,
 		isvc.Spec.Explainer,
 	} {
 		if !reflect.ValueOf(component).IsNil() {
-			if err := component.Validate(); err != nil {
+			if len(NonNilComponents(component.GetImplementations())) != 1 {
+				return ExactlyOneErrorFor(component)
+			}
+			if err := utils.FirstNonNilError([]error{
+				component.GetImplementation().Validate(),
+				component.GetExtensions().Validate(),
+			}); err != nil {
 				return err
 			}
 		}
@@ -95,73 +71,22 @@ func (isvc *InferenceService) ValidateDelete() error {
 	return nil
 }
 
-func validateStorageURI(storageURI *string) error {
-	if storageURI == nil {
-		return nil
-	}
-
-	// local path (not some protocol?)
-	if !regexp.MustCompile("\\w+?://").MatchString(*storageURI) {
-		return nil
-	}
-
-	// one of the prefixes we know?
-	for _, prefix := range SupportedStorageURIPrefixList {
-		if strings.HasPrefix(*storageURI, prefix) {
-			return nil
-		}
-	}
-
-	azureURIMatcher := regexp.MustCompile(AzureBlobURIRegEx)
-	if parts := azureURIMatcher.FindStringSubmatch(*storageURI); parts != nil {
-		return nil
-	}
-
-	return fmt.Errorf(UnsupportedStorageURIFormatError, strings.Join(SupportedStorageURIPrefixList, ", "), *storageURI)
-}
-
-func validateReplicas(minReplicas *int, maxReplicas int) error {
-	if minReplicas == nil {
-		minReplicas = &constants.DefaultMinReplicas
-	}
-	if *minReplicas < 0 {
-		return fmt.Errorf(MinReplicasLowerBoundExceededError)
-	}
-	if maxReplicas < 0 {
-		return fmt.Errorf(MaxReplicasLowerBoundExceededError)
-	}
-	if *minReplicas > maxReplicas && maxReplicas != 0 {
-		return fmt.Errorf(MinReplicasShouldBeLessThanMaxError)
-	}
-	return nil
-}
-
-func validateContainerConcurrency(containerConcurrency *int64) error {
-	if containerConcurrency == nil {
-		return nil
-	}
-	if *containerConcurrency < 0 {
-		return fmt.Errorf(ParallelismLowerBoundExceededError)
-	}
-	return nil
-}
-
-func isGPUEnabled(requirements v1.ResourceRequirements) bool {
-	_, ok := requirements.Limits[constants.NvidiaGPUResourceType]
-	return ok
-}
-
-func validateLogger(logger *LoggerSpec) error {
-	if logger != nil {
-		if !(logger.Mode == LogAll || logger.Mode == LogRequest || logger.Mode == LogResponse) {
-			return fmt.Errorf(InvalidLoggerType)
-		}
-	}
-	return nil
-}
-
 // GetIntReference returns the pointer for the integer input
 func GetIntReference(number int) *int {
 	num := number
 	return &num
+}
+
+// ExactlyOneErrorFor creates an error for the component's one-of semantic.
+func ExactlyOneErrorFor(component Component) error {
+	componentType := reflect.ValueOf(component).Type().Elem()
+	implementationTypes := []string{}
+	for i := 0; i < componentType.NumField()-1; i++ {
+		implementationTypes = append(implementationTypes, componentType.Field(i).Type.Elem().Name())
+	}
+	return fmt.Errorf(
+		"Exactly one of [%s] must be specified in %s",
+		strings.Join(implementationTypes, ", "),
+		componentType.Name(),
+	)
 }

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -113,18 +113,19 @@ func TestUnkownStorageURIPrefixFails(t *testing.T) {
 func TestRejectMultipleModelSpecs(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	isvc := makeTestInferenceService()
+	isvc.Spec.Predictor.XGBoost = &XGBoostSpec{}
+	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneErrorFor(&isvc.Spec.Predictor)))
+}
+
+func TestModelSpecAndCustomOverridesIsValid(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	isvc := makeTestInferenceService()
 	isvc.Spec.Predictor.CustomPredictor = &CustomPredictor{
 		PodTemplateSpec: v1.PodTemplateSpec{
-			Spec: v1.PodSpec{
-				Containers: []v1.Container{
-					{
-						Image: "some-image",
-					},
-				},
-			},
+			Spec: v1.PodSpec{},
 		},
 	}
-	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneErrorFor(&isvc.Spec.Predictor)))
+	g.Expect(isvc.ValidateCreate()).Should(gomega.Succeed())
 }
 
 func TestRejectModelSpecMissing(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -18,8 +18,9 @@ package v1beta1
 
 import (
 	"fmt"
-	"github.com/golang/protobuf/proto"
 	"testing"
+
+	"github.com/golang/protobuf/proto"
 
 	"github.com/onsi/gomega"
 	v1 "k8s.io/api/core/v1"
@@ -123,14 +124,14 @@ func TestRejectMultipleModelSpecs(t *testing.T) {
 			},
 		},
 	}
-	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOnePredictorViolatedError))
+	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneErrorFor(&isvc.Spec.Predictor)))
 }
 
 func TestRejectModelSpecMissing(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	isvc := makeTestInferenceService()
 	isvc.Spec.Predictor.Tensorflow = nil
-	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOnePredictorViolatedError))
+	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneErrorFor(&isvc.Spec.Predictor)))
 }
 
 func TestBadParallelismValues(t *testing.T) {
@@ -217,14 +218,14 @@ func TestRejectBadTransformer(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	isvc := makeTestInferenceService()
 	isvc.Spec.Transformer = &TransformerSpec{}
-	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneTransformerViolatedError))
+	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneErrorFor(isvc.Spec.Transformer)))
 }
 
 func TestRejectBadExplainer(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	isvc := makeTestInferenceService()
 	isvc.Spec.Explainer = &ExplainerSpec{}
-	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneExplainerViolatedError))
+	g.Expect(isvc.ValidateCreate()).Should(gomega.MatchError(ExactlyOneErrorFor(isvc.Spec.Explainer)))
 }
 
 func TestGoodExplainer(t *testing.T) {

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -8,7 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestCustomPredictorValidation(t *testing.T) {
@@ -114,7 +115,7 @@ func TestCustomPredictorValidation(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res := scenario.spec.Validate()
+			res := scenario.spec.CustomPredictor.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -326,9 +327,9 @@ func TestCreateCustomPredictorContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			predictor := scenario.isvc.Spec.Predictor.GetPredictor()[0]
+			predictor := scenario.isvc.Spec.Predictor.GetImplementation()
 			predictor.Default(&config)
-			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, scenario.isvc.Spec.Predictor.ContainerConcurrency, &config)
+			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Predictor.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -18,8 +18,10 @@ package v1beta1
 
 import (
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -36,11 +38,13 @@ type ONNXRuntimeSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ Component = &ONNXRuntimeSpec{}
+var _ ComponentImplementation = &ONNXRuntimeSpec{}
 
 // Validate returns an error if invalid
 func (o *ONNXRuntimeSpec) Validate() error {
-	return nil
+	return utils.FirstNonNilError([]error{
+		validateStorageURI(o.GetStorageUri()),
+	})
 }
 
 // Default sets defaults on the resource
@@ -53,7 +57,7 @@ func (o *ONNXRuntimeSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainers transforms the resource into a container spec
-func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, containerConcurrency *int64, config *InferenceServicesConfig) *v1.Container {
+func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
 	arguments := []string{
 		fmt.Sprintf("%s=%s", "--model_path", constants.DefaultModelLocalMountPath+"/"+ONNXModelFileName),
 		fmt.Sprintf("%s=%s", "--http_port", ONNXServingRestPort),

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -97,7 +98,7 @@ func TestOnnxRuntimeValidation(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res := scenario.spec.Validate()
+			res := scenario.spec.ONNX.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -302,8 +303,8 @@ func TestCreateONNXRuntimeContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			predictor := scenario.isvc.Spec.Predictor.GetPredictor()[0]
-			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, scenario.isvc.Spec.Predictor.ContainerConcurrency, &config)
+			predictor := scenario.isvc.Spec.Predictor.GetImplementation()
+			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, &scenario.isvc.Spec.Predictor.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/predictor_sklearn.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn.go
@@ -18,11 +18,13 @@ package v1beta1
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 // SKLearnSpec defines arguments for configuring SKLearn model serving.
@@ -31,11 +33,13 @@ type SKLearnSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ Component = &SKLearnSpec{}
+var _ ComponentImplementation = &SKLearnSpec{}
 
 // Validate returns an error if invalid
 func (k *SKLearnSpec) Validate() error {
-	return nil
+	return utils.FirstNonNilError([]error{
+		validateStorageURI(k.GetStorageUri()),
+	})
 }
 
 // Default sets defaults on the resource
@@ -48,14 +52,14 @@ func (k *SKLearnSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainer transforms the resource into a container spec
-func (k *SKLearnSpec) GetContainer(metadata metav1.ObjectMeta, containerConcurrency *int64, config *InferenceServicesConfig) *v1.Container {
+func (k *SKLearnSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
 	arguments := []string{
 		fmt.Sprintf("%s=%s", constants.ArgumentModelName, metadata.Name),
 		fmt.Sprintf("%s=%s", constants.ArgumentModelDir, constants.DefaultModelLocalMountPath),
 		fmt.Sprintf("%s=%s", constants.ArgumentHttpPort, constants.InferenceServiceDefaultHttpPort),
 	}
-	if containerConcurrency != nil {
-		arguments = append(arguments, fmt.Sprintf("%s=%s", constants.ArgumentWorkers, strconv.FormatInt(*containerConcurrency, 10)))
+	if extensions.ContainerConcurrency != nil {
+		arguments = append(arguments, fmt.Sprintf("%s=%s", constants.ArgumentWorkers, strconv.FormatInt(*extensions.ContainerConcurrency, 10)))
 	}
 	if k.Container.Image == "" {
 		k.Container.Image = config.Predictors.SKlearn.ContainerImage + ":" + *k.RuntimeVersion

--- a/pkg/apis/serving/v1beta1/predictor_sklearn_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -97,7 +98,7 @@ func TestSKLearnValidation(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res := scenario.spec.Validate()
+			res := scenario.spec.SKLearn.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -303,9 +304,9 @@ func TestCreateSKLearnModelServingContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			predictor := scenario.isvc.Spec.Predictor.GetPredictor()[0]
+			predictor := scenario.isvc.Spec.Predictor.GetImplementation()
 			predictor.Default(&config)
-			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, scenario.isvc.Spec.Predictor.ContainerConcurrency, &config)
+			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, &scenario.isvc.Spec.Predictor.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/predictor_tfserving_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving_test.go
@@ -18,9 +18,10 @@ package v1beta1
 
 import (
 	"fmt"
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -132,7 +133,7 @@ func TestTensorflowValidation(t *testing.T) {
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
 			scenario.spec.Tensorflow.Default(&config)
-			res := scenario.spec.Validate()
+			res := scenario.spec.Tensorflow.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -374,9 +375,9 @@ func TestCreateTFServingContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			predictor := scenario.isvc.Spec.Predictor.GetPredictor()[0]
+			predictor := scenario.isvc.Spec.Predictor.GetImplementation()
 			predictor.Default(&config)
-			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, scenario.isvc.Spec.Predictor.ContainerConcurrency, &config)
+			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, &scenario.isvc.Spec.Predictor.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/predictor_torchserve.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve.go
@@ -18,7 +18,9 @@ package v1beta1
 
 import (
 	"fmt"
+
 	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -33,7 +35,9 @@ type TorchServeSpec struct {
 
 // Validate returns an error if invalid
 func (t *TorchServeSpec) Validate() error {
-	return nil
+	return utils.FirstNonNilError([]error{
+		validateStorageURI(t.GetStorageUri()),
+	})
 }
 
 // Default sets defaults on the resource
@@ -45,7 +49,7 @@ func (t *TorchServeSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainers transforms the resource into a container spec
-func (t *TorchServeSpec) GetContainer(metadata metav1.ObjectMeta, containerConcurrency *int64, config *InferenceServicesConfig) *v1.Container {
+func (t *TorchServeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
 	arguments := []string{
 		"torchserve",
 		"--start",

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -18,8 +18,10 @@ package v1beta1
 
 import (
 	"fmt"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
@@ -35,11 +37,13 @@ type TritonSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ Component = &TritonSpec{}
+var _ ComponentImplementation = &TritonSpec{}
 
 // Validate returns an error if invalid
 func (t *TritonSpec) Validate() error {
-	return nil
+	return utils.FirstNonNilError([]error{
+		validateStorageURI(t.GetStorageUri()),
+	})
 }
 
 // Default sets defaults on the resource
@@ -52,7 +56,7 @@ func (t *TritonSpec) Default(config *InferenceServicesConfig) {
 }
 
 // GetContainers transforms the resource into a container spec
-func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, containerConcurrency *int64, config *InferenceServicesConfig) *v1.Container {
+func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
 	arguments := []string{
 		fmt.Sprintf("%s=%s", "--model-store", constants.DefaultModelLocalMountPath),
 		fmt.Sprintf("%s=%s", "--grpc-port", fmt.Sprint(TritonISGRPCPort)),
@@ -61,8 +65,8 @@ func (t *TritonSpec) GetContainer(metadata metav1.ObjectMeta, containerConcurren
 		fmt.Sprintf("%s=%s", "--allow-grpc", "true"),
 		fmt.Sprintf("%s=%s", "--allow-http", "true"),
 	}
-	if containerConcurrency != nil {
-		arguments = append(arguments, fmt.Sprintf("%s=%d", "--http-thread-count", *containerConcurrency))
+	if extensions.ContainerConcurrency != nil {
+		arguments = append(arguments, fmt.Sprintf("%s=%d", "--http-thread-count", *extensions.ContainerConcurrency))
 	}
 	if t.Container.Image == "" {
 		t.Container.Image = config.Predictors.Triton.ContainerImage + ":" + *t.RuntimeVersion

--- a/pkg/apis/serving/v1beta1/predictor_triton_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -97,7 +98,7 @@ func TestTritonValidation(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res := scenario.spec.Validate()
+			res := scenario.spec.Triton.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -321,9 +322,9 @@ func TestCreateTritonContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			predictor := scenario.isvc.Spec.Predictor.GetPredictor()[0]
+			predictor := scenario.isvc.Spec.Predictor.GetImplementation()
 			predictor.Default(&config)
-			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, scenario.isvc.Spec.Predictor.ContainerConcurrency, &config)
+			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, &scenario.isvc.Spec.Predictor.DeepCopy().ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/predictor_xgboost_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_xgboost_test.go
@@ -17,9 +17,10 @@ limitations under the License.
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -97,7 +98,7 @@ func TestXGBoostValidation(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res := scenario.spec.Validate()
+			res := scenario.spec.XGBoost.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -303,9 +304,9 @@ func TestCreateXGBoostModelServingContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			predictor := scenario.isvc.Spec.Predictor.GetPredictor()[0]
+			predictor := scenario.isvc.Spec.Predictor.GetImplementation()
 			predictor.Default(&config)
-			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, scenario.isvc.Spec.Predictor.ContainerConcurrency, &config)
+			res := predictor.GetContainer(metav1.ObjectMeta{Name: "someName"}, &scenario.isvc.Spec.Predictor.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/apis/serving/v1beta1/transformer.go
+++ b/pkg/apis/serving/v1beta1/transformer.go
@@ -16,11 +16,6 @@ limitations under the License.
 
 package v1beta1
 
-// Constants
-const (
-	ExactlyOneTransformerViolatedError = "Exactly one of [Custom] must be specified in TransformerSpec"
-)
-
 // TransformerSpec defines transformer service for pre/post processing
 type TransformerSpec struct {
 	// Pass through Pod fields or specify a custom container spec
@@ -29,27 +24,19 @@ type TransformerSpec struct {
 	ComponentExtensionSpec `json:",inline"`
 }
 
-func (t *TransformerSpec) GetTransformer() []Component {
-	transformers := []Component{}
-	if t.CustomTransformer != nil {
-		transformers = append(transformers, t.CustomTransformer)
+// GetImplementations returns the implementations for the component
+func (s *TransformerSpec) GetImplementations() []ComponentImplementation {
+	return []ComponentImplementation{
+		s.CustomTransformer,
 	}
-	return transformers
 }
 
-// Validate the TransformerSpec
-func (t *TransformerSpec) Validate() error {
-	transformer := t.GetTransformer()[0]
-	for _, err := range []error{
-		transformer.Validate(),
-		validateStorageURI(transformer.GetStorageUri()),
-		validateContainerConcurrency(t.ContainerConcurrency),
-		validateReplicas(t.MinReplicas, t.MaxReplicas),
-		validateLogger(t.LoggerSpec),
-	} {
-		if err != nil {
-			return err
-		}
-	}
-	return nil
+// GetImplementation returns the implementation for the component
+func (s *TransformerSpec) GetImplementation() ComponentImplementation {
+	return FirstNonNilComponent(s.GetImplementations())
+}
+
+// GetExtensions returns the extensions for the component
+func (s *TransformerSpec) GetExtensions() *ComponentExtensionSpec {
+	return &s.ComponentExtensionSpec
 }

--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -17,10 +17,12 @@ limitations under the License.
 package v1beta1
 
 import (
+	"strconv"
+
 	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"strconv"
 )
 
 // CustomTransformer defines arguments for configuring a custom transformer.
@@ -33,11 +35,13 @@ type CustomTransformer struct {
 	v1.PodTemplateSpec `json:",inline"`
 }
 
-var _ Component = &CustomTransformer{}
+var _ ComponentImplementation = &CustomTransformer{}
 
 // Validate returns an error if invalid
 func (c *CustomTransformer) Validate() error {
-	return nil
+	return utils.FirstNonNilError([]error{
+		validateStorageURI(c.GetStorageUri()),
+	})
 }
 
 // Default sets defaults on the resource
@@ -60,7 +64,7 @@ func (c *CustomTransformer) GetStorageUri() *string {
 }
 
 // GetContainers transforms the resource into a container spec
-func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, containerConcurrency *int64, config *InferenceServicesConfig) *v1.Container {
+func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
 	container := &c.Spec.Containers[0]
 	modelNameExists := false
 	for _, arg := range container.Args {
@@ -80,8 +84,8 @@ func (c *CustomTransformer) GetContainer(metadata metav1.ObjectMeta, containerCo
 		constants.ArgumentHttpPort,
 		constants.InferenceServiceDefaultHttpPort,
 	}...)
-	if containerConcurrency != nil {
-		container.Args = append(container.Args, constants.ArgumentWorkers, strconv.FormatInt(*containerConcurrency, 10))
+	if extensions.ContainerConcurrency != nil {
+		container.Args = append(container.Args, constants.ArgumentWorkers, strconv.FormatInt(*extensions.ContainerConcurrency, 10))
 	}
 	return &c.Spec.Containers[0]
 }

--- a/pkg/apis/serving/v1beta1/transformer_custom_test.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom_test.go
@@ -1,6 +1,8 @@
 package v1beta1
 
 import (
+	"testing"
+
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/onsi/gomega"
@@ -8,7 +10,6 @@ import (
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/resource"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"testing"
 )
 
 func TestTransformerValidation(t *testing.T) {
@@ -114,7 +115,7 @@ func TestTransformerValidation(t *testing.T) {
 
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			res := scenario.spec.Validate()
+			res := scenario.spec.CustomTransformer.Validate()
 			if !g.Expect(res).To(scenario.matcher) {
 				t.Errorf("got %q, want %q", res, scenario.matcher)
 			}
@@ -342,9 +343,9 @@ func TestCreateTransformerContainer(t *testing.T) {
 	}
 	for name, scenario := range scenarios {
 		t.Run(name, func(t *testing.T) {
-			transformer := scenario.isvc.Spec.Transformer.GetTransformer()[0]
+			transformer := scenario.isvc.Spec.Transformer.GetImplementation()
 			transformer.Default(&config)
-			res := transformer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, scenario.isvc.Spec.Transformer.ContainerConcurrency, &config)
+			res := transformer.GetContainer(metav1.ObjectMeta{Name: "someName", Namespace: "default"}, &scenario.isvc.Spec.Transformer.ComponentExtensionSpec, &config)
 			if !g.Expect(res).To(gomega.Equal(scenario.expectedContainerSpec)) {
 				t.Errorf("got %q, want %q", res, scenario.expectedContainerSpec)
 			}

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -16,7 +16,10 @@ limitations under the License.
 
 package utils
 
-import v1 "k8s.io/api/core/v1"
+import (
+	"github.com/kubeflow/kfserving/pkg/constants"
+	v1 "k8s.io/api/core/v1"
+)
 
 /* NOTE TO AUTHORS:
  *
@@ -60,4 +63,19 @@ func AppendVolumeIfNotExists(slice []v1.Volume, volume v1.Volume) []v1.Volume {
 		}
 	}
 	return append(slice, volume)
+}
+
+func IsGPUEnabled(requirements v1.ResourceRequirements) bool {
+	_, ok := requirements.Limits[constants.NvidiaGPUResourceType]
+	return ok
+}
+
+// FirstNonNilError returns the first non nil interface in the slice
+func FirstNonNilError(objects []error) error {
+	for _, object := range objects {
+		if object != nil {
+			return object
+		}
+	}
+	return nil
 }


### PR DESCRIPTION
Fast follow from Dan's v1beta1 PR.

1. Cleaned up GetComponent() validation and accessor logic.
2. Broke apart Component and Implementation abstraction from a dual purpose Component abstraction.
3. Abstracted validation logic to the ComponentImplementation level, rather than both Component and Implementation.
4. Added Validation/Defaulting extension points per Component
5. Automated error messages for one-of semantic ```Exactly one of [SKLearnSpec, XGBoostSpec, TFServingSpec, TorchServeSpec, TritonSpec, ONNXRuntimeSpec, CustomPredictor] must be specified in PredictorSpec```
6. GetContainer now takes the full extension spec instead of just containerconcurrency.