### PR TITLE
Fix dependency for lightgbm and aix python server

### DIFF
--- a/python/aixexplainer/setup.py
+++ b/python/aixexplainer/setup.py
@@ -35,7 +35,8 @@ setup(
         "argparse >= 1.4.0",
         "aix360 >= 0.1.0",
         "lime >= 0.1.1.37",
-        "nest_asyncio>=1.4.0"
+        "nest_asyncio>=1.4.0",
+        "cvxpy == 1.1.7"
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}

--- a/python/lgbserver/setup.py
+++ b/python/lgbserver/setup.py
@@ -36,7 +36,8 @@ setup(
         "kfserving>=0.4.0",
         "lightgbm == 2.3.1",
         "pandas == 0.25.3",
-        "argparse >= 1.4.0"
+        "argparse >= 1.4.0",
+        "numpy == 1.19.5",
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -170,5 +170,5 @@ popd
 
 echo "Starting E2E functional tests ..."
 pushd test/e2e >/dev/null
-  pytest -n 3 --ignore=credentials/test_set_creds.py --ignore=predictor/test_lightgbm.py
+  pytest -n 3 --ignore=credentials/test_set_creds.py
 popd


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The latest numpy 1.20.0 release breaks the aix and lightgbm python servers

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1335 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
