### PR TITLE
Use ModelClassName to differentiate kfserver or torchserve imp for v1 protocol

### DIFF
--- a/docs/apis/v1beta1/README.md
+++ b/docs/apis/v1beta1/README.md
@@ -963,12 +963,12 @@ knative.dev/pkg/apis/duck/v1.Status
 <p>
 (Members of <code>Status</code> are embedded into this type.)
 </p>
-<p>Conditions for the InferenceService
-- PredictorReady: predictor readiness condition;
-- TransformerReady: transformer readiness condition;
-- ExplainerReady: explainer readiness condition;
-- RoutesReady: aggregated routing condition;
-- Ready: aggregated condition;</p>
+<p>Conditions for the InferenceService <br/>
+- PredictorReady: predictor readiness condition; <br/>
+- TransformerReady: transformer readiness condition; <br/>
+- ExplainerReady: explainer readiness condition; <br/>
+- RoutesReady: aggregated routing condition; <br/>
+- Ready: aggregated condition; <br/></p>
 </td>
 </tr>
 <tr>
@@ -2386,7 +2386,7 @@ string
 </td>
 <td>
 <em>(Optional)</em>
-<p>Defaults PyTorch model class name to &lsquo;PyTorchModel&rsquo;</p>
+<p>When this field is specified KFS chooses the KFServer implementation, otherwise KFS uses the TorchServe implementation</p>
 </td>
 </tr>
 <tr>

--- a/docs/samples/v1beta1/torchserve/autoscaling/README.md
+++ b/docs/samples/v1beta1/torchserve/autoscaling/README.md
@@ -32,7 +32,6 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: "gs://kfserving-examples/models/torchserve/image_classifier"
 ```
 
@@ -50,7 +49,6 @@ spec:
   predictor:
     containerConcurrency: 10
     pytorch:
-      protocolVersion: v2
       storageUri: "gs://kfserving-examples/models/torchserve/image_classifier"
 ```
 

--- a/docs/samples/v1beta1/torchserve/autoscaling/autoscaling.yaml
+++ b/docs/samples/v1beta1/torchserve/autoscaling/autoscaling.yaml
@@ -9,8 +9,4 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: gs://kfserving-examples/models/torchserve/image_classifier
-      resources:
-        limits:
-          memory: 4Gi

--- a/docs/samples/v1beta1/torchserve/bert/bert.yaml
+++ b/docs/samples/v1beta1/torchserve/bert/bert.yaml
@@ -5,6 +5,5 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: gs://kfserving-examples/models/torchserve/huggingface
       # storageUri: pvc://model-pv-claim

--- a/docs/samples/v1beta1/torchserve/canary/README.md
+++ b/docs/samples/v1beta1/torchserve/canary/README.md
@@ -10,7 +10,6 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: "gs://kfserving-examples/models/torchserve/image_classifier"
 ```
 

--- a/docs/samples/v1beta1/torchserve/canary/canary.yaml
+++ b/docs/samples/v1beta1/torchserve/canary/canary.yaml
@@ -6,8 +6,4 @@ spec:
   predictor:
     canaryTrafficPercent: 20
     pytorch:
-      protocolVersion: v2
       storageUri: gs://kfserving-examples/models/torchserve/image_classifier/v2
-      resources:
-        limits:
-          memory: 4Gi

--- a/docs/samples/v1beta1/torchserve/gpu.yaml
+++ b/docs/samples/v1beta1/torchserve/gpu.yaml
@@ -5,7 +5,6 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: gs://kfserving-examples/models/torchserve/image_classifier
       resources:
         limits:

--- a/docs/samples/v1beta1/torchserve/metrics/README.md
+++ b/docs/samples/v1beta1/torchserve/metrics/README.md
@@ -38,7 +38,6 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: gs://kfserving-examples/models/torchserve/image_classifier
 ```
 

--- a/docs/samples/v1beta1/torchserve/metrics/metrics.yaml
+++ b/docs/samples/v1beta1/torchserve/metrics/metrics.yaml
@@ -8,5 +8,4 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: gs://kfserving-examples/models/torchserve/image_classifier

--- a/docs/samples/v1beta1/torchserve/torchserve.yaml
+++ b/docs/samples/v1beta1/torchserve/torchserve.yaml
@@ -5,9 +5,5 @@ metadata:
 spec:
   predictor:
     pytorch:
-      protocolVersion: v2
       storageUri: gs://kfserving-examples/models/torchserve/image_classifier
       # storageUri: pvc://model-pv-claim
-      resources:
-        limits:
-          memory: 4Gi

--- a/docs/samples/v1beta1/torchserve/transformer.yaml
+++ b/docs/samples/v1beta1/torchserve/transformer.yaml
@@ -9,11 +9,9 @@ spec:
         name: transformer-container
         env:
           - name: STORAGE_URI
-            value: pvc://model-pv-claim
+            value: gs://kfserving-examples/models/torchserve/image_classifier
+            #value: pvc://model-pv-claim
   predictor:
     pytorch:
