### PR TITLE
Fix: mosaic-onnx sample for ONNX InferenceService

### DIFF
--- a/docs/samples/v1alpha2/onnx/mosaic-onnx.ipynb
+++ b/docs/samples/v1alpha2/onnx/mosaic-onnx.ipynb
@@ -33,9 +33,9 @@
    ],
    "source": [
     "%%bash\n",
-    "echo \"model name: $MODEL_NAME\"\n",
     "echo \"service url: $SERVICE_HOSTNAME\"\n",
-    "echo \"cluster ip: $CLUSTER_IP\""
+    "echo \"ingress ip: $INGRESS_HOST\"\n",
+    "echo \"ingress port: $INGRESS_PORT\""
    ]
   },
   {
@@ -57,10 +57,11 @@
    "source": [
     "# if you dont see values above, see instructions in the readme and replace the values here!\n",
     "import os\n",
-    "model_name = os.environ[\"MODEL_NAME\"]\n",
+    "model_name = \"default\"\n",
     "service_hostname = os.environ[\"SERVICE_HOSTNAME\"]\n",
-    "cluster_ip = os.environ[\"CLUSTER_IP\"]\n",
-    "predictor_url = \"http://%s/v1/models/%s:predict\" % (cluster_ip, model_name)\n",
+    "ingress_ip = os.environ[\"INGRESS_HOST\"]\n",
+    "ingress_port = os.environ[\"INGRESS_PORT\"]\n",
+    "predictor_url = \"http://%s:%s/v1/models/default:predict\" % (ingress_ip, ingress_port)\n",
     "predictor_url"
    ]
   },
@@ -98,7 +99,7 @@
    "source": [
     "# load & resize image\n",
     "image = Image.open(\"image.jpg\")\n",
-    "image = image.resize((244,244), Image.ANTIALIAS)\n",
+    "image = image.resize((224,224), Image.ANTIALIAS)\n",
     "image"
    ]
   },
@@ -171,7 +172,7 @@
     "# Parse response message\n",
     "response_message = json_format.Parse(response.text, predict_pb2.PredictResponse())\n",
     "output1 = np.frombuffer(response_message.outputs['output1'].raw_data, dtype=np.float32)\n",
-    "output1 = output1.reshape(3,244,244)"
+    "output1 = output1.reshape(3,224,224)"
    ]
   },
   {
@@ -216,7 +217,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.5"
+   "version": "3.7.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Closes #1256 

**What this PR does / why we need it**:

This PR fixes `mosaic-onnx.ipynb` to run seamlessly from the procedure in [README.md](https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1alpha2/onnx#run-a-sample-inference).
Also, I fixed the bugs on `mosaic-onnx.ipynb`.

The main fixed points are as follows.

* Use `INGRESS_HOST` and `INGRESS_PORT` instead of `CLUSTER_IP` that make us easy to work from the procedures in [README.md](https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1alpha2/onnx#run-a-sample-inference).
* Change model name to `default` not to raise 500 error.
  * c.f. https://github.com/microsoft/onnxruntime/issues/2442
* Change arguments of `image.resize` which does not match model's input shape.