### PR TITLE
Swap boto3 in for minio in storage initializer

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -23,11 +23,11 @@ import tarfile
 import zipfile
 import gzip
 from urllib.parse import urlparse
-import requests 
+import requests
 from azure.storage.blob import BlockBlobService
 from google.auth import exceptions
 from google.cloud import storage
-from minio import Minio
+import boto3
 
 _GCS_PREFIX = "gs://"
 _S3_PREFIX = "s3://"
@@ -35,6 +35,7 @@ _BLOB_RE = "https://(.+?).blob.core.windows.net/(.+)"
 _LOCAL_PREFIX = "file://"
 _URI_RE = "https?://(.+)/(.+)"
 _HTTP_PREFIX = "http(s)://"
+
 
 class Storage(object): # pylint: disable=too-few-public-methods
     @staticmethod
@@ -73,25 +74,18 @@ class Storage(object): # pylint: disable=too-few-public-methods
 
     @staticmethod
     def _download_s3(uri, temp_dir: str):
-        client = Storage._create_minio_client()
-        bucket_args = uri.replace(_S3_PREFIX, "", 1).split("/", 1)
-        bucket_name = bucket_args[0]
-        bucket_path = bucket_args[1] if len(bucket_args) > 1 else ""
-        objects = client.list_objects(bucket_name, prefix=bucket_path, recursive=True)
-        count = 0
-        for obj in objects:
-            # Replace any prefix from the object key with temp_dir
-            subdir_object_key = obj.object_name.replace(bucket_path, "", 1).strip("/")
-            # fget_object handles directory creation if does not exist
-            if not obj.is_dir:
-                if subdir_object_key == "":
-                    subdir_object_key = obj.object_name
-                client.fget_object(bucket_name, obj.object_name,
-                                   os.path.join(temp_dir, subdir_object_key))
-            count = count + 1
-        if count == 0:
-            raise RuntimeError("Failed to fetch model. \
-The path or model %s does not exist." % (uri))
+        s3 = boto3.resource('s3', endpoint_url=os.getenv("AWS_ENDPOINT_URL", "http://s3.amazonaws.com"))
+        parsed = urlparse(uri, scheme='s3')
+        bucket_name = parsed.netloc
+        bucket_path = parsed.path.lstrip('/')
+
+        bucket = s3.Bucket(bucket_name)
+        for obj in bucket.objects.filter(Prefix=bucket_path):
+            target = temp_dir + '/' + os.path.basename(obj.key)
+            print(f"Moving {obj.key} -> {temp_dir}/{os.path.basename(obj.key)}")
+            if not os.path.exists(os.path.dirname(target)):
+                os.makedirs(os.path.dirname(target), exist_ok=True)
+            bucket.download_file(obj.key, target)
 
     @staticmethod
     def _download_gcs(uri, temp_dir: str):
@@ -254,13 +248,3 @@ The path or model %s does not exist." % (uri))
 
         return out_dir
 
-    @staticmethod
-    def _create_minio_client():
-        # Adding prefixing "http" in urlparse is necessary for it to be the netloc
-        url = urlparse(os.getenv("AWS_ENDPOINT_URL", "http://s3.amazonaws.com"))
-        use_ssl = url.scheme == 'https' if url.scheme else bool(os.getenv("S3_USE_HTTPS", "true"))
-        return Minio(url.netloc,
-                     access_key=os.getenv("AWS_ACCESS_KEY_ID", ""),
-                     secret_key=os.getenv("AWS_SECRET_ACCESS_KEY", ""),
-                     region=os.getenv("AWS_REGION", ""),
-                     secure=use_ssl)

--- a/python/kfserving/requirements.txt
+++ b/python/kfserving/requirements.txt
@@ -6,9 +6,11 @@ urllib3>=1.15.1
 kubernetes==10.0.1
 tornado>=6.0.0
 argparse>=1.4.0
-minio>=4.0.9
+minio>=6.0.0
 google-cloud-storage>=1.31.0
 adal>=1.2.2
 table_logger>=0.3.5
 numpy>=1.17.3
 azure-storage-blob>=1.3.0,<=2.1.0
+boto3==1.15.13
+botocore==1.18.13


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- This PR swaps out minio for boto3 in the storage-initializer mainly bc minio-py's most recent release doesn't support iam for service accounts yet (the code is in their github but they haven't created a release since august)
- I tested this out by uploading a built image with my changes to ECR and then changing the image uri in the inference config map and it worked! I am using IAM for service accounts in my cluster 
```