### PR TITLE
Add Peter Salanki as reviewer

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,7 @@ reviewers:
   - iamlovingit
   - ifilonenko
   - jinchihe
+  - salanki
   - tomcli
   - pugangxa
   - yuzliu


### PR DESCRIPTION
As suggested by @ellistarn in https://github.com/kubeflow/kfserving/pull/1069#issuecomment-685274886. Adding myself as reviewer, primarily for adding `ok-to-test` labels on my own PRs and from my (forthcoming) team.

Org member PR: https://github.com/kubeflow/internal-acls/pull/336