### PR TITLE
Remove redundant code in ONNX InferenceService sample

### DIFF
--- a/docs/samples/v1alpha2/onnx/mosaic-onnx.ipynb
+++ b/docs/samples/v1alpha2/onnx/mosaic-onnx.ipynb
@@ -134,10 +134,6 @@
    "outputs": [],
    "source": [
     "# Create request message to be sent to the predictor\n",
-    "import assets.onnx_ml_pb2 as onnx_ml_pb2\n",
-    "import assets.predict_pb2 as predict_pb2\n",
-    "import requests\n",
-    "\n",
     "input_tensor = onnx_ml_pb2.TensorProto()\n",
     "input_tensor.dims.extend(norm_img_data.shape)\n",
     "input_tensor.data_type = 1\n",


### PR DESCRIPTION
**What this PR does / why we need it**:

Remove redundant code in ONNX InferenceService sample notebook.
Some modules are imported in multiple times.