### PR TITLE
Fix cluster local inference service

### DIFF
--- a/docs/samples/v1beta1/advanced/cluster_local.yaml
+++ b/docs/samples/v1beta1/advanced/cluster_local.yaml
@@ -1,0 +1,10 @@
+apiVersion: "serving.kubeflow.org/v1beta1"
+kind: "InferenceService"
+metadata:
+  name: "sklearn-iris-local"
+  labels:
+    serving.knative.dev/visibility: cluster-local
+spec:
+  predictor:
+    sklearn:
+      storageUri: "gs://kfserving-samples/models/sklearn/iris"

--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -1,7 +1,7 @@
 set -e
 
 export ISTIO_VERSION=1.6.2
-export KNATIVE_VERSION=v0.15.0
+export KNATIVE_VERSION=v0.19.0
 export KFSERVING_VERSION=v0.4.1
 curl -L https://git.io/getLatestIstio | sh -
 cd istio-${ISTIO_VERSION}

--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -1,7 +1,7 @@
 set -e
 
 export ISTIO_VERSION=1.6.2
-export KNATIVE_VERSION=v0.19.0
+export KNATIVE_VERSION=v0.18.0
 export KFSERVING_VERSION=v0.4.1
 curl -L https://git.io/getLatestIstio | sh -
 cd istio-${ISTIO_VERSION}

--- a/pkg/apis/serving/v1beta1/openapi_generated.go
+++ b/pkg/apis/serving/v1beta1/openapi_generated.go
@@ -2984,7 +2984,6 @@ func schema_pkg_apis_serving_v1beta1_ONNXRuntimeSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -3242,7 +3241,6 @@ func schema_pkg_apis_serving_v1beta1_PMMLSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -3900,7 +3898,6 @@ func schema_pkg_apis_serving_v1beta1_PredictorExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -4686,7 +4683,6 @@ func schema_pkg_apis_serving_v1beta1_SKLearnSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -4944,7 +4940,6 @@ func schema_pkg_apis_serving_v1beta1_TFServingSpec(ref common.ReferenceCallback)
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5209,7 +5204,6 @@ func schema_pkg_apis_serving_v1beta1_TorchServeSpec(ref common.ReferenceCallback
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5926,7 +5920,6 @@ func schema_pkg_apis_serving_v1beta1_TritonSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6184,7 +6177,6 @@ func schema_pkg_apis_serving_v1beta1_XGBoostSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -204,6 +204,10 @@ var (
 		StorageInitializerSourceUriInternalAnnotationKey,
 		"kubectl.kubernetes.io/last-applied-configuration",
 	}
+
+	RevisionTemplateLabelDisallowedList = []string{
+		VisibilityLabel,
+	}
 )
 
 func (e InferenceServiceComponent) String() string {

--- a/pkg/controller/v1alpha2/inferenceservice/resources/istio/virtualservice_test.go
+++ b/pkg/controller/v1alpha2/inferenceservice/resources/istio/virtualservice_test.go
@@ -40,6 +40,8 @@ func TestCreateVirtualService(t *testing.T) {
 	predictorHostname := constants.InferenceServiceHostName(constants.DefaultPredictorServiceName(serviceName), namespace, domain)
 	transformerHostname := constants.InferenceServiceHostName(constants.DefaultTransformerServiceName(serviceName), namespace, domain)
 	explainerHostname := constants.InferenceServiceHostName(constants.DefaultExplainerServiceName(serviceName), namespace, domain)
+	canaryPredictorHostname := constants.InferenceServiceHostName(constants.CanaryPredictorServiceName(serviceName), namespace, domain)
+	canaryTransformerHostname := constants.InferenceServiceHostName(constants.CanaryTransformerServiceName(serviceName), namespace, domain)
 	predictorRouteMatch := []*istiov1alpha3.HTTPMatchRequest{
 		{
 			Authority: &istiov1alpha3.StringMatch{
@@ -136,6 +138,96 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 	}, {
+		name: "missing canary predictor",
+		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: predictorHostname,
+			},
+		},
+		canaryStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{},
+		},
+		expectedStatus:  createFailedStatus(PredictorHostnameUnknown, PredictorMissingMessage),
+		expectedService: nil,
+	}, {
+		name: "canary predictor no hostname",
+		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: predictorHostname,
+			},
+		},
+		canaryStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{},
+		},
+		expectedStatus:  createFailedStatus(PredictorHostnameUnknown, PredictorMissingMessage),
+		expectedService: nil,
+	}, {
+		name: "found default and canary predictor",
+		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: predictorHostname,
+			},
+		},
+		canaryStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: canaryPredictorHostname,
+			},
+		},
+		expectedStatus: &v1alpha2.VirtualServiceStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{{
+					Type:   v1alpha2.RoutesReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+			URL: expectedURL,
+			Address: &duckv1beta1.Addressable{
+				URL: &apis.URL{
+					Scheme: "http",
+					Path:   constants.PredictPath(serviceName),
+					Host:   network.GetServiceHostname(serviceName, namespace),
+				},
+			},
+			DefaultWeight: 80,
+			CanaryWeight:  20,
+		},
+		expectedService: &v1alpha3.VirtualService{
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+			Spec: istiov1alpha3.VirtualService{
+				Hosts:    []string{serviceHostName, serviceInternalHostName},
+				Gateways: []string{constants.KnativeIngressGateway, constants.KnativeLocalGateway},
+				Http: []*istiov1alpha3.HTTPRoute{
+					{
+						Match: predictorRouteMatch,
+						Route: []*istiov1alpha3.HTTPRouteDestination{
+							{
+								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
+								Weight:      80,
+								Headers: &istiov1alpha3.Headers{
+									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)},
+									},
+								},
+							},
+							{
+								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
+								Weight:      20,
+								Headers: &istiov1alpha3.Headers{
+									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.CanaryPredictorServiceName(serviceName), namespace)},
+									},
+								},
+							},
+						},
+						Retries: &istiov1alpha3.HTTPRetry{
+							Attempts:      0,
+							PerTryTimeout: nil,
+						},
+					},
+				},
+			},
+		},
+	}, {
 		name: "nil transformer status fails with status unknown",
 		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
 			constants.Transformer: v1alpha2.StatusConfigurationSpec{},
@@ -201,6 +293,94 @@ func TestCreateVirtualService(t *testing.T) {
 									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
 										"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
 									}},
