### PR TITLE
Allow any .onnx file name in v1beta1 api

### DIFF
--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -18,6 +18,7 @@ package v1beta1
 
 import (
 	"fmt"
+	"path"
 
 	"github.com/golang/protobuf/proto"
 	"github.com/kubeflow/kfserving/pkg/constants"
@@ -29,7 +30,8 @@ import (
 var (
 	ONNXServingRestPort = "8080"
 	ONNXServingGRPCPort = "9000"
-	ONNXModelFileName   = "model.onnx"
+	ONNXFileExt         = ".onnx"
+	DefaultONNXFileName = "model.onnx"
 )
 
 // ONNXRuntimeSpec defines arguments for configuring ONNX model serving.
@@ -42,6 +44,12 @@ var _ ComponentImplementation = &ONNXRuntimeSpec{}
 
 // Validate returns an error if invalid
 func (o *ONNXRuntimeSpec) Validate() error {
+	if o.GetStorageUri() != nil {
+		if ext := path.Ext(*o.GetStorageUri()); ext != ONNXFileExt && ext != "" {
+			return fmt.Errorf("Expected storageUri file extension: '%s' but got '%s'", ONNXFileExt, ext)
+		}
+	}
+
 	return utils.FirstNonNilError([]error{
 		validateStorageURI(o.GetStorageUri()),
 	})
@@ -58,8 +66,16 @@ func (o *ONNXRuntimeSpec) Default(config *InferenceServicesConfig) {
 
 // GetContainers transforms the resource into a container spec
 func (o *ONNXRuntimeSpec) GetContainer(metadata metav1.ObjectMeta, extensions *ComponentExtensionSpec, config *InferenceServicesConfig) *v1.Container {
+	filename := DefaultONNXFileName
+
+	if o.GetStorageUri() != nil {
+		if ext := path.Ext(*o.GetStorageUri()); ext != "" {
+			filename = path.Base(*o.GetStorageUri())
+		}
+	}
+
 	arguments := []string{
-		fmt.Sprintf("%s=%s", "--model_path", constants.DefaultModelLocalMountPath+"/"+ONNXModelFileName),
+		fmt.Sprintf("%s=%s", "--model_path", constants.DefaultModelLocalMountPath+"/"+filename),
 		fmt.Sprintf("%s=%s", "--http_port", ONNXServingRestPort),
 		fmt.Sprintf("%s=%s", "--grpc_port", ONNXServingGRPCPort),
 	}

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime_test.go
@@ -94,6 +94,26 @@ func TestOnnxRuntimeValidation(t *testing.T) {
 			},
 			matcher: gomega.Not(gomega.BeNil()),
 		},
+		"ValidModelExtension": {
+			spec: PredictorSpec{
+				ONNX: &ONNXRuntimeSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						StorageURI: proto.String("gs://my_model.onnx"),
+					},
+				},
+			},
+			matcher: gomega.BeNil(),
+		},
+		"InvalidModelExtension": {
+			spec: PredictorSpec{
+				ONNX: &ONNXRuntimeSpec{
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						StorageURI: proto.String("gs://my_model.txt"),
+					},
+				},
+			},
+			matcher: gomega.Not(gomega.BeNil()),
+		},
 	}
 
 	for name, scenario := range scenarios {
@@ -297,6 +317,36 @@ func TestCreateONNXRuntimeContainer(t *testing.T) {
 				Resources: requestedResource,
 				Args: []string{
 					"--model_path=/mnt/models/model.onnx",
+					"--http_port=8080",
+					"--grpc_port=9000",
+				},
+			},
+		},
+		"ContainerSpecWithNonDefaultFileName": {
+			isvc: InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "onnx",
+				},
+				Spec: InferenceServiceSpec{
+					Predictor: PredictorSpec{
+						ONNX: &ONNXRuntimeSpec{
+							PredictorExtensionSpec: PredictorExtensionSpec{
+								StorageURI:     proto.String("gs://my_model.onnx"),
+								RuntimeVersion: proto.String("v1.0.0"),
+								Container: v1.Container{
+									Resources: requestedResource,
+								},
+							},
+						},
+					},
+				},
+			},
+			expectedContainerSpec: &v1.Container{
+				Image:     "mcr.microsoft.com/onnxruntime/server:v1.0.0",
+				Name:      constants.InferenceServiceContainerName,
+				Resources: requestedResource,
+				Args: []string{
+					"--model_path=/mnt/models/my_model.onnx",
 					"--http_port=8080",
 					"--grpc_port=9000",
 				},


### PR DESCRIPTION
**What this PR does / why we need it**:

Allow any model file name with `.onnx` extension or a storageURI with no extension.

This was added in `v1alpha2` but was not ported to `v1beta1` https://github.com/kubeflow/kfserving/pull/1078