### PR TITLE
Add E2E tests for MMS with the V2 protocol

### DIFF
--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -37,7 +37,7 @@ KFServing = KFServingClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/co
 
 
 @pytest.mark.parametrize(
-    "protocol_version,storage_uris,input_json",
+    "protocol_version,storage_uris",
     [
         (
             "v1",
@@ -45,21 +45,17 @@ KFServing = KFServingClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/co
                 "gs://kfserving-samples/models/sklearn/iris",
                 "gs://kfserving-samples/models/sklearn/iris",
             ],
-            "./data/iris_input.json",
         ),
         (
             "v2",
             [
-                "gs://seldon-models/sklearn/mms/model1-sklearn",
-                "gs://seldon-models/sklearn/mms/model2-sklearn",
+                "gs://seldon-models/sklearn/mms/model1-sklearn-v2",
+                "gs://seldon-models/sklearn/mms/model2-sklearn-v2",
             ],
-            "./data/iris_input_v2.json",
         ),
     ],
 )
-def test_mms_sklearn_kfserving(
-    protocol_version: str, storage_uris: List[str], input_json: str
-):
+def test_mms_sklearn_kfserving(protocol_version: str, storage_uris: List[str]):
     # Define an inference service
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
@@ -88,7 +84,10 @@ def test_mms_sklearn_kfserving(
 
     cluster_ip = get_cluster_ip()
 
-    model_names = ["model1-sklearn", "model2-sklearn"]
+    model_names = [
+        f"model1-sklearn-{protocol_version}",
+        f"model2-sklearn-{protocol_version}",
+    ]
 
     for model_name, storage_uri in zip(model_names, storage_uris):
         model_spec = V1alpha1ModelSpec(
@@ -120,6 +119,10 @@ def test_mms_sklearn_kfserving(
             cluster_ip=cluster_ip,
         )
 
+    input_json = "./data/iris_input.json"
+    if protocol_version == "v2":
+        input_json = "./data/iris_input_v2.json"
+
     responses = [
         predict(
             service_name,
@@ -143,12 +146,31 @@ def test_mms_sklearn_kfserving(
     KFServing.delete(service_name, KFSERVING_TEST_NAMESPACE)
 
 
-def test_mms_xgboost_kfserving():
+@pytest.mark.parametrize(
+    "protocol_version,storage_uris",
+    [
+        (
+            "v1",
+            [
+                "gs://kfserving-samples/models/xgboost/iris",
+                "gs://kfserving-samples/models/xgboost/iris",
+            ],
+        ),
+        (
+            "v2",
+            [
+                "gs://seldon-models/xgboost/mms/model1-xgboost-v2",
+                "gs://seldon-models/xgboost/mms/model2-xgboost-v2",
+            ],
+        ),
+    ],
+)
+def test_mms_xgboost_kfserving(protocol_version: str, storage_uris: List[str]):
     # Define an inference service
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         xgboost=V1beta1XGBoostSpec(
-            protocol_version="v1",
+            protocol_version=protocol_version,
             resources=client.V1ResourceRequirements(
                 requests={"cpu": "100m", "memory": "256Mi"},
                 limits={"cpu": "100m", "memory": "256Mi"},
@@ -156,7 +178,7 @@ def test_mms_xgboost_kfserving():
         ),
     )
 
-    service_name = "isvc-xgboost-mms"
+    service_name = f"isvc-xgboost-mms-{protocol_version}"
     isvc = V1beta1InferenceService(
         api_version=constants.KFSERVING_V1BETA1,
         kind=constants.KFSERVING_KIND,
@@ -170,80 +192,65 @@ def test_mms_xgboost_kfserving():
     KFServing.create(isvc)
     KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE)
 
-    # Define trained models
-    model1_spec = V1alpha1ModelSpec(
-        storage_uri="gs://kfserving-samples/models/xgboost/iris",
-        memory="256Mi",
-        framework="xgboost",
-    )
-
-    model2_spec = V1alpha1ModelSpec(
-        storage_uri="gs://kfserving-samples/models/xgboost/iris",
-        memory="256Mi",
-        framework="xgboost",
-    )
-
-    model1_name = "model1-xgboost"
-    model2_name = "model2-xgboost"
-    model1 = V1alpha1TrainedModel(
-        api_version=constants.KFSERVING_V1ALPHA1,
-        kind=constants.KFSERVING_KIND_TRAINEDMODEL,
-        metadata=client.V1ObjectMeta(
-            name=model1_name, namespace=KFSERVING_TEST_NAMESPACE
-        ),
-        spec=V1alpha1TrainedModelSpec(
-            inference_service=service_name, model=model1_spec
-        ),
-    )
-
-    model2 = V1alpha1TrainedModel(
-        api_version=constants.KFSERVING_V1ALPHA1,
-        kind=constants.KFSERVING_KIND_TRAINEDMODEL,
-        metadata=client.V1ObjectMeta(
-            name=model2_name, namespace=KFSERVING_TEST_NAMESPACE
-        ),
-        spec=V1alpha1TrainedModelSpec(
-            inference_service=service_name, model=model2_spec
-        ),
-    )
-
-    # Create instances of trained models using model1 and model2
-    KFServing.create_trained_model(model1, KFSERVING_TEST_NAMESPACE)
-    KFServing.create_trained_model(model2, KFSERVING_TEST_NAMESPACE)
-
     cluster_ip = get_cluster_ip()
+    model_names = [
+        f"model1-xgboost-{protocol_version}",
+        f"model2-xgboost-{protocol_version}",
+    ]
 
-    KFServing.wait_model_ready(
-        service_name,
-        model1_name,
-        isvc_namespace=KFSERVING_TEST_NAMESPACE,
-        isvc_version=constants.KFSERVING_V1BETA1_VERSION,
-        cluster_ip=cluster_ip,
-    )
-    KFServing.wait_model_ready(
-        service_name,
-        model2_name,
-        isvc_namespace=KFSERVING_TEST_NAMESPACE,
-        isvc_version=constants.KFSERVING_V1BETA1_VERSION,
-        cluster_ip=cluster_ip,
-    )
+    for model_name, storage_uri in zip(model_names, storage_uris):
+        # Define trained models
+        model_spec = V1alpha1ModelSpec(
+            storage_uri=storage_uri,
+            memory="256Mi",
+            framework="xgboost",
+        )
 
-    # Call predict on the two models
-    res_model1 = predict(
-        service_name,
-        input_json,
-        model_name=model1_name,
-        protocol_version=protocol_version,
-    )
-    res_model2 = predict(
-        service_name,
-        input_json,
-        model_name=model2_name,
-        protocol_version=protocol_version,
-    )
+        model = V1alpha1TrainedModel(
+            api_version=constants.KFSERVING_V1ALPHA1,
+            kind=constants.KFSERVING_KIND_TRAINEDMODEL,
+            metadata=client.V1ObjectMeta(
+                name=model_name, namespace=KFSERVING_TEST_NAMESPACE
+            ),
+            spec=V1alpha1TrainedModelSpec(
+                inference_service=service_name, model=model_spec
+            ),
+        )
 
-    assert res_model1["predictions"] == [1, 1]
-    assert res_model2["predictions"] == [1, 1]
+        # Create instances of trained models using model1 and model2
+        KFServing.create_trained_model(model, KFSERVING_TEST_NAMESPACE)
 
-    # Clean up inference service
+        KFServing.wait_model_ready(
+            service_name,
+            model_name,
+            isvc_namespace=KFSERVING_TEST_NAMESPACE,
+            isvc_version=constants.KFSERVING_V1BETA1_VERSION,
+            protocol_version=protocol_version,
+            cluster_ip=cluster_ip,
+        )
+
+    input_json = "./data/iris_input.json"
+    if protocol_version == "v2":
+        input_json = "./data/iris_input_v2.json"
+
+    responses = [
+        predict(
+            service_name,
+            input_json,
+            model_name=model_name,
+            protocol_version=protocol_version,
+        )
+        for model_name in model_names
+    ]
+
+    if protocol_version == "v1":
+        assert responses[0]["predictions"] == [1, 1]
+        assert responses[1]["predictions"] == [1, 1]
+    elif protocol_version == "v2":
+        assert responses[0]["outputs"][0]["data"] == [1.0, 1.0]
+        assert responses[1]["outputs"][0]["data"] == [1.0, 1.0]
+
+    # Clean up inference service and trained models
+    for model_name in model_names:
+        KFServing.delete_trained_model(model_name, KFSERVING_TEST_NAMESPACE)
     KFServing.delete(service_name, KFSERVING_TEST_NAMESPACE)

--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -13,20 +13,21 @@
 # limitations under the License.
 
 import os
+import pytest
+
+from typing import List
 from kubernetes import client
 from kfserving import (
     constants,
     KFServingClient,
     V1beta1PredictorSpec,
     V1alpha1TrainedModel,
-    V1alpha2EndpointSpec,
     V1beta1InferenceService,
     V1beta1InferenceServiceSpec,
     V1alpha1ModelSpec,
     V1alpha1TrainedModelSpec,
     V1beta1SKLearnSpec,
     V1beta1XGBoostSpec,
-    V1alpha2TritonSpec,
 )
 
 from ..common.utils import predict, get_cluster_ip
@@ -34,95 +35,113 @@ from ..common.utils import KFSERVING_TEST_NAMESPACE
 
 KFServing = KFServingClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
 
-def test_mms_sklearn_kfserving():
+
+@pytest.mark.parametrize(
+    "protocol_version,storage_uris,input_json",
+    [
+        (
+            "v1",
+            [
+                "gs://kfserving-samples/models/sklearn/iris",
+                "gs://kfserving-samples/models/sklearn/iris",
+            ],
+            "./data/iris_input.json",
+        ),
+        (
+            "v2",
+            [
+                "gs://seldon-models/sklearn/mms/model1-sklearn",
+                "gs://seldon-models/sklearn/mms/model2-sklearn",
+            ],
+            "./data/iris_input_v2.json",
+        ),
+    ],
+)
+def test_mms_sklearn_kfserving(
+    protocol_version: str, storage_uris: List[str], input_json: str
+):
     # Define an inference service
     predictor = V1beta1PredictorSpec(
         min_replicas=1,
         sklearn=V1beta1SKLearnSpec(
-            protocol_version="v1",
+            protocol_version=protocol_version,
             resources=client.V1ResourceRequirements(
                 requests={"cpu": "100m", "memory": "256Mi"},
                 limits={"cpu": "100m", "memory": "256Mi"},
-            )
-        )
+            ),
+        ),
     )
 
-    service_name = "isvc-sklearn-mms"
+    service_name = f"isvc-sklearn-mms-{protocol_version}"
     isvc = V1beta1InferenceService(
         api_version=constants.KFSERVING_V1BETA1,
         kind=constants.KFSERVING_KIND,
         metadata=client.V1ObjectMeta(
-            name=service_name,
-            namespace=KFSERVING_TEST_NAMESPACE
+            name=service_name, namespace=KFSERVING_TEST_NAMESPACE
         ),
-        spec=V1beta1InferenceServiceSpec(predictor=predictor)
-    )
-
-    # Define trained models
-    model1_spec = V1alpha1ModelSpec(
-        storage_uri=f"gs://kfserving-samples/models/sklearn/iris",
-        memory='256Mi',
-        framework="sklearn"
-    )
-
-    model2_spec = V1alpha1ModelSpec(
-        storage_uri=f"gs://kfserving-samples/models/sklearn/iris",
-        memory='256Mi',
-        framework="sklearn"
-    )
-
-    model1_name = "model1-sklearn"
-    model2_name = "model2-sklearn"
-    model1 = V1alpha1TrainedModel(
-        api_version=constants.KFSERVING_V1ALPHA1,
-        kind=constants.KFSERVING_KIND_TRAINEDMODEL,
-        metadata=client.V1ObjectMeta(
-            name=model1_name,
-            namespace=KFSERVING_TEST_NAMESPACE
-        ),
-        spec=V1alpha1TrainedModelSpec(
-            inference_service=service_name,
-            model=model1_spec
-        )
-    )
-
-    model2 = V1alpha1TrainedModel(
-        api_version=constants.KFSERVING_V1ALPHA1,
-        kind=constants.KFSERVING_KIND_TRAINEDMODEL,
-        metadata=client.V1ObjectMeta(
-            name=model2_name,
-            namespace=KFSERVING_TEST_NAMESPACE
-        ),
-        spec=V1alpha1TrainedModelSpec(
-            inference_service=service_name,
-            model=model2_spec
-        )
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
 
     # Create an instance of inference service with isvc
     KFServing.create(isvc)
     KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE)
 
-    # Create instances of trained models using model1 and model2
-    KFServing.create_trained_model(model1, KFSERVING_TEST_NAMESPACE)
-    KFServing.create_trained_model(model2, KFSERVING_TEST_NAMESPACE)
-
     cluster_ip = get_cluster_ip()
 
-    KFServing.wait_model_ready(service_name, model1_name, isvc_namespace=KFSERVING_TEST_NAMESPACE,
-                                isvc_version=constants.KFSERVING_V1BETA1_VERSION, cluster_ip=cluster_ip)
-    KFServing.wait_model_ready(service_name, model2_name, isvc_namespace=KFSERVING_TEST_NAMESPACE,
-                                isvc_version=constants.KFSERVING_V1BETA1_VERSION, cluster_ip=cluster_ip)
+    model_names = ["model1-sklearn", "model2-sklearn"]
 
-    # Call predict on the two models
-    res_model1 = predict(service_name, "./data/iris_input.json", model_name=model1_name)
-    res_model2 = predict(service_name, "./data/iris_input.json", model_name=model2_name)
+    for model_name, storage_uri in zip(model_names, storage_uris):
+        model_spec = V1alpha1ModelSpec(
+            storage_uri=storage_uri,
+            memory="256Mi",
+            framework="sklearn",
+        )
 
-    assert res_model1["predictions"] == [1,1]
-    assert res_model2["predictions"] == [1,1]
+        model = V1alpha1TrainedModel(
+            api_version=constants.KFSERVING_V1ALPHA1,
+            kind=constants.KFSERVING_KIND_TRAINEDMODEL,
+            metadata=client.V1ObjectMeta(
+                name=model_name, namespace=KFSERVING_TEST_NAMESPACE
+            ),
+            spec=V1alpha1TrainedModelSpec(
+                inference_service=service_name, model=model_spec
+            ),
+        )
 
-    # Clean up inference service
+        # Create instances of trained models using model1 and model2
+        KFServing.create_trained_model(model, KFSERVING_TEST_NAMESPACE)
+
+        KFServing.wait_model_ready(
+            service_name,
+            model_name,
+            isvc_namespace=KFSERVING_TEST_NAMESPACE,
+            isvc_version=constants.KFSERVING_V1BETA1_VERSION,
+            protocol_version=protocol_version,
+            cluster_ip=cluster_ip,
+        )
+
+    responses = [
+        predict(
+            service_name,
+            input_json,
+            model_name=model_name,
+            protocol_version=protocol_version,
+        )
+        for model_name in model_names
+    ]
+
+    if protocol_version == "v1":
+        assert responses[0]["predictions"] == [1, 1]
+        assert responses[1]["predictions"] == [1, 1]
+    elif protocol_version == "v2":
+        assert responses[0]["outputs"][0]["data"] == [1, 2]
+        assert responses[1]["outputs"][0]["data"] == [1, 2]
+
+    # Clean up inference service and trained models
+    for model_name in model_names:
+        KFServing.delete_trained_model(model_name, KFSERVING_TEST_NAMESPACE)
     KFServing.delete(service_name, KFSERVING_TEST_NAMESPACE)
+
 
 def test_mms_xgboost_kfserving():
     # Define an inference service
@@ -133,8 +152,8 @@ def test_mms_xgboost_kfserving():
             resources=client.V1ResourceRequirements(
                 requests={"cpu": "100m", "memory": "256Mi"},
                 limits={"cpu": "100m", "memory": "256Mi"},
-            )
-        )
+            ),
+        ),
     )
 
     service_name = "isvc-xgboost-mms"
