### PR TITLE
Add the ko prefix to prevent the notice message during building

### DIFF
--- a/config/overlays/development/configmap/ko_resolve_batcher
+++ b/config/overlays/development/configmap/ko_resolve_batcher
@@ -1,1 +1,1 @@
-image: github.com/kubeflow/kfserving/cmd/batcher
+image: ko://github.com/kubeflow/kfserving/cmd/batcher


### PR DESCRIPTION
**What this PR does / why we need it**:

During build there's message like:
```
➜  kfserving git:(master) ✗ make deploy-dev
/Users/pugang/go/bin/controller-gen "crd:maxDescLen=0" paths=./pkg/apis/serving/v1alpha2/... output:crd:dir=config/crd
/Users/pugang/go/bin/controller-gen rbac:roleName=kfserving-manager-role paths=./pkg/controller/inferenceservice/... output:rbac:artifacts:config=config/rbac
.....................................
2020/09/02 15:34:34 Publishing docker.io/pugang/logger-254effe41b2d12817e512614f7349610:latest
2020/09/02 15:40:55 Published docker.io/pugang/logger-254effe41b2d12817e512614f7349610@sha256:e593d7a8f7d4cbc0b2640342a672bfbfbf8d8dcc5db18670cdcda60638015cf2
2020/09/02 15:40:56 NOTICE!
-----------------------------------------------------------------
We will start requiring ko:// in a coming release.  Please prefix
the following import path for things to continue working:

   github.com/kubeflow/kfserving/cmd/batcher

For more information see:

   https://github.com/google/ko/issues/158

-----------------------------------------------------------------
2020/09/02 15:40:56 Using base registry.access.redhat.com/ubi7/ubi-minimal:latest for github.com/kubeflow/kfserving/cmd/batcher
2020/09/02 15:41:01 Building github.com/kubeflow/kfserving/cmd/batcher
```

I saw there's for logger and manager there's already "ko://" prefix added, so will do the same for batcher to prevent the message above.