-      protocolVersion: v2
-      storageUri: pvc://model-pv-claim
-      resources:
-        limits:
-          memory: 4Gi
+      storageUri: gs://kfserving-examples/models/torchserve/image_classifier
+      #storageUri: pvc://model-pv-claim

--- a/pkg/apis/serving/v1beta1/openapi_generated.go
+++ b/pkg/apis/serving/v1beta1/openapi_generated.go
@@ -447,7 +447,7 @@ func schema_pkg_apis_serving_v1beta1_AlibiExplainerSpec(ref common.ReferenceCall
 				Properties: map[string]spec.Schema{
 					"type": {
 						SchemaProps: spec.SchemaProps{
-							Description: "The type of Alibi explainer Valid values are: - \"AnchorTabular\"; - \"AnchorImages\"; - \"AnchorText\"; - \"Counterfactuals\"; - \"Contrastive\";",
+							Description: "The type of Alibi explainer <br /> Valid values are: <br /> - \"AnchorTabular\"; <br /> - \"AnchorImages\"; <br /> - \"AnchorText\"; <br /> - \"Counterfactuals\"; <br /> - \"Contrastive\"; <br />",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -2982,7 +2982,7 @@ func schema_pkg_apis_serving_v1beta1_LoggerSpec(ref common.ReferenceCallback) co
 					},
 					"mode": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Specifies the scope of the loggers. Valid values are: - \"all\" (default): log both request and response; - \"request\": log only request; - \"response\": log only response",
+							Description: "Specifies the scope of the loggers. <br /> Valid values are: <br /> - \"all\" (default): log both request and response; <br /> - \"request\": log only request; <br /> - \"response\": log only response <br />",
 							Type:        []string{"string"},
 							Format:      "",
 						},
@@ -4243,7 +4243,7 @@ func schema_pkg_apis_serving_v1beta1_PredictorSpec(ref common.ReferenceCallback)
 					},
 					"pmml": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Spec for PMML",
+							Description: "Spec for PMML (http://dmg.org/pmml/v4-1/GeneralStructure.html)",
 							Ref:         ref("./pkg/apis/serving/v1beta1.PMMLSpec"),
 						},
 					},
