### PR TITLE
config: Fix port number of webhook in manager Pod

### DIFF
--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -39,7 +39,7 @@ spec:
             cpu: 100m
             memory: 200Mi
         ports:
-        - containerPort: 443
+        - containerPort: 9443
           name: webhook-server
           protocol: TCP
         volumeMounts:

--- a/config/webhook/service.yaml
+++ b/config/webhook/service.yaml
@@ -6,6 +6,6 @@ metadata:
 spec:
   ports:
     - port: 443
-      targetPort: 9443
+      targetPort: webhook-server
   selector:
     control-plane: kfserving-controller-manager


### PR DESCRIPTION
**What this PR does / why we need it**:

The webhook-server port in the manager Pod was set to 443, while it was
changed to 9443 [1]. Fix the discrepancy and refer to the port by name.

**Release note**:
```release-note
Fix the webhook-server's port number in the manager Pod.
```
