### PR TITLE
Add S3 access key format for prior version of KFServing

### DIFF
--- a/docs/samples/s3/README.md
+++ b/docs/samples/s3/README.md
@@ -37,11 +37,15 @@ metadata:
      serving.kubeflow.org/s3-usehttps: "0" # by default 1, for testing with minio you need to set to 0
 type: Opaque
 stringData:
+# Before KFServing 0.3
+  awsAccessKeyID: XXXX
+  awsSecretAccessKey: XXXXXXXX
+# KFServing 0.4
   AWS_ACCESS_KEY_ID: XXXX
   AWS_SECRET_ACCESS_KEY: XXXXXXXX
 ```
 
-`KFServing` gets the secrets from your service account, you need to add the above created or existing secret to your service account's secret list. 
+`KFServing` gets the secrets from your service account, you need to add the above created or existing secret to your service account's secret list.
 By default `KFServing` uses `default` service account, user can use own service account and overwrite on `InferenceService` CRD.
 
 ```yaml
@@ -61,7 +65,7 @@ kubectl apply -f s3_secret.yaml
 ## Create the InferenceService
 Apply the CRD
 ```bash
-kubectl apply -f tensorflow_s3.yaml 
+kubectl apply -f tensorflow_s3.yaml
 ```
 
 Expected Output
@@ -90,7 +94,7 @@ Expected Output
 > Content-Length: 2052
 > Content-Type: application/x-www-form-urlencoded
 > Expect: 100-continue
-> 
+>
 < HTTP/1.1 100 Continue
 * We are completely uploaded and fine
 
@@ -100,7 +104,7 @@ Expected Output
 < date: Thu, 23 May 2019 01:33:08 GMT
 < server: istio-envoy
 < x-envoy-upstream-service-time: 20536
-< 
+<
 {
     "predictions": [
         {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Kubeflow manifests repository's master branch is configured with KFServing version 0.3. And current kfserving s3 sample document is working with KFServing version 0.4 but not with before version 0.3. So, I would like to supply additional configuration information with this PR. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #None

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.
None

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