@@ -142,23 +161,26 @@ def test_mms_xgboost_kfserving():
         api_version=constants.KFSERVING_V1BETA1,
         kind=constants.KFSERVING_KIND,
         metadata=client.V1ObjectMeta(
-            name=service_name,
-            namespace=KFSERVING_TEST_NAMESPACE
+            name=service_name, namespace=KFSERVING_TEST_NAMESPACE
         ),
-        spec=V1beta1InferenceServiceSpec(predictor=predictor)
+        spec=V1beta1InferenceServiceSpec(predictor=predictor),
     )
+
+    # Create an instance of inference service with isvc
+    KFServing.create(isvc)
+    KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE)
 
     # Define trained models
     model1_spec = V1alpha1ModelSpec(
         storage_uri="gs://kfserving-samples/models/xgboost/iris",
-        memory='256Mi',
-        framework="xgboost"
+        memory="256Mi",
+        framework="xgboost",
     )
 
     model2_spec = V1alpha1ModelSpec(
         storage_uri="gs://kfserving-samples/models/xgboost/iris",
-        memory='256Mi',
-        framework="xgboost"
+        memory="256Mi",
+        framework="xgboost",
     )
 
     model1_name = "model1-xgboost"
@@ -167,31 +189,23 @@ def test_mms_xgboost_kfserving():
         api_version=constants.KFSERVING_V1ALPHA1,
         kind=constants.KFSERVING_KIND_TRAINEDMODEL,
         metadata=client.V1ObjectMeta(
-            name=model1_name,
-            namespace=KFSERVING_TEST_NAMESPACE
+            name=model1_name, namespace=KFSERVING_TEST_NAMESPACE
         ),
         spec=V1alpha1TrainedModelSpec(
-            inference_service=service_name,
-            model=model1_spec
-        )
+            inference_service=service_name, model=model1_spec
+        ),
     )
 
     model2 = V1alpha1TrainedModel(
         api_version=constants.KFSERVING_V1ALPHA1,
         kind=constants.KFSERVING_KIND_TRAINEDMODEL,
         metadata=client.V1ObjectMeta(
-            name=model2_name,
-            namespace=KFSERVING_TEST_NAMESPACE
+            name=model2_name, namespace=KFSERVING_TEST_NAMESPACE
         ),
         spec=V1alpha1TrainedModelSpec(
-            inference_service=service_name,
-            model=model2_spec
-        )
+            inference_service=service_name, model=model2_spec
+        ),
     )
