### PR TITLE
Workaround for kustomize bug triggered in metrics and monitoring instructions

### DIFF
--- a/docs/samples/metrics-and-monitoring/README.md
+++ b/docs/samples/metrics-and-monitoring/README.md
@@ -30,7 +30,7 @@ In this section, we will use a v1beta1 InferenceService sample to demonstrate ho
 1. `kubectl create ns kfserving-test`
 2. `cd docs/samples/v1beta1/sklearn`
 3. `kubectl apply -f sklearn.yaml -n kfserving-test`
-4. If you are using a Minikube based cluster, then in a separate terminal, run `minikube tunnel` and supply password if prompted.
+4. If you are using a Minikube based cluster, then in a separate terminal, run `minikube tunnel --cleanup` and supply password if prompted.
 5. In a separate terminal, follow [these instructions](https://github.com/kubeflow/kfserving/blob/master/README.md#determine-the-ingress-ip-and-ports) to find and set your ingress IP, host, and service hostname. Then, send prediction requests to the `sklearn-iris` model you created in Step 3. above as follows.
 ```
 while clear; do \

--- a/docs/samples/metrics-and-monitoring/prometheus/clusterrolebinding.yaml
+++ b/docs/samples/metrics-and-monitoring/prometheus/clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: kfserving-monitoring
+  namespace: default

--- a/docs/samples/metrics-and-monitoring/prometheus/clusterrolebinding.yaml
+++ b/docs/samples/metrics-and-monitoring/prometheus/clusterrolebinding.yaml
@@ -9,4 +9,4 @@ roleRef:
 subjects:
 - kind: ServiceAccount
   name: prometheus
-  namespace: default
+  


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The sample instructions for getting started with metrics monitoring for KFServing models (see [here](https://github.com/kubeflow/kfserving/tree/master/docs/samples/metrics-and-monitoring)) triggers a bug in Kustomize.

The Kustomize bug is reported here: https://github.com/kubernetes-sigs/kustomize/issues/3430

Meanwhile, this simple one-field change in the kustomization resources provides a workaround which enables Prometheus monitoring to work as claimed.

**Special notes for your reviewer**:

@Tomcli @animeshsingh 

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

This is a pure documentation PR.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
