### PR TITLE
Update metrics service label and selector

### DIFF
--- a/config/rbac/auth_proxy_service.yaml
+++ b/config/rbac/auth_proxy_service.yaml
@@ -6,7 +6,7 @@ metadata:
     prometheus.io/scheme: https
     prometheus.io/scrape: "true"
   labels:
-    control-plane: controller-manager
+    control-plane: kfserving-controller-manager
     controller-tools.k8s.io: "1.0"
   name: kfserving-controller-manager-metrics-service
   namespace: kfserving-system
@@ -16,5 +16,5 @@ spec:
     port: 8443
     targetPort: https
   selector:
-    control-plane: controller-manager
+    control-plane: kfserving-controller-manager
     controller-tools.k8s.io: "1.0"


### PR DESCRIPTION
**What this PR does / why we need it**:

This PR updates the control-plane label and selector for the `kfserving-controller-manager-metrics-service` to be consistent with the other control-plane values. This was an issue brought up in the manifests repo here: https://github.com/kubeflow/manifests/issues/1666

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Fix kfserving-controller-manager-metrics-service control-plane label and selector
```