-
-    # Create an instance of inference service with isvc
-    KFServing.create(isvc)
-    KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE)
 
     # Create instances of trained models using model1 and model2
     KFServing.create_trained_model(model1, KFSERVING_TEST_NAMESPACE)
@@ -199,17 +213,37 @@ def test_mms_xgboost_kfserving():
 
     cluster_ip = get_cluster_ip()
 
-    KFServing.wait_model_ready(service_name, model1_name, isvc_namespace=KFSERVING_TEST_NAMESPACE,
-                                isvc_version=constants.KFSERVING_V1BETA1_VERSION, cluster_ip=cluster_ip)
-    KFServing.wait_model_ready(service_name, model2_name, isvc_namespace=KFSERVING_TEST_NAMESPACE,
-                                isvc_version=constants.KFSERVING_V1BETA1_VERSION, cluster_ip=cluster_ip)
+    KFServing.wait_model_ready(
+        service_name,
+        model1_name,
+        isvc_namespace=KFSERVING_TEST_NAMESPACE,
+        isvc_version=constants.KFSERVING_V1BETA1_VERSION,
+        cluster_ip=cluster_ip,
+    )
+    KFServing.wait_model_ready(
+        service_name,
+        model2_name,
+        isvc_namespace=KFSERVING_TEST_NAMESPACE,
+        isvc_version=constants.KFSERVING_V1BETA1_VERSION,
+        cluster_ip=cluster_ip,
+    )
 
     # Call predict on the two models
-    res_model1 = predict(service_name, "./data/iris_input.json", model_name=model1_name)
-    res_model2 = predict(service_name, "./data/iris_input.json", model_name=model2_name)
+    res_model1 = predict(
+        service_name,
+        input_json,
+        model_name=model1_name,
+        protocol_version=protocol_version,
+    )
+    res_model2 = predict(
+        service_name,
+        input_json,
+        model_name=model2_name,
+        protocol_version=protocol_version,
+    )
 
-    assert res_model1["predictions"] == [1,1]
-    assert res_model2["predictions"] == [1,1]
+    assert res_model1["predictions"] == [1, 1]
+    assert res_model2["predictions"] == [1, 1]
 
     # Clean up inference service
     KFServing.delete(service_name, KFSERVING_TEST_NAMESPACE)


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Add integration tests for MMS when using the V2 protocol with SKLearn and XGBoost models.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

There are some changes due to `black`'s autoformatting rules. 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
NONE
```
