### PR TITLE
Puller streamlining/simplification

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -35,7 +35,7 @@ func main() {
 		}
 	}
 
-	watcher := agent.NewWatcher(*configDir)
+	watcher := agent.NewWatcher(*configDir, *modelDir)
 	agent.StartPuller(downloader, watcher.ModelEvents)
 	watcher.Start()
 }

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -35,22 +35,7 @@ func main() {
 		}
 	}
 
-	watcher := agent.Watcher{
-		ConfigDir:    *configDir,
-		ModelTracker: map[string]agent.ModelWrapper{},
-		Puller: agent.Puller{
-			ChannelMap: map[string]agent.Channel{},
-			Downloader: downloader,
-		},
-	}
-
-	syncer := agent.Syncer{
-		Watcher: watcher,
-	}
-
-	// Doing a forced sync in the case of container failures
-	// and for pre-filled config maps
-	syncer.Start()
+	watcher := agent.NewWatcher(*configDir)
+	agent.StartPuller(downloader, watcher.ModelEvents)
 	watcher.Start()
-
 }

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -1,73 +1,126 @@
 package agent
 
 import (
-	"fmt"
 	"github.com/kubeflow/kfserving/pkg/agent/storage"
+	v1 "github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
 	"log"
 	"path/filepath"
 )
 
+type OpType string
+
+const (
+	Add    OpType = "Add"
+	Remove OpType = "Remove"
+)
+
+// sentinel to represent model absence
+var remove v1.ModelSpec = v1.ModelSpec{}
+
 type Puller struct {
-	ChannelMap map[string]Channel
-	Downloader Downloader
+	channelMap  map[string]ModelChannel
+	completions chan string
+	Downloader  Downloader
 }
 
