### PR TITLE
Docs/custom domain

### DIFF
--- a/docs/samples/custom-domain/README.md
+++ b/docs/samples/custom-domain/README.md
@@ -73,11 +73,10 @@ $ ingress.networking.k8s.io/kfserving-ingress created
 
 ## Verify 
 
-You can call your models using your custom domain by passing the `Host` header and supplying the correct subdomain. For example if you deploy the sample [sklearn model](https://github.com/kubeflow/kfserving/tree/master/docs/samples/sklearn) in the `default` namespace using `customdomain.com`, you can reach it in the following way
+You can call your models using your custom top-level domain with the correct subdomain. For example if you deploy the sample [sklearn model](https://github.com/kubeflow/kfserving/tree/master/docs/samples/sklearn) in the `default` namespace using `customdomain.com`, you can reach it in the following way
 
 ```
 curl -v \
-    -H "Host: sklearn-iris.default.customdomain.com" \
     http://sklearn-iris.default.customdomain.com/v1/models/sklearn-iris:predict \
     -d @./input.json
 ```

--- a/docs/samples/custom-domain/README.md
+++ b/docs/samples/custom-domain/README.md
@@ -39,7 +39,7 @@ configmap/config-domain edited
 
 ## Create the Ingress resource
 
-#### Note: This step is only necessary if you are configuring a domain to route incoming traffic to a Kubernetes Ingress. For example, many cloud platforms provide default domains which route to a Kuberenetes Ingress. If you inted to route a domain directly to the `istio-ingressgateway`, you can skip this step.
+#### Note: This step is only necessary if you are configuring a domain to route incoming traffic to a Kubernetes Ingress. For example, many cloud platforms provide default domains which route to a Kuberenetes Ingress. If you intend to route a domain directly to the `istio-ingressgateway`, you can skip this step.
 
 Edit the `kfserving-ingress.yaml` file to add your custom wildcard domain to the `spec.rules.host` section, replacing `<*.custom_domain>` with your custom wildcard domain. This is so that all incoming network traffic from your custom domain and any subdomain is routed to the `istio-ingressgateway`.
 

--- a/docs/samples/custom-domain/README.md
+++ b/docs/samples/custom-domain/README.md
@@ -1,49 +1,18 @@
 # Setting up custom domain name
 
+## Motivation
+
+A custom domain is useful in a microservice architecture when you want to expose kfserving outside of kubernetes to other compute resources under a semantic domain. This works especially well in cases where you are using a cloud-provided [Ingress Controller](https://kubernetes.io/docs/concepts/services-networking/ingress-controllers/) with [External DNS](https://github.com/kubernetes-sigs/external-dns) to dynamically create DNS records and route traffic to your models.
+
 ## Setup
 
 1. Your ~/.kube/config should point to a cluster with [KFServing installed](https://github.com/kubeflow/kfserving/#install-kfserving).
 2. Your cluster's Istio Ingress gateway must be network accessible.
-3. You have a custom domain configured to route incoming traffic either to the Cloud provided Kubernetes Ingress gateway or the istio-ingressgateway's IP address / Load Balancer.
-
-## Create the Ingress resource
-
-#### Note: This step is only necessary if using a domain that is configured to route incoming traffic to the cluster's Kubernetes Ingress. For example, many cloud platforms provide default domains which route to a Kuberenetes Ingress. If using a domain that is routed to the `istio-ingressgateway`, you can skip this step.
-
-Edit the `kfserving-ingress.yaml` file to add your custom wildcard domain to the `spec.rules.host` section, replacing `<*.custom_domain>` with your custom wildcard domain. This is so that all incoming network traffic from your custom domain and any subdomain is routed to the `istio-ingressgateway`.
-
-```
-apiVersion: networking.k8s.io/v1beta1
-kind: Ingress
-metadata:
-  name: kfserving-ingress
-  namespace: istio-system
-spec:
-  rules:
-    - host: "<*.custom_domain>"
-      http:
-        paths:
-          - backend:
-              serviceName: istio-ingressgateway
-              servicePort: 80
-            path: /
-```
-
-Apply the Ingress resource
-
-```
-kubectl apply -f kfserving-ingress.yaml
-```
-
-Expected Output
-
-```
-$ ingress.networking.k8s.io/kfserving-ingress created
-```
+3. You own a domain that can be configured to route incoming traffic to a cloud provided kubernetes `Ingress` or the istio-ingressgateway's IP address / Load Balancer.
 
 ## Modify the config-domain Configmap
 
-Modify the config map to use your custom domain when assigning hostnames to Knative services.
+Modify the config map to use your custom domain when assigning hostnames to Knative services. By default, kfserving uses `example.com`.
 
 Open the `config-domain` configmap to start editing it.
 
@@ -68,56 +37,64 @@ Save your changes. Expected Output
 configmap/config-domain edited
 ```
 
-With your Ingress routing rules and Knative configmaps set up, you can create Knative services that use your custom domain.
+## Create the Ingress resource
 
-## Create a sample InferenceService
+#### Note: This step is only necessary if you are configuring a domain to route incoming traffic to a Kubernetes Ingress. For example, many cloud platforms provide default domains which route to a Kuberenetes Ingress. If you inted to route a domain directly to the `istio-ingressgateway`, you can skip this step.
 
-To create an InferenceService using Tensorflow, refer to the [guide](/docs/samples/tensorflow).
-
-## Run a prediction
+Edit the `kfserving-ingress.yaml` file to add your custom wildcard domain to the `spec.rules.host` section, replacing `<*.custom_domain>` with your custom wildcard domain. This is so that all incoming network traffic from your custom domain and any subdomain is routed to the `istio-ingressgateway`.
 
 ```
-MODEL_NAME=flowers-sample
-INPUT_PATH=@./input.json
-SERVICE_HOSTNAME=$(kubectl get inferenceservice ${MODEL_NAME} -o jsonpath='{.status.url}')
+apiVersion: networking.k8s.io/v1beta1
+kind: Ingress
+metadata:
+  name: kfserving-ingress
+  namespace: istio-system
+spec:
+  rules:
+    - host: "<*.custom_domain>"
+      http:
+        paths:
+          - backend:
+              serviceName: istio-ingressgateway
+              servicePort: 80
+```
 
-curl -v $SERVICE_HOSTNAME:predict -d $INPUT_PATH
+Apply the Ingress resource
+
+```
+kubectl apply -f kfserving-ingress.yaml
 ```
 
 Expected Output
 
 ```
-*   Trying 34.83.190.188...
-* TCP_NODELAY set
-* Connected to flowers-sample.default.<custom_domain> (34.83.190.188) port 80 (#0)
-> POST /v1/models/flowers-sample:predict HTTP/1.1
-> Host: flowers-sample.default.<custom_domain>
-> User-Agent: curl/7.64.1
-> Accept: */*
-> Content-Length: 16169
-> Content-Type: application/x-www-form-urlencoded
-> Expect: 100-continue
->
-< HTTP/1.1 100 Continue
-* We are completely uploaded and fine
-< HTTP/1.1 200 OK
-< Date: Fri, 20 Mar 2020 17:25:49 GMT
-< Content-Type: application/json
-< Content-Length: 220
-< Connection: keep-alive
-< x-envoy-upstream-service-time: 18958
-<
-{
-    "predictions": [
-        {
-            "scores": [0.999114931, 9.2098875e-05, 0.000136786344, 0.000337257865, 0.000300532876, 1.8481378e-05],
-            "prediction": 0,
-            "key": "   1"
-        }
-    ]
-* Connection #0 to host flowers-sample.default.<custom_domain> left intact
-}* Closing connection 0
+$ ingress.networking.k8s.io/kfserving-ingress created
 ```
+
+## Verify 
+
+You can call your models using your custom domain by passing the `Host` header and supplying the correct subdomain. For example if you deploy the sample [sklearn model](https://github.com/kubeflow/kfserving/tree/master/docs/samples/sklearn) in the `default` namespace using `customdomain.com`, you can reach it in the following way
+
+```
+curl -v \
+    -H "Host: sklearn-iris.default.customdomain.com" \
+    http://sklearn-iris.default.customdomain.com/v1/models/sklearn-iris:predict \
+    -d @./input.json
+```
+
+## AWS
+
+If you are using the AWS's [ALB Ingress Controller](https://github.com/kubernetes-sigs/aws-alb-ingress-controller), you can set custom annotations in the `kfserving-ingress.yaml` to deploy an Application Load Balancer instead of the less-configurable, default Classic Load Balancer. For example, to create an internal Application Load Balancer, use the following annotations
+
+```
+metadata:
+  annotations:
+    kubernetes.io/ingress.class: alb
+    alb.ingress.kubernetes.io/scheme: internal
+```
+
+If you are also using `external-dns` this configuration is enough to automatically create an entry in Route53 and expose your Knative applications to everything else that is inside your VPC.
+
 
 ## External Links
 

--- a/docs/samples/custom-domain/kfserving-ingress.yaml
+++ b/docs/samples/custom-domain/kfserving-ingress.yaml
@@ -11,4 +11,3 @@ spec:
           - backend:
               serviceName: istio-ingressgateway
               servicePort: 80
-            path: /


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

Update documentation related to setting up a custom domain for kfserving.

I made these changes after a conversation in the kfserving slack channel. I want to help clarify use-cases and motivations for future users. It personally took me a long time to find and apply this example doc.

So hopefully by updating the wording and adding some implementation context, others will be able to more quickly find and use these snippets.

Fixes:

* Remove path constraint from `kf-serving.yml` that breaks the intended functionality
* Update the verify example
* Add AWS example using ALB Ingress Controller


**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
