### PR TITLE
support generic filename for ONNX runtime model (#1004)

### DIFF
--- a/pkg/apis/serving/v1alpha2/framework_onnx.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx.go
@@ -14,15 +14,20 @@ limitations under the License.
 package v1alpha2
 
 import (
+	"net/url"
+	"path"
+
+	"strconv"
+
 	"github.com/kubeflow/kfserving/pkg/constants"
 	v1 "k8s.io/api/core/v1"
-	"strconv"
 )
 
 var (
 	ONNXServingRestPort            = "8080"
 	ONNXServingGRPCPort            = "9000"
-	ONNXModelFileName              = "model.onnx"
+	DefaultONNXModelName           = "model.onnx"
+	ONNXFileExt                    = "onnx"
 	InvalidONNXRuntimeVersionError = "ONNX RuntimeVersion must be one of %s"
 )
 
@@ -36,8 +41,15 @@ func (s *ONNXSpec) GetResourceRequirements() *v1.ResourceRequirements {
 }
 
 func (s *ONNXSpec) GetContainer(modelName string, parallelism int, config *InferenceServicesConfig) *v1.Container {
+	uri, _ := url.Parse(s.StorageURI)
+	var filename string
+	if path.Ext(uri.Path) != ONNXFileExt {
+		filename = DefaultONNXModelName
+	} else {
+		filename = path.Base(uri.Path)
+	}
 	arguments := []string{
-		"--model_path", constants.DefaultModelLocalMountPath + "/" + ONNXModelFileName,
+		"--model_path", constants.DefaultModelLocalMountPath + "/" + filename,
 		"--http_port", ONNXServingRestPort,
 		"--grpc_port", ONNXServingGRPCPort,
 	}

--- a/pkg/apis/serving/v1alpha2/framework_onnx.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx.go
@@ -27,7 +27,7 @@ var (
 	ONNXServingRestPort            = "8080"
 	ONNXServingGRPCPort            = "9000"
 	DefaultONNXModelName           = "model.onnx"
-	ONNXFileExt                    = "onnx"
+	ONNXFileExt                    = ".onnx"
 	InvalidONNXRuntimeVersionError = "ONNX RuntimeVersion must be one of %s"
 )
 

--- a/pkg/apis/serving/v1alpha2/framework_onnx.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx.go
@@ -72,5 +72,9 @@ func (s *ONNXSpec) ApplyDefaults(config *InferenceServicesConfig) {
 }
 
 func (s *ONNXSpec) Validate(config *InferenceServicesConfig) error {
+	_, err := url.Parse(s.StorageURI)
+	if err != nil {
+		return err
+	}
 	return nil
 }

--- a/pkg/apis/serving/v1alpha2/framework_onnx_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx_test.go
@@ -40,7 +40,7 @@ var onnxRequestedResource = v1.ResourceRequirements{
 }
 
 var onnxSpec = ONNXSpec{
-	StorageURI:     "gs://someUri/model.onnx",
+	StorageURI:     "gs://someUri",
 	Resources:      onnxRequestedResource,
 	RuntimeVersion: "someAmazingVersion",
 }

--- a/pkg/apis/serving/v1alpha2/framework_onnx_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx_test.go
@@ -45,6 +45,18 @@ var onnxSpec = ONNXSpec{
 	RuntimeVersion: "someAmazingVersion",
 }
 
+var onnxSpecWithOtherFilename = ONNXSpec{
+	StorageURI:     "gs://someUri/other_name.onnx",
+	Resources:      onnxRequestedResource,
+	RuntimeVersion: "someAmazingVersion",
+}
+
+var onnxSpecWithQueryParameterFilename = ONNXSpec{
+	StorageURI:     "https://someUri/other_name.onnx?raw=true",
+	Resources:      onnxRequestedResource,
+	RuntimeVersion: "someAmazingVersion",
+}
+
 var onnxConfig = InferenceServicesConfig{
 	Predictors: &PredictorsConfig{
 		ONNX: PredictorConfig{
@@ -70,5 +82,45 @@ func TestCreateOnnxModelServingContainer(t *testing.T) {
 
 	// Test Create with config
 	container := onnxSpec.GetContainer("someName", 0, &onnxConfig)
+	g.Expect(container).To(gomega.Equal(expectedContainer))
+}
+
+func TestCreateOnnxModelServingContainerWithOtherFilename(t *testing.T) {
+
+	g := gomega.NewGomegaWithT(t)
+
+	expectedContainer := &v1.Container{
+		Image:     "someOtherImage:someAmazingVersion",
+		Name:      constants.InferenceServiceContainerName,
+		Resources: onnxRequestedResource,
+		Args: []string{
+			"--model_path", "/mnt/models/other_name.onnx",
+			"--http_port", "8080",
+			"--grpc_port", "9000",
+		},
+	}
+
+	// Test Create with config
+	container := onnxSpecWithOtherFilename.GetContainer("someName", 0, &onnxConfig)
+	g.Expect(container).To(gomega.Equal(expectedContainer))
+}
+
+func TestCreateOnnxModelServingContainerWithQueryParameter(t *testing.T) {
+
+	g := gomega.NewGomegaWithT(t)
+
+	expectedContainer := &v1.Container{
+		Image:     "someOtherImage:someAmazingVersion",
+		Name:      constants.InferenceServiceContainerName,
+		Resources: onnxRequestedResource,
+		Args: []string{
+			"--model_path", "/mnt/models/other_name.onnx",
+			"--http_port", "8080",
+			"--grpc_port", "9000",
+		},
+	}
+
+	// Test Create with config
+	container := onnxSpecWithQueryParameterFilename.GetContainer("someName", 0, &onnxConfig)
 	g.Expect(container).To(gomega.Equal(expectedContainer))
 }

--- a/pkg/apis/serving/v1alpha2/framework_onnx_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx_test.go
@@ -40,7 +40,7 @@ var onnxRequestedResource = v1.ResourceRequirements{
 }
 
 var onnxSpec = ONNXSpec{
-	StorageURI:     "gs://someUri",
+	StorageURI:     "gs://someUri/model.onnx",
 	Resources:      onnxRequestedResource,
 	RuntimeVersion: "someAmazingVersion",
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Add the support for parsing the `storageUri` in an `InferenceService` CRD to take in a generic filename such that the below:
```yaml
apiVersion: serving.kubeflow.org/v1alpha2
kind: InferenceService
metadata:
  name: onnx-from-uri
spec:
  default:
    predictor:
      onnx:
        storageUri: s3://some_bucket/some/key/path/my_great_model.onnx
```
will also be valid. Here, if the path does not specify a file name, e.g. `s3://some_bucket/some/key/path`, then we'd continue to use the default `model.onnx`.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1004 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