-type Channel struct {
-	EventChannel chan EventWrapper
+type ModelOp struct {
+	ModelName string
+	Op        OpType
+	Spec      *v1.ModelSpec
 }
 
-func (p *Puller) AddModel(modelName string) Channel {
-	// TODO: Figure out the appropriate buffer-size for this
-	// TODO: Check if event Channel exists
-	eventChannel := make(chan EventWrapper, 20)
-	channel := Channel{
-		EventChannel: eventChannel,
+func StartPuller(downloader Downloader, commands <-chan ModelOp) {
+	puller := Puller{
+		channelMap:  map[string]ModelChannel{},
+		completions: make(chan string, 128),
+		Downloader:  downloader,
 	}
-	go p.modelProcessor(modelName, channel.EventChannel)
-	p.ChannelMap[modelName] = channel
-	return p.ChannelMap[modelName]
+	go func() {
+		var finished bool
+		for {
+			select {
+			case modelOp, ok := <-commands:
+				if !ok {
+					finished = true
+				} else {
+					switch modelOp.Op {
+					case Add:
+						puller.enqueueModelOp(modelOp.ModelName, modelOp.Spec)
+					case Remove:
+						puller.enqueueModelOp(modelOp.ModelName, &remove)
+					}
+				}
+			case completed := <-puller.completions:
+				puller.modelOpComplete(completed, finished)
+			}
+		}
+	}()
 }
 
-func (p *Puller) RemoveModel(modelName string) error {
-	channel, ok := p.ChannelMap[modelName]
+type ModelChannel struct {
+	modelOps    chan *v1.ModelSpec
+	opsInFlight int
+}
+
+func (p *Puller) enqueueModelOp(modelName string, modelSpec *v1.ModelSpec) {
+	modelChan, ok := p.channelMap[modelName]
+	if !ok {
+		modelChan = ModelChannel{
+			modelOps: make(chan *v1.ModelSpec, 8),
+		}
+		go p.modelProcessor(modelName, modelChan.modelOps)
+		p.channelMap[modelName] = modelChan
+	}
+	modelChan.opsInFlight += 1
+	modelChan.modelOps <- modelSpec
+}
+
+func (p *Puller) modelOpComplete(modelName string, closed bool) {
+	modelChan, ok := p.channelMap[modelName]
 	if ok {
-		close(channel.EventChannel)
-		delete(p.ChannelMap, modelName)
+		modelChan.opsInFlight -= 1
+		if modelChan.opsInFlight == 0 {
+			close(modelChan.modelOps)
+			delete(p.channelMap, modelName)
+			if closed && len(p.channelMap) == 0 {
+				// this was the final completion, close the channel
+				close(p.completions)
+			}
+		}
+	} else {
+		//TODO log warning, shouldn't happen
 	}
-	if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
-		return fmt.Errorf("failing to delete model directory: %v", err)
-	}
-	return nil
 }
 
-func (p *Puller) modelProcessor(modelName string, events chan EventWrapper) {
+func (p *Puller) modelProcessor(modelName string, ops <-chan *v1.ModelSpec) {
 	log.Println("worker for", modelName, "is initialized")
 	// TODO: Instead of going through each event, one-by-one, we need to drain and combine
 	// this is important for handling Load --> Unload requests sent in tandem
 	// Load --> Unload = 0 (cancel first load)
 	// Load --> Unload --> Load = 1 Load (cancel second load?)
-	for event := range events {
-		log.Println("worker", modelName, "started  job", event)
-		switch event.LoadState {
-		case ShouldLoad:
-			log.Println("Should download", event.ModelSpec.StorageURI)
-			err := p.Downloader.DownloadModel(event)
+	for modelSpec := range ops {
+		if modelSpec != &remove {
+			// Load
+			log.Println("Should download", modelSpec.StorageURI)
+			err := p.Downloader.DownloadModel(modelName, modelSpec)
 			if err != nil {
-				log.Println("worker failed on", event, "because: ", err)
+				log.Println("Download of model", modelName, "failed because: ", err)
 			} else {
 				// If there is an error, we will NOT send a request. As such, to know about errors, you will
 				// need to call the error endpoint of the puller
 				// TODO: Do request logic
-				log.Println("Now doing a request on", event)
+				log.Println("Now doing load request for", modelName)
 			}
-		case ShouldUnload:
+		} else {
+			// Unload
 			// TODO: Do request logic
-			log.Println("Now doing a request on", event)
+			log.Println("Now doing unload request for", modelName)
 			// If there is an error, we will NOT do a delete... that could be problematic
-			log.Println("Should unload", event.ModelName)
-			if err := p.RemoveModel(event.ModelName); err != nil {
-				log.Println("worker failed on", event, "because: ", err)
+			log.Println("Should unload", modelName)
+			if err := storage.RemoveDir(filepath.Join(p.Downloader.ModelDir, modelName)); err != nil {
+				log.Printf("failing to delete model directory: %v", err)
 			}
 		}
+		p.completions <- modelName
 	}
 }

--- a/pkg/agent/syncer.go
+++ b/pkg/agent/syncer.go
@@ -2,18 +2,13 @@ package agent
 
 import (
 	"encoding/hex"
-	"encoding/json"
 	"fmt"
 	"github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
-	"github.com/kubeflow/kfserving/pkg/constants"
-	"github.com/kubeflow/kfserving/pkg/modelconfig"
-	"io/ioutil"
 	"k8s.io/apimachinery/pkg/api/resource"
 	"log"
 	"os"
 	"path/filepath"
 	"strings"
-	"time"
 )
 
 type Syncer struct {
@@ -24,9 +19,8 @@ type FileError error
 
 var NoSuccessFile FileError = fmt.Errorf("no success file can be found")
 
-func (s *Syncer) Start() {
-	modelDir := filepath.Clean(s.Watcher.Puller.Downloader.ModelDir)
-	timeNow := time.Now()
+func SyncModelDir(modelDir string) (map[string]modelWrapper, error) {
+	modelTracker := make(map[string]modelWrapper)
 	err := filepath.Walk(modelDir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {
 			modelName := info.Name()
@@ -35,10 +29,15 @@ func (s *Syncer) Start() {
 					base := filepath.Base(path)
 					baseSplit := strings.SplitN(base, ".", 4)
 					if baseSplit[0] == "SUCCESS" {
-						if e := s.successParse(timeNow, modelName, baseSplit); e != nil {
+						if spec, e := successParse(modelName, baseSplit); e != nil {
 							return fmt.Errorf("error parsing SUCCESS file: %v", e)
+						} else {
+							modelTracker[modelName] = modelWrapper{
+								Spec:  spec,
+								stale: true,
+							}
+							return nil
 						}
-						return nil
 					}
 				}
 				return NoSuccessFile
@@ -54,50 +53,31 @@ func (s *Syncer) Start() {
 		return nil
 	})
 	if err != nil {
-		log.Println("error in going through:", modelDir, err)
+		return nil, fmt.Errorf("error in syncing %s: %w", modelDir, err)
 	}
-	filePath := filepath.Join(s.Watcher.ConfigDir, constants.ModelConfigFileName)
-	log.Println("Syncing of", filePath)
-	file, err := ioutil.ReadFile(filePath)
-	if err != nil {
-		log.Println("Error in reading file", err)
-	} else {
-		modelConfigs := make(modelconfig.ModelConfigs, 0)
-		err = json.Unmarshal([]byte(file), &modelConfigs)
-		if err != nil {
-			log.Println("unable to marshall for modelConfig with error", err)
-		}
-		s.Watcher.ParseConfig(modelConfigs)
-	}
+	return modelTracker, nil
 }
 
-func (s *Syncer) successParse(timeNow time.Time, modelName string, baseSplit []string) error {
+func successParse(modelName string, baseSplit []string) (*v1beta1.ModelSpec, error) {
 	storageURI, err := unhash(baseSplit[1])
 	errorMessage := "unable to unhash the SUCCESS file, maybe the SUCCESS file has been modified?: %v"
 	if err != nil {
-		return fmt.Errorf(errorMessage, err)
+		return nil, fmt.Errorf(errorMessage, err)
 	}
 	framework, err := unhash(baseSplit[2])
 	if err != nil {
-		return fmt.Errorf(errorMessage, err)
+		return nil, fmt.Errorf(errorMessage, err)
 	}
 	memory, err := unhash(baseSplit[3])
 	if err != nil {
-		return fmt.Errorf(errorMessage, err)
+		return nil, fmt.Errorf(errorMessage, err)
 	}
 	memoryResource := resource.MustParse(memory)
-
-	s.Watcher.ModelTracker[modelName] = ModelWrapper{
-		ModelSpec: &v1beta1.ModelSpec{
-			StorageURI: storageURI,
-			Framework:  framework,
-			Memory:     memoryResource,
-		},
-		Time:       timeNow,
-		Stale:      true,
-		Redownload: true,
-	}
-	return nil
+	return &v1beta1.ModelSpec{
+		StorageURI: storageURI,
+		Framework:  framework,
+		Memory:     memoryResource,
+	}, nil
 }
 
 func unhash(s string) (string, error) {

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -10,44 +10,45 @@ import (
 	"io/ioutil"
 	"log"
 	"path/filepath"
-	"time"
 )
 
 type Watcher struct {
-	ConfigDir    string
-	ModelTracker map[string]ModelWrapper
-	Puller       Puller
+	configDir    string
+	modelTracker map[string]modelWrapper
+	puller       Puller
+	ModelEvents  chan ModelOp
 }
 
-type LoadState string
-
-const (
-	// State Related
-	ShouldLoad   LoadState = "Load"
-	ShouldUnload LoadState = "Unload"
-)
-
-type EventWrapper struct {
-	ModelName      string
-	ModelSpec      *v1beta1.ModelSpec
-	LoadState      LoadState
-	ShouldDownload bool
+func NewWatcher(configDir string) Watcher {
+	return Watcher{
+		configDir:   configDir,
+		ModelEvents: make(chan ModelOp),
+	}
 }
 
-type ModelWrapper struct {
-	ModelSpec  *v1beta1.ModelSpec
-	Time       time.Time
-	Stale      bool
-	Redownload bool
+type modelWrapper struct {
+	Spec  *v1beta1.ModelSpec
+	stale bool
 }
 
 func (w *Watcher) Start() {
+	var err error
+	if w.modelTracker, err = SyncModelDir(w.puller.Downloader.ModelDir); err != nil {
+		log.Fatal(err)
+	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)
 	}
 	defer watcher.Close()
-
+	if err = watcher.Add(w.configDir); err != nil {
+		log.Fatal(err)
+	}
+	// Add a first create event to the channel to force initial sync
+	watcher.Events <- fsnotify.Event{
+		Name: filepath.Join(w.configDir, "..data"),
+		Op:   fsnotify.Create,
+	}
 	done := make(chan bool)
 	go func() {
 		for {
@@ -70,8 +71,9 @@ func (w *Watcher) Start() {
 						err = json.Unmarshal([]byte(file), &modelConfigs)
 						if err != nil {
 							log.Println("unable to marshall for", event, "with error", err)
+						} else {
+							w.parseConfig(modelConfigs)
 						}
-						w.ParseConfig(modelConfigs)
 					}
 				}
 			case err, ok := <-watcher.Errors:
@@ -84,78 +86,47 @@ func (w *Watcher) Start() {
 			}
 		}
 	}()
-	err = watcher.Add(w.ConfigDir)
-	if err != nil {
-		log.Fatal(err)
-	}
-	log.Println("Watching", w.ConfigDir)
+	log.Println("Watching", w.configDir)
 	<-done
 }
 
-func (w *Watcher) ParseConfig(modelConfigs modelconfig.ModelConfigs) {
-	timeNow := time.Now()
+func (w *Watcher) parseConfig(modelConfigs modelconfig.ModelConfigs) {
 	for _, modelConfig := range modelConfigs {
-		modelName := modelConfig.Name
-		modelSpec := modelConfig.Spec
-		log.Println("Name:", modelName, "Spec:", modelSpec)
-		oldModel, ok := w.ModelTracker[modelName]
-		if !ok {
-			w.ModelTracker[modelName] = ModelWrapper{
-				ModelSpec:  &modelSpec,
-				Time:       timeNow,
-				Stale:      true,
-				Redownload: true,
-			}
-		} else {
-			isStale := true
-			reDownload := true
-			if oldModel.ModelSpec != nil {
-				isStale = !cmp.Equal(*oldModel.ModelSpec, modelSpec)
-				reDownload = !cmp.Equal(oldModel.ModelSpec.StorageURI, modelSpec.StorageURI)
-				log.Println("same", !isStale, *oldModel.ModelSpec, modelSpec)
-			}
-			// Need to store new time, TODO: maybe worth to have seperate map?
-			w.ModelTracker[modelName] = ModelWrapper{
-				ModelSpec:  &modelSpec,
-				Time:       timeNow,
-				Stale:      isStale,
-				Redownload: reDownload,
-			}
+		name, spec := modelConfig.Name, modelConfig.Spec
+		existing, exists := w.modelTracker[name]
+		if !exists {
+			// New - add
+			w.modelTracker[name] = modelWrapper{Spec: &spec}
+			w.modelAdded(name, &spec)
+		} else if !cmp.Equal(spec, *existing.Spec) {
+			existing.Spec, existing.stale = &spec, false
+			// Changed - replace
+			w.modelRemoved(name)
+			w.modelAdded(name, &spec)
 		}
 	}
-	// TODO: Maybe make parallel and more efficient?
-	for modelName, modelWrapper := range w.ModelTracker {
-		if modelWrapper.Time.Before(timeNow) {
-			delete(w.ModelTracker, modelName)
-			channel, ok := w.Puller.ChannelMap[modelName]
-			if !ok {
-				log.Println("Model", modelName, "was never added to channel map")
-			} else {
-				event := EventWrapper{
-					ModelName:      modelName,
-					ModelSpec:      nil,
-					LoadState:      ShouldUnload,
-					ShouldDownload: false,
-				}
-				log.Println("Sending event", event)
-				channel.EventChannel <- event
-			}
+	for name, wrapper := range w.modelTracker {
+		if wrapper.stale {
+			// Gone - remove
+			delete(w.modelTracker, name)
+			w.modelRemoved(name)
 		} else {
-			if modelWrapper.Stale {
-				channel, ok := w.Puller.ChannelMap[modelName]
-				if !ok {
-					log.Println("Need to add model", modelName)
-					channel = w.Puller.AddModel(modelName)
-				}
-				event := EventWrapper{
-					ModelName:      modelName,
-					ModelSpec:      modelWrapper.ModelSpec,
-					LoadState:      ShouldLoad,
-					ShouldDownload: modelWrapper.Redownload,
-				}
-				log.Println("Sending event", event)
-				channel.EventChannel <- event
-			}
+			wrapper.stale = true // reset for next iteration
 		}
+	}
+}
+
+func (w *Watcher) modelAdded(name string, spec *v1beta1.ModelSpec) {
+	w.ModelEvents <- ModelOp{
+		ModelName: name,
+		Op:        Add,
+		Spec:      spec,
+	}
+}
+
+func (w *Watcher) modelRemoved(name string) {
+	w.ModelEvents <- ModelOp{
+		ModelName: name,
+		Op:        Remove,
 	}
 }

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -15,14 +15,18 @@ import (
 type Watcher struct {
 	configDir    string
 	modelTracker map[string]modelWrapper
-	puller       Puller
 	ModelEvents  chan ModelOp
 }
 
-func NewWatcher(configDir string) Watcher {
+func NewWatcher(configDir string, modelDir string) Watcher {
+	modelTracker, err := SyncModelDir(modelDir)
+	if err != nil {
+		log.Fatal(err)
+	}
 	return Watcher{
-		configDir:   configDir,
-		ModelEvents: make(chan ModelOp),
+		configDir:    configDir,
+		modelTracker: modelTracker,
+		ModelEvents:  make(chan ModelOp),
 	}
 }
 
@@ -32,10 +36,6 @@ type modelWrapper struct {
 }
 
 func (w *Watcher) Start() {
-	var err error
-	if w.modelTracker, err = SyncModelDir(w.puller.Downloader.ModelDir); err != nil {
-		log.Fatal(err)
-	}
 	watcher, err := fsnotify.NewWatcher()
 	if err != nil {
 		log.Fatal(err)

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -44,12 +44,6 @@ func (w *Watcher) Start() {
 	if err = watcher.Add(w.configDir); err != nil {
 		log.Fatal(err)
 	}
-	// Add a first create event to the channel to force initial sync
-	watcher.Events <- fsnotify.Event{
-		Name: filepath.Join(w.configDir, "..data"),
-		Op:   fsnotify.Create,
-	}
-	done := make(chan bool)
 	go func() {
 		for {
 			select {
@@ -86,8 +80,12 @@ func (w *Watcher) Start() {
 			}
 		}
 	}()
+	// Add a first create event to the channel to force initial sync
+	watcher.Events <- fsnotify.Event{
+		Name: filepath.Join(w.configDir, "..data"),
+		Op:   fsnotify.Create,
+	}
 	log.Println("Watching", w.configDir)
-	<-done
 }
 
 func (w *Watcher) parseConfig(modelConfigs modelconfig.ModelConfigs) {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Follow-on changes to #989 based on remaining review suggestions.

- Simplified configmap change diffing
- Connect watcher and puller with event channel
- Have puller track in-progress ops per model via op completion channel and tie lifecycle of per-model channel+goroutine pairs to this