### PR TITLE
Update Triton repo links

### DIFF
--- a/docs/apis/README.md
+++ b/docs/apis/README.md
@@ -1003,7 +1003,7 @@ TritonSpec
 </em>
 </td>
 <td>
-<p>Spec for Triton Inference Server (<a href="https://github.com/NVIDIA/triton-inference-server">https://github.com/NVIDIA/triton-inference-server</a>)</p>
+<p>Spec for Triton Inference Server (<a href="https://github.com/triton-inference-server/server">https://github.com/triton-inference-server/server</a>)</p>
 </td>
 </tr>
 <tr>

--- a/docs/predict-api/v2/README.md
+++ b/docs/predict-api/v2/README.md
@@ -9,7 +9,7 @@ standardized around this protocol.
 The protocol is composed of a required set of APIs that must be
 implemented by a compliant server. This required set of APIs is
 described in [required_api.md](./required_api.md). The [GRPC proto
-specification](https://github.com/NVIDIA/triton-inference-server/blob/master/docs/protocol/grpc_core_service.proto)
+specification](https://github.com/triton-inference-server/server/blob/master/docs/protocol/grpc_core_service.proto)
 for the required APIs is available.
 
 The protocol supports an extension mechanism as a required part of the
@@ -18,7 +18,7 @@ compliant server. Inference servers that have implemented extensions
 and the link to those extensions are:
 
 - Triton Inference Server:
-  https://github.com/NVIDIA/triton-inference-server/tree/master/docs/protocol
+  https://github.com/triton-inference-server/server/tree/master/docs/protocol
 
 The protocol is not yet finalized and so feedback is welcome. To
 provide feedback open an issue and prepend the title with "[Predict

--- a/docs/samples/triton/bert/bert_tokenizer/Dockerfile
+++ b/docs/samples/triton/bert/bert_tokenizer/Dockerfile
@@ -5,7 +5,7 @@ RUN  apt-get update \
 COPY bert_transformer bert_transformer/bert_transformer
 COPY setup.py bert_transformer/setup.py
 RUN pip install kfserving
-RUN wget https://github.com/NVIDIA/triton-inference-server/releases/download/v1.11.0/v1.11.0_ubuntu1604.clients.tar.gz && tar -xvzf v1.11.0_ubuntu1604.clients.tar.gz
+RUN wget https://github.com/triton-inference-server/server/releases/download/v1.11.0/v1.11.0_ubuntu1604.clients.tar.gz && tar -xvzf v1.11.0_ubuntu1604.clients.tar.gz
 RUN pip install python/tensorrtserver-1.11.0-py3-none-linux_x86_64.whl
 WORKDIR bert_transformer
 RUN pip install -e .

--- a/pkg/apis/serving/v1alpha2/framework_triton.go
+++ b/pkg/apis/serving/v1alpha2/framework_triton.go
@@ -20,7 +20,7 @@ import (
 )
 
 var (
-	// For versioning see https://github.com/NVIDIA/triton-inference-server/releases
+	// For versioning see https://github.com/triton-inference-server/server/releases
 	TritonISGRPCPort = int32(9000)
 	TritonISRestPort = int32(8080)
 )

--- a/pkg/apis/serving/v1alpha2/inferenceservice_types.go
+++ b/pkg/apis/serving/v1alpha2/inferenceservice_types.go
@@ -110,7 +110,7 @@ type PredictorSpec struct {
 	Custom *CustomSpec `json:"custom,omitempty"`
 	// Spec for Tensorflow Serving (https://github.com/tensorflow/serving)
 	Tensorflow *TensorflowSpec `json:"tensorflow,omitempty"`
-	// Spec for Triton Inference Server (https://github.com/NVIDIA/triton-inference-server)
+	// Spec for Triton Inference Server (https://github.com/triton-inference-server/server)
 	Triton *TritonSpec `json:"triton,omitempty"`
 	// Spec for XGBoost predictor
 	XGBoost *XGBoostSpec `json:"xgboost,omitempty"`

--- a/pkg/apis/serving/v1alpha2/openapi_generated.go
+++ b/pkg/apis/serving/v1alpha2/openapi_generated.go
@@ -700,7 +700,7 @@ func schema_pkg_apis_serving_v1alpha2_PredictorSpec(ref common.ReferenceCallback
 					},
 					"triton": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec for Triton Inference Server (https://github.com/NVIDIA/triton-inference-server)",
+							Description: "Spec for Triton Inference Server (https://github.com/triton-inference-server/server)",
 							Ref:         ref("./pkg/apis/serving/v1alpha2.TritonSpec"),
 						},
 					},

--- a/pkg/apis/serving/v1alpha2/swagger.json
+++ b/pkg/apis/serving/v1alpha2/swagger.json
@@ -519,7 +519,7 @@
           "$ref": "#/definitions/v1alpha2.TensorflowSpec"
         },
         "triton": {
-          "description": "Spec for Triton Inference Server (https://github.com/NVIDIA/triton-inference-server)",
+          "description": "Spec for Triton Inference Server (https://github.com/triton-inference-server/server)",
           "$ref": "#/definitions/v1alpha2.TritonSpec"
         },
         "xgboost": {

--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -31,7 +31,7 @@ type PredictorSpec struct {
 	Tensorflow *TFServingSpec `json:"tensorflow,omitempty"`
 	// Spec for TorchServe (https://pytorch.org/serve)
 	PyTorch *TorchServeSpec `json:"pytorch,omitempty"`
-	// Spec for Triton Inference Server (https://github.com/NVIDIA/triton-inference-server)
+	// Spec for Triton Inference Server (https://github.com/triton-inference-server/server)
 	Triton *TritonSpec `json:"triton,omitempty"`
 	// Spec for ONNX runtime (https://github.com/microsoft/onnxruntime)
 	ONNX *ONNXRuntimeSpec `json:"onnx,omitempty"`

--- a/python/kfserving/docs/V1alpha2PredictorSpec.md
+++ b/python/kfserving/docs/V1alpha2PredictorSpec.md
@@ -14,7 +14,7 @@ Name | Type | Description | Notes
 **service_account_name** | **str** | ServiceAccountName is the name of the ServiceAccount to use to run the service | [optional] 
 **sklearn** | [**V1alpha2SKLearnSpec**](V1alpha2SKLearnSpec.md) | Spec for SKLearn predictor | [optional] 
 **tensorflow** | [**V1alpha2TensorflowSpec**](V1alpha2TensorflowSpec.md) | Spec for Tensorflow Serving (https://github.com/tensorflow/serving) | [optional] 
-**triton** | [**V1alpha2TritonSpec**](V1alpha2TritonSpec.md) | Spec for Triton Inference Server (https://github.com/NVIDIA/triton-inference-server) | [optional] 
+**triton** | [**V1alpha2TritonSpec**](V1alpha2TritonSpec.md) | Spec for Triton Inference Server (https://github.com/triton-inference-server/server) | [optional] 
 **xgboost** | [**V1alpha2XGBoostSpec**](V1alpha2XGBoostSpec.md) | Spec for XGBoost predictor | [optional] 
 
 [[Back to Model list]](../README.md#documentation-for-models) [[Back to API list]](../README.md#documentation-for-api-endpoints) [[Back to README]](../README.md)

--- a/python/kfserving/kfserving/models/v1alpha2_predictor_spec.py
+++ b/python/kfserving/kfserving/models/v1alpha2_predictor_spec.py
@@ -388,7 +388,7 @@ class V1alpha2PredictorSpec(object):
     def triton(self):
         """Gets the triton of this V1alpha2PredictorSpec.  # noqa: E501
 
-        Spec for Triton Inference Server (https://github.com/NVIDIA/triton-inference-server)  # noqa: E501
+        Spec for Triton Inference Server (https://github.com/triton-inference-server/server)  # noqa: E501
 
         :return: The triton of this V1alpha2PredictorSpec.  # noqa: E501
         :rtype: V1alpha2TritonSpec
@@ -399,7 +399,7 @@ class V1alpha2PredictorSpec(object):
     def triton(self, triton):
         """Sets the triton of this V1alpha2PredictorSpec.
 
-        Spec for Triton Inference Server (https://github.com/NVIDIA/triton-inference-server)  # noqa: E501
+        Spec for Triton Inference Server (https://github.com/triton-inference-server/server)  # noqa: E501
 
         :param triton: The triton of this V1alpha2PredictorSpec.  # noqa: E501
         :type: V1alpha2TritonSpec


### PR DESCRIPTION
The Github repo was updated recently, so this PR updates the references so as to not rely on redirects.

https://github.com/NVIDIA/triton-inference-server -> https://github.com/triton-inference-server/server