+								},
+							},
+						},
+						Retries: &istiov1alpha3.HTTPRetry{
+							Attempts:      0,
+							PerTryTimeout: nil,
+						},
+					},
+				},
+			},
+		},
+	}, {
+		name: "missing canary transformer",
+		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Transformer: v1alpha2.StatusConfigurationSpec{
+				Hostname: transformerHostname,
+			},
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: predictorHostname,
+			},
+		},
+		canaryStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Transformer: v1alpha2.StatusConfigurationSpec{},
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: predictorHostname,
+			},
+		},
+		expectedStatus:  createFailedStatus(TransformerHostnameUnknown, TransformerMissingMessage),
+		expectedService: nil,
+	}, {
+		name: "canary & default transformer and predictor",
+		defaultStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Transformer: v1alpha2.StatusConfigurationSpec{
+				Hostname: transformerHostname,
+			},
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: predictorHostname,
+			},
+		},
+		canaryStatus: &map[constants.InferenceServiceComponent]v1alpha2.StatusConfigurationSpec{
+			constants.Transformer: v1alpha2.StatusConfigurationSpec{
+				Hostname: canaryTransformerHostname,
+			},
+			constants.Predictor: v1alpha2.StatusConfigurationSpec{
+				Hostname: canaryPredictorHostname,
+			},
+		},
+		expectedStatus: &v1alpha2.VirtualServiceStatus{
+			Status: duckv1beta1.Status{
+				Conditions: duckv1beta1.Conditions{{
+					Type:   v1alpha2.RoutesReady,
+					Status: corev1.ConditionTrue,
+				}},
+			},
+			URL: expectedURL,
+			Address: &duckv1beta1.Addressable{
+				URL: &apis.URL{
+					Scheme: "http",
+					Path:   constants.PredictPath(serviceName),
+					Host:   network.GetServiceHostname(serviceName, namespace),
+				},
+			},
+			DefaultWeight: 80,
+			CanaryWeight:  20,
+		},
+		expectedService: &v1alpha3.VirtualService{
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+			Spec: istiov1alpha3.VirtualService{
+				Hosts:    []string{serviceHostName, serviceInternalHostName},
+				Gateways: []string{constants.KnativeIngressGateway, constants.KnativeLocalGateway},
+				Http: []*istiov1alpha3.HTTPRoute{
+					{
+						Match: predictorRouteMatch,
+						Route: []*istiov1alpha3.HTTPRouteDestination{
+							{
+								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
+								Weight:      80,
+								Headers: &istiov1alpha3.Headers{
+									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace)}},
+								},
+							},
+							{
+								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
+								Weight:      20,
+								Headers: &istiov1alpha3.Headers{
+									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.CanaryTransformerServiceName(serviceName), namespace)}},
 								},
 							},
 						},
@@ -346,12 +526,25 @@ func TestCreateVirtualService(t *testing.T) {
 				},
 				Spec: v1alpha2.InferenceServiceSpec{
 					Default: v1alpha2.EndpointSpec{
+						Predictor:   createMockPredictorSpec(&tc.defaultStatus),
+						Explainer:   createMockExplainerSpec(tc.defaultStatus),
+						Transformer: createMockTransformerSpec(tc.defaultStatus),
 					},
 				},
 				Status: v1alpha2.InferenceServiceStatus{
 					Default: tc.defaultStatus,
 					Canary:  tc.canaryStatus,
 				},
+			}
+
+			if tc.canaryStatus != nil {
+				canarySpec := &v1alpha2.EndpointSpec{
+					Predictor:   createMockPredictorSpec(&tc.canaryStatus),
+					Explainer:   createMockExplainerSpec(tc.canaryStatus),
+					Transformer: createMockTransformerSpec(tc.canaryStatus),
+				}
+				testIsvc.Spec.Canary = canarySpec
+				testIsvc.Spec.CanaryTrafficPercent = v1alpha2.GetIntReference(20)
 			}
 
 			serviceBuilder := VirtualServiceBuilder{
@@ -414,3 +607,28 @@ func createInferenceServiceWithHostname(hostName string) *v1alpha2.InferenceServ
 	}
 }
 
