### PR TITLE
Fix: Missing link to Python SDK samples

### DIFF
--- a/python/kfserving/README.md
+++ b/python/kfserving/README.md
@@ -57,7 +57,7 @@ KFServing supports the following storage providers:
 
 ### Getting Started
 
-KFServing's python client interacts with KFServing APIs for executing operations on a remote KFServing cluster, such as creating, patching and deleting of a InferenceService instance. See the [Sample for KFServing Python SDK Client](../../docs/samples/client/kfserving_sdk_sample.ipynb) to get started.
+KFServing's python client interacts with KFServing APIs for executing operations on a remote KFServing cluster, such as creating, patching and deleting of a InferenceService instance. See the [Sample for KFServing Python SDK Client](../../docs/samples/client) to get started.
 
 ### Documentation for Client API
 


### PR DESCRIPTION
**What this PR does / why we need it**:

The link to the sample for KFServing Python SDK is missing.
This PR fixes it.