@@ -5238,7 +5238,7 @@ func schema_pkg_apis_serving_v1beta1_TorchServeSpec(ref common.ReferenceCallback
 				Properties: map[string]spec.Schema{
 					"modelClassName": {
 						SchemaProps: spec.SchemaProps{
-							Description: "Defaults PyTorch model class name to 'PyTorchModel'",
+							Description: "When this field is specified KFS chooses the KFServer implementation, otherwise KFS uses the TorchServe implementation",
 							Type:        []string{"string"},
 							Format:      "",
 						},

--- a/pkg/apis/serving/v1beta1/predictor_torchserve_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve_test.go
@@ -176,6 +176,7 @@ func TestTorchServeDefaulter(t *testing.T) {
 		"DefaultRuntimeVersion": {
 			spec: PredictorSpec{
 				PyTorch: &TorchServeSpec{
+					ModelClassName: "PyTorchModel",
 					PredictorExtensionSpec: PredictorExtensionSpec{
 						ProtocolVersion: &protocolV1,
 					},
@@ -225,6 +226,7 @@ func TestTorchServeDefaulter(t *testing.T) {
 		"DefaultResources": {
 			spec: PredictorSpec{
 				PyTorch: &TorchServeSpec{
+					ModelClassName: "PyTorchModel",
 					PredictorExtensionSpec: PredictorExtensionSpec{
 						ProtocolVersion: &protocolV1,
 						RuntimeVersion:  proto.String("0.3.0"),
@@ -298,6 +300,7 @@ func TestCreateTorchServeModelServingContainerV1(t *testing.T) {
 				Spec: InferenceServiceSpec{
 					Predictor: PredictorSpec{
 						PyTorch: &TorchServeSpec{
+							ModelClassName: "PyTorchModel",
 							PredictorExtensionSpec: PredictorExtensionSpec{
 								StorageURI: proto.String("gs://someUri"),
 								Container: v1.Container{
@@ -328,6 +331,7 @@ func TestCreateTorchServeModelServingContainerV1(t *testing.T) {
 				Spec: InferenceServiceSpec{
 					Predictor: PredictorSpec{
 						PyTorch: &TorchServeSpec{
+							ModelClassName: "PyTorchModel",
 							PredictorExtensionSpec: PredictorExtensionSpec{
 								StorageURI:      proto.String("gs://someUri"),
 								RuntimeVersion:  proto.String("latest"),
@@ -360,6 +364,7 @@ func TestCreateTorchServeModelServingContainerV1(t *testing.T) {
 				Spec: InferenceServiceSpec{
 					Predictor: PredictorSpec{
 						PyTorch: &TorchServeSpec{
+							ModelClassName: "PyTorchModel",
 							PredictorExtensionSpec: PredictorExtensionSpec{
 								StorageURI: proto.String("gs://someUri"),
 								Container: v1.Container{
@@ -394,6 +399,7 @@ func TestCreateTorchServeModelServingContainerV1(t *testing.T) {
 							ContainerConcurrency: proto.Int64(1),
 						},
 						PyTorch: &TorchServeSpec{
+							ModelClassName: "PyTorchModel",
 							PredictorExtensionSpec: PredictorExtensionSpec{
 								StorageURI:     proto.String("gs://someUri"),
 								RuntimeVersion: proto.String("0.1.0"),
@@ -432,7 +438,7 @@ func TestCreateTorchServeModelServingContainerV1(t *testing.T) {
 }
 
 func TestCreateTorchServeModelServingContainerV2(t *testing.T) {
-	protocolV2 := constants.ProtocolV2
+	protocolV1 := constants.ProtocolV1
 
 	var requestedResource = v1.ResourceRequirements{
 		Limits: v1.ResourceList{
@@ -476,7 +482,7 @@ func TestCreateTorchServeModelServingContainerV2(t *testing.T) {
 							PredictorExtensionSpec: PredictorExtensionSpec{
 								StorageURI:      proto.String("gs://someUri"),
 								RuntimeVersion:  proto.String("0.3.0"),
-								ProtocolVersion: &protocolV2,
+								ProtocolVersion: &protocolV1,
 								Container: v1.Container{
 									Resources: requestedResource,
 								},
@@ -507,7 +513,7 @@ func TestCreateTorchServeModelServingContainerV2(t *testing.T) {
 						PyTorch: &TorchServeSpec{
 							PredictorExtensionSpec: PredictorExtensionSpec{
 								StorageURI:      proto.String("gs://someUri"),
-								ProtocolVersion: &protocolV2,
+								ProtocolVersion: &protocolV1,
 								Container: v1.Container{
 									Image:     "customImage:0.1.0",
 									Resources: requestedResource,

--- a/pkg/apis/serving/v1beta1/swagger.json
+++ b/pkg/apis/serving/v1beta1/swagger.json
@@ -332,7 +332,7 @@
           "type": "boolean"
         },
         "type": {
-          "description": "The type of Alibi explainer Valid values are: - \"AnchorTabular\"; - \"AnchorImages\"; - \"AnchorText\"; - \"Counterfactuals\"; - \"Contrastive\";",
+          "description": "The type of Alibi explainer \u003cbr /\u003e Valid values are: \u003cbr /\u003e - \"AnchorTabular\"; \u003cbr /\u003e - \"AnchorImages\"; \u003cbr /\u003e - \"AnchorText\"; \u003cbr /\u003e - \"Counterfactuals\"; \u003cbr /\u003e - \"Contrastive\"; \u003cbr /\u003e",
           "type": "string"
         },
         "volumeDevices": {
@@ -1607,7 +1607,7 @@
       "type": "object",
       "properties": {
         "mode": {
-          "description": "Specifies the scope of the loggers. Valid values are: - \"all\" (default): log both request and response; - \"request\": log only request; - \"response\": log only response",
+          "description": "Specifies the scope of the loggers. \u003cbr /\u003e Valid values are: \u003cbr /\u003e - \"all\" (default): log both request and response; \u003cbr /\u003e - \"request\": log only request; \u003cbr /\u003e - \"response\": log only response \u003cbr /\u003e",
           "type": "string"
         },
         "url": {
@@ -2415,7 +2415,7 @@
           }
         },
         "pmml": {
-          "description": "Spec for PMML",
+          "description": "Spec for PMML (http://dmg.org/pmml/v4-1/GeneralStructure.html)",
           "$ref": "#/definitions/v1beta1.PMMLSpec"
         },
         "preemptionPolicy": {
@@ -2892,7 +2892,7 @@
           "$ref": "#/definitions/v1.Probe"
         },
         "modelClassName": {
-          "description": "Defaults PyTorch model class name to 'PyTorchModel'",
+          "description": "When this field is specified KFS chooses the KFServer implementation, otherwise KFS uses the TorchServe implementation",
           "type": "string"
         },
         "name": {

--- a/test/e2e/predictor/test_torchserve.py
+++ b/test/e2e/predictor/test_torchserve.py
@@ -45,7 +45,7 @@ def test_torchserve_kfserving():
         min_replicas=1,
         pytorch=V1beta1TorchServeSpec(
             storage_uri="gs://kfserving-examples/models/torchserve/image_classifier",
-            protocol_version="v2",
+            protocol_version="v1",
             resources=V1ResourceRequirements(
                 requests={"cpu": "1", "memory": "4Gi"},
                 limits={"cpu": "1", "memory": "4Gi"},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Use v2 protocolVersion to choose TorchServe implementation is confusing as v2 protocol is not supported yet, added the validation to reject when v2 protocol is specified.
2. Added the check that when `ModelClassName` is specified KFS choose the kfserver implementation otherwise use torchserve implementation.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