+func createMockPredictorSpec(componentStatusMap *v1alpha2.ComponentStatusMap) v1alpha2.PredictorSpec {
+	return v1alpha2.PredictorSpec{}
+}
+
+func createMockExplainerSpec(componentStatusMap v1alpha2.ComponentStatusMap) *v1alpha2.ExplainerSpec {
+	if componentStatusMap == nil {
+		return nil
+	}
+
+	if _, ok := (*componentStatusMap)[constants.Explainer]; ok {
+		return &v1alpha2.ExplainerSpec{}
+	}
+	return nil
+}
+
+func createMockTransformerSpec(componentStatusMap v1alpha2.ComponentStatusMap) *v1alpha2.TransformerSpec {
+	if componentStatusMap == nil {
+		return nil
+	}
+
+	if _, ok := (*componentStatusMap)[constants.Transformer]; ok {
+		return &v1alpha2.TransformerSpec{}
+	}
+	return nil
+}

--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -217,12 +217,12 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			expectedVirtualService := &v1alpha3.VirtualService{
 				Spec: istiov1alpha3.VirtualService{
 					Gateways: []string{
-						constants.KnativeIngressGateway,
 						constants.KnativeLocalGateway,
+						constants.KnativeIngressGateway,
 					},
 					Hosts: []string{
-						constants.InferenceServiceHostName(serviceKey.Name, serviceKey.Namespace, domain),
 						network.GetServiceHostname(serviceKey.Name, serviceKey.Namespace),
+						constants.InferenceServiceHostName(serviceKey.Name, serviceKey.Namespace, domain),
 					},
 					Http: []*istiov1alpha3.HTTPRoute{
 						{
@@ -257,6 +257,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 										Host: network.GetServiceHostname("cluster-local-gateway", "istio-system"),
 										Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort},
 									},
+									Weight: 100,
 								},
 							},
 						},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -242,7 +242,7 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	}
 	isInternal := false
 	//if service is labelled with cluster local or knative domain is configured as internal
-	if val, ok := isvc.Labels[constants.VisibilityLabel]; ok && val == "ClusterLocal" {
+	if val, ok := isvc.Labels[constants.VisibilityLabel]; ok && val == "cluster-local" {
 		isInternal = true
 	}
 	serviceInternalHostName := network.GetServiceHostname(isvc.Name, isvc.Namespace)

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -19,6 +19,7 @@ import (
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
 	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/utils"
 	"github.com/pkg/errors"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -107,7 +108,9 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 				Percent:        proto.Int64(100),
 			})
 	}
-
+	labels := utils.Filter(componentMeta.Labels, func(key string) bool {
+		return !utils.Includes(constants.RevisionTemplateLabelDisallowedList, key)
+	})
 	service := &knservingv1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      componentMeta.Name,
@@ -118,7 +121,7 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 			ConfigurationSpec: knservingv1.ConfigurationSpec{
 				Template: knservingv1.RevisionTemplateSpec{
 					ObjectMeta: metav1.ObjectMeta{
-						Labels:      componentMeta.Labels,
+						Labels:      labels,
 						Annotations: annotations,
 					},
 					Spec: knservingv1.RevisionSpec{

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -24,7 +24,7 @@ CLUSTER_NAME="${CLUSTER_NAME}"
 AWS_REGION="${AWS_REGION}"
 
 ISTIO_VERSION="1.3.1"
-KNATIVE_VERSION="v0.15.0"
+KNATIVE_VERSION="v0.17.0"
 KUBECTL_VERSION="v1.14.0"
 CERT_MANAGER_VERSION="v0.12.0"
 # Check and wait for istio/knative/kfserving pod started normally.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1218 

**Special notes for your reviewer**:

1. According to https://knative.dev/docs/serving/cluster-local-route/#label-a-service-to-be-cluster-local, the value should be `cluster-local`

2. Tested with the following example 
```
apiVersion: "serving.kubeflow.org/v1beta1"
kind: "InferenceService"
metadata:
  name: "sklearn-iris-local"
  labels:
    serving.knative.dev/visibility: cluster-local
spec:
  predictor:
    sklearn:
      storageUri: "gs://kfserving-samples/models/sklearn/iris"
```

ksvc shows the correct local cluster url
```
kubectl get ksvc sklearn-iris-local-predictor-default
NAME                                   URL                                                                     LATESTCREATED                                LATESTREADY                                  READY   REASON
sklearn-iris-local-predictor-default   http://sklearn-iris-local-predictor-default.default.svc.cluster.local   sklearn-iris-local-predictor-default-8h7ck   sklearn-iris-local-predictor-default-8h7ck   True    
```

```
kubectl get vs sklearn-iris-local 
NAME                 GATEWAYS                                  HOSTS                                            AGE
sklearn-iris-local   [knative-serving/cluster-local-gateway]   [sklearn-iris-local.default.svc.cluster.local]   3m51s
```
**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
