### PR TITLE
Add nil conversion for v1beta1 -> v1alpha2 explainer spec

### DIFF
--- a/pkg/apis/serving/v1alpha2/inferenceservice_conversion.go
+++ b/pkg/apis/serving/v1alpha2/inferenceservice_conversion.go
@@ -343,11 +343,13 @@ func (dst *InferenceService) ConvertFrom(srcRaw conversion.Hub) error {
 				},
 			}
 		}
-		dst.Spec.Default.Explainer.ServiceAccountName = src.Spec.Explainer.PodSpec.ServiceAccountName
-		dst.Spec.Default.Explainer.MinReplicas = src.Spec.Explainer.MinReplicas
-		dst.Spec.Default.Explainer.MaxReplicas = src.Spec.Explainer.MaxReplicas
-		if src.Spec.Explainer.ContainerConcurrency != nil {
-			dst.Spec.Default.Explainer.Parallelism = int(*src.Spec.Explainer.ContainerConcurrency)
+		if dst.Spec.Default.Explainer != nil {
+			dst.Spec.Default.Explainer.ServiceAccountName = src.Spec.Explainer.PodSpec.ServiceAccountName
+			dst.Spec.Default.Explainer.MinReplicas = src.Spec.Explainer.MinReplicas
+			dst.Spec.Default.Explainer.MaxReplicas = src.Spec.Explainer.MaxReplicas
+			if src.Spec.Explainer.ContainerConcurrency != nil {
+				dst.Spec.Default.Explainer.Parallelism = int(*src.Spec.Explainer.ContainerConcurrency)
+			}
 		}
 	}
 	return nil


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1310 

**Special notes for your reviewer**:

1. Add nil check in converter for explainer that doesn't support v1alpha2 spec.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
