### PR TITLE
Add yq as dep in developer guide 

### DIFF
--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -47,6 +47,7 @@ You must install these tools:
 1. [`kubectl`](https://kubernetes.io/docs/tasks/tools/install-kubectl/): For
    managing development environments.
 1. [`kustomize`](https://github.com/kubernetes-sigs/kustomize/) To customize YAMLs for different environments, requires v3.5.4+.
+1. [`yq`](https://github.com/mikefarah/yq) yq is used in the project makefiles to parse and display YAML output
 
 ### Install Knative on a Kubernetes cluster
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The Makefile requires yq to deploy, so this just adds it as a dep.