### PR TITLE
Cherry-pick of 'Support Kubernetes 1.18' (#1128) to release-0.4

### DIFF
--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -10,3 +10,11 @@
 resources:
 - serving.kubeflow.org_inferenceservices.yaml
 
+patchesJson6902:
+  # Fix for https://github.com/kubernetes/kubernetes/issues/91395
+  - target:
+      group: apiextensions.k8s.io
+      version: v1beta1
+      kind: CustomResourceDefinition
+      name: inferenceservices.serving.kubeflow.org
+    path: patches/protocol.yaml

--- a/config/crd/patches/protocol.yaml
+++ b/config/crd/patches/protocol.yaml
@@ -1,0 +1,23 @@
+- op: add
+  path: /spec/validation/openAPIV3Schema/properties/spec/properties/canary/properties/explainer/properties/custom/properties/container/properties/ports/items/required/1
+  value: protocol
+
+- op: add
+  path:  /spec/validation/openAPIV3Schema/properties/spec/properties/canary/properties/predictor/properties/custom/properties/container/properties/ports/items/required/1
+  value: protocol
+
+- op: add
+  path:  /spec/validation/openAPIV3Schema/properties/spec/properties/canary/properties/transformer/properties/custom/properties/container/properties/ports/items/required/1
+  value: protocol
+
+- op: add
+  path:  /spec/validation/openAPIV3Schema/properties/spec/properties/default/properties/explainer/properties/custom/properties/container/properties/ports/items/required/1
+  value: protocol
+
+- op: add
+  path:  /spec/validation/openAPIV3Schema/properties/spec/properties/default/properties/predictor/properties/custom/properties/container/properties/ports/items/required/1
+  value: protocol
+
+- op: add
+  path:  /spec/validation/openAPIV3Schema/properties/spec/properties/default/properties/transformer/properties/custom/properties/container/properties/ports/items/required/1
+  value: protocol

--- a/docs/samples/custom/prebuilt-image/custom.yaml
+++ b/docs/samples/custom/prebuilt-image/custom.yaml
@@ -13,3 +13,4 @@ spec:
           image: codait/max-object-detector
           ports:
             - containerPort: 5000
+              protocol: TCP


### PR DESCRIPTION
This PR cherrypicks a yaml fix commit (#1128). This is a yaml only change.
