### PR TITLE
Fix model puller flag and logging conflicts

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -231,11 +231,12 @@ func startLogger(workers int, logger *zap.SugaredLogger) *loggerArgs {
 }
 
 func startModelPuller(logger *zap.SugaredLogger) {
-	logger.Info("Initializing model agent with", "config-dir", configDir, "model-dir", modelDir)
+	logger.Infof("Initializing model agent with config-dir %s, model-dir %s", *configDir, *modelDir)
 
 	downloader := agent.Downloader{
 		ModelDir:  *modelDir,
 		Providers: map[storage.Protocol]storage.Provider{},
+		Logger:    logger,
 	}
 
 	if endpoint, ok := os.LookupEnv(s3credential.AWSEndpointUrl); ok {
@@ -250,7 +251,7 @@ func startModelPuller(logger *zap.SugaredLogger) {
 			Region:           aws.String(region),
 			S3ForcePathStyle: aws.Bool(!useVirtualBucket)},
 		)
-		logger.Info("Initializing s3 client with ", "endpoint", endpoint, "region", region)
+		logger.Infof("Initializing s3 client with endpoint %s, region %s", endpoint, region)
 		if err != nil {
 			panic(err)
 		}
@@ -262,8 +263,10 @@ func startModelPuller(logger *zap.SugaredLogger) {
 		}
 	}
 
-	watcher := agent.NewWatcher(*configDir, *modelDir)
-	agent.StartPuller(downloader, watcher.ModelEvents)
+	watcher := agent.NewWatcher(*configDir, *modelDir, logger)
+	logger.Info("starting puller")
+	agent.StartPuller(downloader, watcher.ModelEvents, logger)
+	logger.Info("starting watcher")
 	watcher.Start()
 }
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -264,9 +264,9 @@ func startModelPuller(logger *zap.SugaredLogger) {
 	}
 
 	watcher := agent.NewWatcher(*configDir, *modelDir, logger)
-	logger.Info("starting puller")
+	logger.Info("Starting puller")
 	agent.StartPuller(downloader, watcher.ModelEvents, logger)
-	logger.Info("starting watcher")
+	logger.Info("Starting watcher")
 	watcher.Start()
 }
 

--- a/docs/samples/v1beta1/triton/multimodel/s3_secret.yaml
+++ b/docs/samples/v1beta1/triton/multimodel/s3_secret.yaml
@@ -3,7 +3,7 @@ kind: Secret
 metadata:
   name: mysecret
   annotations:
-     serving.kubeflow.org/region: us-west-2
+     serving.kubeflow.org/s3-region: us-west-2
      serving.kubeflow.org/s3-usevirtualbucket: "false"
      serving.kubeflow.org/s3-endpoint: minio-service:9000 # replace with your s3 endpoint
      serving.kubeflow.org/s3-usehttps: "0" # by default 1, for testing with minio you need to set to 0

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -118,7 +118,7 @@ func (p *Puller) modelOpComplete(modelOp *ModelOp, closed bool) {
 }
 
 func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
-	p.logger.Infof("worker is started for %s", modelName)
+	p.logger.Infof("Worker is started for %s", modelName)
 	// TODO: Instead of going through each event, one-by-one, we need to drain and combine
 	// this is important for handling Load --> Unload requests sent in tandem
 	// Load --> Unload = 0 (cancel first load)
@@ -142,9 +142,13 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 					p.logger.Errorf("Failed to Load model %s", modelName)
 				} else {
 					defer resp.Body.Close()
-					body, err := ioutil.ReadAll(resp.Body)
-					if err == nil {
-						p.logger.Infof("Loaded model %s, resp=", modelName, body)
+					if resp.StatusCode == 200 {
+						p.logger.Infof("Successfully loaded model %s", modelName)
+					} else {
+						body, err := ioutil.ReadAll(resp.Body)
+						if err == nil {
+							p.logger.Infof("Failed to load model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
+						}
 					}
 				}
 			}
@@ -163,9 +167,13 @@ func (p *Puller) modelProcessor(modelName string, ops <-chan *ModelOp) {
 					p.logger.Errorf("Failed to Unload model %s", modelName)
 				} else {
 					defer resp.Body.Close()
-					body, err := ioutil.ReadAll(resp.Body)
-					if err == nil {
-						p.logger.Info("Unloaded model %s, resp=", modelName, body)
+					if resp.StatusCode == 200 {
+						p.logger.Infof("Successfully unloaded model %s", modelName)
+					} else {
+						body, err := ioutil.ReadAll(resp.Body)
+						if err == nil {
+							p.logger.Infof("Failed to unload model %s with status [%d] and resp:%v", modelName, resp.StatusCode, body)
+						}
 					}
 				}
 			}

--- a/pkg/agent/syncer.go
+++ b/pkg/agent/syncer.go
@@ -24,8 +24,12 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"path/filepath"
-	logf "sigs.k8s.io/controller-runtime/pkg/runtime/log"
+	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
+)
+
+var (
+	syncLogger = ctrl.Log.WithName("Syncer")
 )
 
 type FileError error
