### PR TITLE
Fix thread safety issue in KFServer asyncio

### DIFF
--- a/python/alibiexplainer/alibiexplainer/__main__.py
+++ b/python/alibiexplainer/alibiexplainer/__main__.py
@@ -17,7 +17,6 @@ import kfserving
 import logging
 import os
 import sys
-import nest_asyncio
 from alibiexplainer import AlibiExplainer
 from alibiexplainer.explainer import ExplainerMethod  # pylint:disable=no-name-in-module
 from alibiexplainer.parser import parse_args
@@ -30,8 +29,6 @@ EXPLAINER_FILENAME = "explainer.dill"
 def main():
     args, extra = parse_args(sys.argv[1:])
     # Pretrained Alibi explainer
-
-    nest_asyncio.apply()
 
     alibi_model = None
     if args.storage_uri is not None:
@@ -50,7 +47,7 @@ def main():
         alibi_model,
     )
     explainer.load()
-    kfserving.KFServer().start(models=[explainer])
+    kfserving.KFServer().start(models=[explainer], nest_asyncio=True)
 
 
 if __name__ == "__main__":

--- a/python/kfserving/kfserving/kfserver.py
+++ b/python/kfserving/kfserving/kfserver.py
@@ -67,7 +67,7 @@ class KFServer:
              ExplainHandler, dict(models=self.registered_models)),
         ])
 
-    def start(self, models: List[KFModel]):
+    def start(self, models: List[KFModel], nest_asyncio: bool = False):
         for model in models:
             self.register_model(model)
 
@@ -78,6 +78,14 @@ class KFServer:
         self._http_server.bind(self.http_port)
         logging.info("Will fork %d workers", self.workers)
         self._http_server.start(self.workers)
+
+        # Need to start the IOLoop after workers have been started
+        # https://github.com/tornadoweb/tornado/issues/2426
+        # The nest_asyncio package needs to be installed by the downstream module
+        if nest_asyncio:
+            import nest_asyncio
+            nest_asyncio.apply()
+
         tornado.ioloop.IOLoop.current().start()
 
     def register_model(self, model: KFModel):


### PR DESCRIPTION
#983 got merged while me and @yuzisun were nailing down the sporadic build issues. There seems to be a lot of situations where multi process workers break with Tornado in Python 3.5+ due to asyncio not being thread (process) safe. These issues are realized with the async-mangling needed to get the synchronous Alibi implementation to work with the now async KFServer.

The recommendation from the Tornado team seems to be to run only one process and handle load balancing elsewhere. Instead of making that change, as I do not know what impact it would have on other usages of KFServer I'm trying to shift the IOLoop and process fork order to make sure all IOLoop actions happen after the fork.