### PR TITLE
Update references to Knative monitoring docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -181,10 +181,10 @@ If the default ingress gateway setup does not fit your need, you can choose to s
 - [Configure Custom Domain](https://knative.dev/docs/serving/using-a-custom-domain/)
 - [Configure HTTPS Connection](https://knative.dev/docs/serving/using-a-tls-cert/)
 
-### Setup Monitoring
-- [Metrics](https://knative.dev/docs/serving/accessing-metrics/)
+### Metrics, Tracing and Debugging
+- [AutoScaling Metrics](https://knative.dev/docs/serving/autoscaling/autoscaling-metrics/)
 - [Tracing](https://knative.dev/docs/serving/accessing-traces/)
-- [Logging](https://knative.dev/docs/serving/accessing-logs/)
+- [Debugging Knative Services](https://knative.dev/docs/serving/debugging-application-issues/)
 - [Dashboard for ServiceMesh](https://istio.io/latest/docs/tasks/observability/kiali/)
 
 ### Use KFServing SDK

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,0 +1,20 @@
+# KFServing Observability
+
+The Knative Observability project is deprecated and no longer ships releases. So for the time being, it is necessary to look deeper for metrics regarding deployed `InferenceServices`.
+
+## Istio / Prometheus
+
+The default Prometheus deployment is configured to collect metrics from all Envoy proxies running in the cluster, augmenting each metric with a set of labels about their origin (instance, pod, and namespace).
+
+### Workload Aggregation
+
+The Istio documentation describes Prometheus rules which will provide aggregated metrics by workload. In their words, "In Kubernetes, a workload typically corresponds to a Kubernetes deployment, while a workload instance corresponds to an individual pod". By collecting and viewing these metrics with Prometheus, one can get a good sense of the state of the services requests and its volume of traffic.
+
+These properties are available in policy and telemetry configuration using the following attributes:
+
+```
+source.workload.name, source.workload.namespace, source.workload.uid
+destination.workload.name, destination.workload.namespace, destination.workload.uid
+```
+
+https://istio.io/latest/docs/ops/best-practices/observability/#workload-level-aggregation-via-recording-rules

--- a/docs/observability/README.md
+++ b/docs/observability/README.md
@@ -1,6 +1,6 @@
 # KFServing Observability
 
-The Knative Observability project is deprecated and no longer ships releases. So for the time being, it is necessary to look deeper for metrics regarding deployed `InferenceServices`.
+The [Knative Observability](https://github.com/knative/observability) project is deprecated and no longer ships releases. So for the time being, it is necessary to look deeper for metrics regarding deployed `InferenceServices`.
 
 ## Istio / Prometheus
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The links in the README are broken and point to the [deprecated Knative monitoring system](https://github.com/knative/docs/pull/2946). This PR just updates the links to updated information.