### PR TITLE
fix conditional in ONNX storage URI validation

### DIFF
--- a/pkg/apis/serving/v1alpha2/framework_onnx.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx.go
@@ -77,7 +77,7 @@ func (s *ONNXSpec) Validate(config *InferenceServicesConfig) error {
 	if err != nil {
 		return err
 	}
-	if ext := path.Ext(uri.Path); ext != ONNXFileExt || ext != "" {
+	if ext := path.Ext(uri.Path); ext != ONNXFileExt && ext != "" {
 		return fmt.Errorf("Expected storageUri file extension: %s but got %s", ONNXFileExt, ext)
 	}
 	return nil

--- a/pkg/apis/serving/v1alpha2/framework_onnx_test.go
+++ b/pkg/apis/serving/v1alpha2/framework_onnx_test.go
@@ -57,6 +57,12 @@ var onnxSpecWithQueryParameterFilename = ONNXSpec{
 	RuntimeVersion: "someAmazingVersion",
 }
 
+var onnxSpecWithBadFileExt = ONNXSpec{
+	StorageURI:     "gs://someUri/model.notonnx",
+	Resources:      onnxRequestedResource,
+	RuntimeVersion: "someUnAmazingVersion",
+}
+
 var onnxConfig = InferenceServicesConfig{
 	Predictors: &PredictorsConfig{
 		ONNX: PredictorConfig{
@@ -123,4 +129,18 @@ func TestCreateOnnxModelServingContainerWithQueryParameter(t *testing.T) {
 	// Test Create with config
 	container := onnxSpecWithQueryParameterFilename.GetContainer("someName", 0, &onnxConfig)
 	g.Expect(container).To(gomega.Equal(expectedContainer))
+}
+
+func TestOnnxPathValidationSuccess(t *testing.T) {
+
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(onnxSpec.Validate(&onnxConfig)).Should(gomega.Succeed())
+	g.Expect(onnxSpecWithOtherFilename.Validate(&onnxConfig)).Should(gomega.Succeed())
+	g.Expect(onnxSpecWithQueryParameterFilename.Validate(&onnxConfig)).Should(gomega.Succeed())
+}
+
+func TestOnnxPathValidationFailure(t *testing.T) {
+
+	g := gomega.NewGomegaWithT(t)
+	g.Expect(onnxSpecWithBadFileExt.Validate(&onnxConfig)).ShouldNot(gomega.Succeed())
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Fixes a conditional for ONNX storage URI validation.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
