### PR TITLE
Set KFServing default worker to 1

### DIFF
--- a/python/kfserving/kfserving/kfserver.py
+++ b/python/kfserving/kfserving/kfserver.py
@@ -38,7 +38,7 @@ parser.add_argument('--grpc_port', default=DEFAULT_GRPC_PORT, type=int,
                     help='The GRPC Port listened to by the model server.')
 parser.add_argument('--max_buffer_size', default=DEFAULT_MAX_BUFFER_SIZE, type=int,
                     help='The max buffer size for tornado.')
-parser.add_argument('--workers', default=0, type=int,
+parser.add_argument('--workers', default=1, type=int,
                     help='The number of works to fork')
 args, _ = parser.parse_known_args()
 


### PR DESCRIPTION
KFServer uses the number of cores on the machine to set the number of process in its tornado service which can delay the initialization time and increase the memory usage a lot.

A local testing suggests that KFServer loaded 64 processes and used more than 500Mb for a simple SKLearn model. Once I set the worker number to 1, the memory usage was reduced to around 100Mb. 
```
[I 200927 18:26:06 kfserver:88] Registering model: mlguild-iris-svm
[I 200927 18:26:06 kfserver:77] Listening on port 8080
[I 200927 18:26:06 kfserver:79] Will fork 0 workers
[I 200927 18:26:06 process:126] Starting 64 processes
```

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