@@ -33,8 +37,7 @@ type FileError error
 var NoSuccessFile FileError = fmt.Errorf("no success file can be found")
 
 func SyncModelDir(modelDir string) (map[string]modelWrapper, error) {
-	log := logf.Log.WithName("Syncer")
-	log.Info("Syncing model directory..", "modelDir", modelDir)
+	syncLogger.Info("Syncing model directory..", "modelDir", modelDir)
 	modelTracker := make(map[string]modelWrapper)
 	err := filepath.Walk(modelDir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {

--- a/pkg/agent/syncer.go
+++ b/pkg/agent/syncer.go
@@ -24,12 +24,7 @@ import (
 	"k8s.io/apimachinery/pkg/api/resource"
 	"os"
 	"path/filepath"
-	ctrl "sigs.k8s.io/controller-runtime"
 	"strings"
-)
-
-var (
-	syncLogger = ctrl.Log.WithName("Syncer")
 )
 
 type FileError error
@@ -37,7 +32,6 @@ type FileError error
 var NoSuccessFile FileError = fmt.Errorf("no success file can be found")
 
 func SyncModelDir(modelDir string) (map[string]modelWrapper, error) {
-	syncLogger.Info("Syncing model directory..", "modelDir", modelDir)
 	modelTracker := make(map[string]modelWrapper)
 	err := filepath.Walk(modelDir, func(path string, info os.FileInfo, err error) error {
 		if info.IsDir() {

--- a/pkg/apis/serving/v1beta1/openapi_generated.go
+++ b/pkg/apis/serving/v1beta1/openapi_generated.go
@@ -2971,7 +2971,6 @@ func schema_pkg_apis_serving_v1beta1_LightGBMSpec(ref common.ReferenceCallback) 
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -3256,7 +3255,6 @@ func schema_pkg_apis_serving_v1beta1_ONNXRuntimeSpec(ref common.ReferenceCallbac
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -3514,7 +3512,6 @@ func schema_pkg_apis_serving_v1beta1_PMMLSpec(ref common.ReferenceCallback) comm
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -4179,7 +4176,6 @@ func schema_pkg_apis_serving_v1beta1_PredictorExtensionSpec(ref common.Reference
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -4976,7 +4972,6 @@ func schema_pkg_apis_serving_v1beta1_SKLearnSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5234,7 +5229,6 @@ func schema_pkg_apis_serving_v1beta1_TFServingSpec(ref common.ReferenceCallback)
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -5499,7 +5493,6 @@ func schema_pkg_apis_serving_v1beta1_TorchServeSpec(ref common.ReferenceCallback
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6216,7 +6209,6 @@ func schema_pkg_apis_serving_v1beta1_TritonSpec(ref common.ReferenceCallback) co
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{
@@ -6474,7 +6466,6 @@ func schema_pkg_apis_serving_v1beta1_XGBoostSpec(ref common.ReferenceCallback) c
 						},
 					},
 				},
-				
 			},
 		},
 		Dependencies: []string{

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,6 +53,7 @@ var (
 const (
 	AgentContainerName    = "agent"
 	AgentConfigMapKeyName = "agent"
+	AgentEnableFlag       = "-enable-puller"
 	AgentConfigDirArgName = "-config-dir"
 	AgentModelDirArgName  = "-model-dir"
 )

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -53,9 +53,9 @@ var (
 const (
 	AgentContainerName    = "agent"
 	AgentConfigMapKeyName = "agent"
-	AgentEnableFlag       = "-enable-puller"
-	AgentConfigDirArgName = "-config-dir"
-	AgentModelDirArgName  = "-model-dir"
+	AgentEnableFlag       = "--enable-puller"
+	AgentConfigDirArgName = "--config-dir"
+	AgentModelDirArgName  = "--model-dir"
 )
 
 // InferenceService Annotations

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -130,6 +130,8 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 	var args []string
 	modelConfig, ok := pod.ObjectMeta.Annotations[constants.AgentModelConfigMountPathAnnotationKey]
 	if ok {
+		args = append(args, constants.AgentEnableFlag)
+		args = append(args, "true")
 		args = append(args, constants.AgentConfigDirArgName)
 		args = append(args, modelConfig)
 	}

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -128,10 +128,13 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 	}
 
 	var args []string
-	modelConfig, ok := pod.ObjectMeta.Annotations[constants.AgentModelConfigMountPathAnnotationKey]
-	if ok {
+	if injectPuller {
 		args = append(args, constants.AgentEnableFlag)
 		args = append(args, "true")
+	}
+
+	modelConfig, ok := pod.ObjectMeta.Annotations[constants.AgentModelConfigMountPathAnnotationKey]
+	if ok {
 		args = append(args, constants.AgentConfigDirArgName)
 		args = append(args, modelConfig)
 	}

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -119,7 +119,7 @@ func TestAgentInjector(t *testing.T) {
 									MountPath: constants.ModelConfigDir,
 								},
 							},
-							Args: []string{"-enable-puller", "true", "-config-dir", "/mnt/configs", "-model-dir", "/mnt/models"},
+							Args: []string{"--enable-puller", "true", "--config-dir", "/mnt/configs", "--model-dir", "/mnt/models"},
 							Env:  []v1.EnvVar{},
 						},
 					},

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -119,7 +119,7 @@ func TestAgentInjector(t *testing.T) {
 									MountPath: constants.ModelConfigDir,
 								},
 							},
-							Args: []string{"-config-dir", "/mnt/configs", "-model-dir", "/mnt/models"},
+							Args: []string{"-enable-puller", "true", "-config-dir", "/mnt/configs", "-model-dir", "/mnt/models"},
 							Env:  []v1.EnvVar{},
 						},
 					},

--- a/test/e2e/predictor/test_torchserve.py
+++ b/test/e2e/predictor/test_torchserve.py
@@ -65,11 +65,6 @@ def test_torchserve_kfserving():
     KFServing.create(isvc, version=constants.KFSERVING_V1BETA1_VERSION)
     KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE)
 
-    ksvc = KFServing.get(
-        service_name,
-        namespace=KFSERVING_TEST_NAMESPACE,
-        version=constants.KFSERVING_V1BETA1_VERSION,
-    )
     res = predict(service_name, "./data/torchserve_input.json")
     assert(res.get("predictions")[0]==2)
     


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1280 

**Special notes for your reviewer**:

tested loading new model and then unload

```
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"logging/config.go:110","msg":"Successfully created the logger."}
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"logging/config.go:111","msg":"Logging level set to: info"}
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"logging/config.go:78","msg":"Fetch GitHub commit ID from kodata failed","error":"open /var/run/ko/HEAD: no such file or directory"}
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"agent/main.go:234","msg":"Initializing model agent with config-dir /mnt/configs, model-dir /mnt/models"}
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"agent/main.go:254","msg":"Initializing s3 client with endpoint http://minio-service.default:9000, region us-west-2"}
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"agent/watcher.go:173","msg":"adding model cifar10"}
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"agent/main.go:267","msg":"Starting puller"}
{"level":"info","ts":"2021-01-07T03:40:55.638Z","caller":"agent/main.go:269","msg":"Starting watcher"}
{"level":"info","ts":"2021-01-07T03:40:55.639Z","caller":"agent/watcher.go:89","msg":"Start to watch model config event"}
{"level":"info","ts":"2021-01-07T03:40:55.639Z","caller":"agent/watcher.go:127","msg":"Watching /mnt/data/models.json"}
{"level":"info","ts":"2021-01-07T03:40:55.639Z","caller":"agent/puller.go:121","msg":"Worker is started for cifar10"}
{"level":"info","ts":"2021-01-07T03:40:55.639Z","caller":"agent/puller.go:129","msg":"Downloading model from s3://triton/torchscript/cifar10"}
{"level":"info","ts":"2021-01-07T03:40:55.639Z","caller":"agent/downloader.go:47","msg":"Downloading s3://triton/torchscript/cifar10 to model dir /mnt/models"}
{"level":"info","ts":"2021-01-07T03:40:55.773Z","caller":"agent/puller.go:146","msg":"Successfully loaded model cifar10"}
{"level":"info","ts":"2021-01-07T03:40:55.773Z","caller":"agent/puller.go:114","msg":"completion event for model cifar10, in flight ops 0"}
{"level":"info","ts":"2021-01-07T03:42:01.648Z","caller":"agent/watcher.go:103","msg":"Processing event \"/mnt/configs/..data\": CREATE"}
{"level":"info","ts":"2021-01-07T03:42:01.649Z","caller":"agent/watcher.go:182","msg":"removing model cifar10"}
{"level":"info","ts":"2021-01-07T03:42:01.649Z","caller":"agent/puller.go:121","msg":"Worker is started for cifar10"}
{"level":"info","ts":"2021-01-07T03:42:01.649Z","caller":"agent/puller.go:156","msg":"unloading model cifar10"}
{"level":"info","ts":"2021-01-07T03:42:01.652Z","caller":"agent/puller.go:171","msg":"Successfully unloaded model cifar10"}
{"level":"info","ts":"2021-01-07T03:42:01.652Z","caller":"agent/puller.go:114","msg":"completion event for model cifar10, in flight ops 0"}
```

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
