### PR TITLE
Feature to include headers in http/https service requests (non-MMS)

### DIFF
--- a/docs/samples/storage/uri/README.md
+++ b/docs/samples/storage/uri/README.md
@@ -19,7 +19,7 @@ metadata:
   name: mysecret
 type: Opaque
 data:
-  https-host-uri: ZXhhbXBsZS5jb20=
+  https-host: ZXhhbXBsZS5jb20=
   headers: |-
     YWNjb3VudC1uYW1lOiBzb21lX2FjY291bnRfbmFtZQpzZWNyZXQta2V5OiBzb21lX3NlY3JldF9rZXk=
 ---
@@ -30,9 +30,9 @@ metadata:
 secrets:
   - name: mysecret
 ```
-Make sure you have serviceAccountName specified in your predictor in your inference service. These headers will be applied to any http/https requests that have the same host uri.
+Make sure you have serviceAccountName specified in your predictor in your inference service. These headers will be applied to any http/https requests that have the same host.
 
-You will need to base64 encode the headers and host uri. Make sure each header is on a newline with the format `header_key: header_value`.
+You will need to base64 encode the headers and host. Make sure each header is on a newline with the format `header_key: header_value`.
 ```text
 example.com
 # echo -n "example.com" | base64

--- a/docs/samples/storage/uri/README.md
+++ b/docs/samples/storage/uri/README.md
@@ -8,6 +8,39 @@ This `storageUri` option supports single file models, like `sklearn` which is sp
 2. Your cluster's Istio Ingress gateway must be network accessible.
 3. Your cluster's Istio Egress gateway must [allow http / https traffic](https://knative.dev/docs/serving/outbound-network-access/)
 
+## Create HTTP/HTTPS header Secret and attach to Service account
+If you do not require headers in your HTTP/HTTPS service request then you can skip this step.
+You can define headers by following the following format:
+
+```yaml
+apiVersion: v1
+kind: Secret
+metadata:
+  name: mysecret
+  annotations:
+    serving.kubeflow.org/https-host-uri: “example.com”
+type: Opaque
+data:
+  headers: |-
+    YWNjb3VudC1uYW1lOiBzb21lX2FjY291bnRfbmFtZQpzZWNyZXQta2V5OiBzb21lX3NlY3JldF9rZXk=
+---
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: sa
+secrets:
+  - name: mysecret
+```
+Make sure you have serviceAccountName specified in your predictor in your inference service. These headers will be applied to any http/https requests that have the same host uri.
+
+You will need to base64 encode the headers
+```
+account-name: some_account_name
+secret-key: some_secret_key
+# Base64 encoded into:
+YWNjb3VudC1uYW1lOiBzb21lX2FjY291bnRfbmFtZQpzZWNyZXQta2V5OiBzb21lX3NlY3JldF9rZXk=
+```
+
 ## Sklearn
 ### Train and freeze the model
 Here, we'll train a simple iris model. Please note that `kfserving` requires `sklearn==0.20.3`. 

--- a/docs/samples/storage/uri/README.md
+++ b/docs/samples/storage/uri/README.md
@@ -33,8 +33,8 @@ secrets:
 ```
 Make sure you have serviceAccountName specified in your predictor in your inference service. These headers will be applied to any http/https requests that have the same host uri.
 
-You will need to base64 encode the headers
-```
+You will need to base64 encode the headers. Make sure each header is on a newline with the format `header_key: header_value`.
+```text
 account-name: some_account_name
 secret-key: some_secret_key
 # Base64 encoded into:

--- a/docs/samples/storage/uri/README.md
+++ b/docs/samples/storage/uri/README.md
@@ -10,7 +10,7 @@ This `storageUri` option supports single file models, like `sklearn` which is sp
 
 ## Create HTTP/HTTPS header Secret and attach to Service account
 If you do not require headers in your HTTP/HTTPS service request then you can skip this step.
-You can define headers by following the following format:
+You can define headers using the following format:
 
 ```yaml
 apiVersion: v1
@@ -21,7 +21,7 @@ type: Opaque
 data:
   https-host: ZXhhbXBsZS5jb20=
   headers: |-
-    YWNjb3VudC1uYW1lOiBzb21lX2FjY291bnRfbmFtZQpzZWNyZXQta2V5OiBzb21lX3NlY3JldF9rZXk=
+    ewoiYWNjb3VudC1uYW1lIjogInNvbWVfYWNjb3VudF9uYW1lIiwKInNlY3JldC1rZXkiOiAic29tZV9zZWNyZXRfa2V5Igp9
 ---
 apiVersion: v1
 kind: ServiceAccount
@@ -32,16 +32,18 @@ secrets:
 ```
 Make sure you have serviceAccountName specified in your predictor in your inference service. These headers will be applied to any http/https requests that have the same host.
 
-You will need to base64 encode the headers and host. Make sure each header is on a newline with the format `header_key: header_value`.
+You will need to base64 encode the headers and host. Make sure the headers are in proper json format.
 ```text
 example.com
 # echo -n "example.com" | base64
 ZXhhbXBsZS5jb20=
 ---
-account-name: some_account_name
-secret-key: some_secret_key
-# echo -n 'account-name: some_account_name\nsecret-key: some_secret_key' | base64
-YWNjb3VudC1uYW1lOiBzb21lX2FjY291bnRfbmFtZQpzZWNyZXQta2V5OiBzb21lX3NlY3JldF9rZXk=
+{
+  "account-name": "some_account_name",
+  "secret-key": "some_secret_key"
+}
+# echo -n '{\n"account-name": "some_account_name",\n"secret-key": "some_secret_key"\n}' | base64
+ewoiYWNjb3VudC1uYW1lIjogInNvbWVfYWNjb3VudF9uYW1lIiwKInNlY3JldC1rZXkiOiAic29tZV9zZWNyZXRfa2V5Igp9
 ```
 
 ## Sklearn

--- a/docs/samples/storage/uri/README.md
+++ b/docs/samples/storage/uri/README.md
@@ -17,10 +17,9 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: mysecret
-  annotations:
-    serving.kubeflow.org/https-host-uri: “example.com”
 type: Opaque
 data:
+  https-host-uri: ZXhhbXBsZS5jb20=
   headers: |-
     YWNjb3VudC1uYW1lOiBzb21lX2FjY291bnRfbmFtZQpzZWNyZXQta2V5OiBzb21lX3NlY3JldF9rZXk=
 ---
@@ -33,8 +32,12 @@ secrets:
 ```
 Make sure you have serviceAccountName specified in your predictor in your inference service. These headers will be applied to any http/https requests that have the same host uri.
 
-You will need to base64 encode the headers. Make sure each header is on a newline with the format `header_key: header_value`.
+You will need to base64 encode the headers and host uri. Make sure each header is on a newline with the format `header_key: header_value`.
 ```text
+example.com
+# echo -n "example.com" | base64
+ZXhhbXBsZS5jb20=
+---
 account-name: some_account_name
 secret-key: some_secret_key
 # echo -n 'account-name: some_account_name\nsecret-key: some_secret_key' | base64

--- a/docs/samples/storage/uri/README.md
+++ b/docs/samples/storage/uri/README.md
@@ -37,7 +37,7 @@ You will need to base64 encode the headers. Make sure each header is on a newlin
 ```text
 account-name: some_account_name
 secret-key: some_secret_key
-# Base64 encoded into:
+# echo -n 'account-name: some_account_name\nsecret-key: some_secret_key' | base64
 YWNjb3VudC1uYW1lOiBzb21lX2FjY291bnRfbmFtZQpzZWNyZXQta2V5OiBzb21lX3NlY3JldF9rZXk=
 ```
 

--- a/pkg/credentials/https/https_secret.go
+++ b/pkg/credentials/https/https_secret.go
@@ -24,7 +24,7 @@ import (
 
 // Create constants -- baseURI
 const (
-	HTTPSHostURI = "https-base-uri"
+	HTTPSHostURI = "https-host-uri"
 	HEADERS      = "headers"
 	HEADER       = "header"
 	NEWLINE      = "\n"

--- a/pkg/credentials/https/https_secret.go
+++ b/pkg/credentials/https/https_secret.go
@@ -23,10 +23,10 @@ import (
 
 // Create constants -- baseURI
 const (
-	HTTPSHostURI = "https-host-uri"
-	HEADERS      = "headers"
-	HEADER       = "header"
-	NEWLINE      = "\n"
+	HTTPSHost = "https-host"
+	HEADERS   = "headers"
+	HEADER    = "header"
+	NEWLINE   = "\n"
 )
 
 var (
@@ -39,7 +39,7 @@ var (
 func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
 	var fieldKeys []string
 	envs := []v1.EnvVar{}
-	hostURI, ok := secret.Data[HTTPSHostURI]
+	uriHost, ok := secret.Data[HTTPSHost]
 
 	if !ok {
 		return envs
@@ -69,7 +69,7 @@ func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
 
 	if len(envs) > 0 {
 		envs = append(envs, v1.EnvVar{
-			Name:  string(hostURI),
+			Name:  string(uriHost),
 			Value: strings.Join(fieldKeys, CommaSeparator),
 		})
 	}

--- a/pkg/credentials/https/https_secret.go
+++ b/pkg/credentials/https/https_secret.go
@@ -25,6 +25,7 @@ import (
 // Create constants -- baseURI
 const (
 	HTTPSHostURI = "https-base-uri"
+	HEADERS      = "headers"
 	HEADER       = "header"
 	NEWLINE      = "\n"
 )
@@ -47,7 +48,7 @@ func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
 	}
 
 	for key, element := range secret.Data {
-		if key == HEADER {
+		if key == HEADERS {
 			// Headers will be stored in multi-lined string
 			headersKeyValue := strings.Split(string(element), NEWLINE)
 			for _, headerKeyValue := range headersKeyValue {

--- a/pkg/credentials/https/https_secret.go
+++ b/pkg/credentials/https/https_secret.go
@@ -1,0 +1,77 @@
+/*
+Copyright 2021 kubeflow.org.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"github.com/kubeflow/kfserving/pkg/constants"
+	v1 "k8s.io/api/core/v1"
+	"strings"
+)
+
+// Create constants -- baseURI
+const (
+	HTTPSHostURI = "https-base-uri"
+	HEADER       = "header"
+	NEWLINE      = "\n"
+)
+
+var (
+	InferenceServiceHTTPSHostURI = constants.KFServingAPIGroupName + "/" + HTTPSHostURI
+	HeaderPrefix                 = HEADER + "."
+	CommaSeparator               = ","
+	ColonSeparator               = ": "
+)
+
+// Can be used for http and https uris
+func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
+	var fieldKeys []string
+	envs := []v1.EnvVar{}
+	hostURI, ok := secret.Annotations[InferenceServiceHTTPSHostURI]
+
+	if !ok {
+		return envs
+	}
+
+	for key, element := range secret.Data {
+		if key == HEADER {
+			// Headers will be stored in multi-lined string
+			headersKeyValue := strings.Split(string(element), NEWLINE)
+			for _, headerKeyValue := range headersKeyValue {
+				res := strings.Split(headerKeyValue, ColonSeparator)
+				if len(res) != 2 {
+					continue
+				}
+				headerKey, headerValue := HeaderPrefix+res[0], res[1]
+
+				fieldKeys = append(fieldKeys, headerKey)
+				envs = append(envs, v1.EnvVar{
+					Name:  headerKey,
+					Value: headerValue,
+				})
+			}
+		}
+	}
+
+	if len(envs) > 0 {
+		envs = append(envs, v1.EnvVar{
+			Name:  hostURI,
+			Value: strings.Join(fieldKeys, CommaSeparator),
+		})
+	}
+
+	return envs
+}

--- a/pkg/credentials/https/https_secret.go
+++ b/pkg/credentials/https/https_secret.go
@@ -18,26 +18,22 @@ package https
 
 import (
 	v1 "k8s.io/api/core/v1"
-	"strings"
 )
 
 // Create constants -- baseURI
 const (
 	HTTPSHost = "https-host"
 	HEADERS   = "headers"
-	HEADER    = "header"
 	NEWLINE   = "\n"
 )
 
 var (
-	HeaderPrefix   = HEADER + "."
-	CommaSeparator = ","
+	HeadersSuffix  = "-" + HEADERS
 	ColonSeparator = ": "
 )
 
 // Can be used for http and https uris
 func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
-	var fieldKeys []string
 	envs := []v1.EnvVar{}
 	uriHost, ok := secret.Data[HTTPSHost]
 
@@ -51,28 +47,10 @@ func BuildSecretEnvs(secret *v1.Secret) []v1.EnvVar {
 		return envs
 	}
 
-	// Headers are stored in multi-lined string
-	headersKeyValue := strings.Split(string(headers), NEWLINE)
-	for _, headerKeyValue := range headersKeyValue {
-		res := strings.Split(headerKeyValue, ColonSeparator)
-		if len(res) != 2 {
-			continue
-		}
-		headerKey, headerValue := HeaderPrefix+res[0], res[1]
-
-		fieldKeys = append(fieldKeys, headerKey)
-		envs = append(envs, v1.EnvVar{
-			Name:  headerKey,
-			Value: headerValue,
-		})
-	}
-
-	if len(envs) > 0 {
-		envs = append(envs, v1.EnvVar{
-			Name:  string(uriHost),
-			Value: strings.Join(fieldKeys, CommaSeparator),
-		})
-	}
+	envs = append(envs, v1.EnvVar{
+		Name:  string(uriHost) + HeadersSuffix,
+		Value: string(headers),
+	})
 
 	return envs
 }

--- a/pkg/credentials/https/https_secret_test.go
+++ b/pkg/credentials/https/https_secret_test.go
@@ -59,21 +59,13 @@ func TestHTTPSSecret(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{},
 				Data: map[string][]byte{
 					HTTPSHost: []byte(uriHost),
-					HEADERS:   []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
+					HEADERS:   []byte(`{` + NEWLINE + header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2 + NEWLINE + `}`),
 				},
 			},
 			expected: []v1.EnvVar{
 				{
-					Name:  HeaderPrefix + header1,
-					Value: headerValue1,
-				},
-				{
-					Name:  HeaderPrefix + header2,
-					Value: headerValue2,
-				},
-				{
-					Name:  uriHost,
-					Value: HeaderPrefix + header1 + CommaSeparator + HeaderPrefix + header2,
+					Name:  uriHost + HeadersSuffix,
+					Value: `{` + NEWLINE + header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2 + NEWLINE + `}`,
 				},
 			},
 		},

--- a/pkg/credentials/https/https_secret_test.go
+++ b/pkg/credentials/https/https_secret_test.go
@@ -36,7 +36,7 @@ func TestHTTPSSecret(t *testing.T) {
 		secret   *v1.Secret
 		expected []v1.EnvVar
 	}{
-		"noBaseUri": {
+		"noHostUri": {
 			secret: &v1.Secret{
 				Data: map[string][]byte{
 					header1: []byte(headerValue1),
@@ -47,24 +47,19 @@ func TestHTTPSSecret(t *testing.T) {
 		},
 		"noHeaders": {
 			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						InferenceServiceHTTPSHostURI: hostUri,
-					},
+				ObjectMeta: metav1.ObjectMeta{},
+				Data: map[string][]byte{
+					HTTPSHostURI: []byte(hostUri),
 				},
-				Data: map[string][]byte{},
 			},
 			expected: []v1.EnvVar{},
 		},
 		"secretEnvs": {
 			secret: &v1.Secret{
-				ObjectMeta: metav1.ObjectMeta{
-					Annotations: map[string]string{
-						InferenceServiceHTTPSHostURI: hostUri,
-					},
-				},
+				ObjectMeta: metav1.ObjectMeta{},
 				Data: map[string][]byte{
-					HEADERS: []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
+					HTTPSHostURI: []byte(hostUri),
+					HEADERS:      []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
 				},
 			},
 			expected: []v1.EnvVar{

--- a/pkg/credentials/https/https_secret_test.go
+++ b/pkg/credentials/https/https_secret_test.go
@@ -1,0 +1,94 @@
+/*
+Copyright 2021 kubeflow.org.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package https
+
+import (
+	"github.com/google/go-cmp/cmp"
+	v1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"testing"
+)
+
+var (
+	header1      = "username"
+	header2      = "password"
+	headerValue1 = "someUsername"
+	headerValue2 = "somePassword"
+	hostUri      = "www.example.com"
+)
+
+func TestHTTPSSecret(t *testing.T) {
+	scenarios := map[string]struct {
+		secret   *v1.Secret
+		expected []v1.EnvVar
+	}{
+		"noBaseUri": {
+			secret: &v1.Secret{
+				Data: map[string][]byte{
+					header1: []byte(headerValue1),
+					header2: []byte(headerValue2),
+				},
+			},
+			expected: []v1.EnvVar{},
+		},
+		"noHeaders": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						InferenceServiceHTTPSHostURI: hostUri,
+					},
+				},
+				Data: map[string][]byte{},
+			},
+			expected: []v1.EnvVar{},
+		},
+		"secretEnvs": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Annotations: map[string]string{
+						InferenceServiceHTTPSHostURI: hostUri,
+					},
+				},
+				Data: map[string][]byte{
+					HEADER: []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name:  HeaderPrefix + header1,
+					Value: headerValue1,
+				},
+				{
+					Name:  HeaderPrefix + header2,
+					Value: headerValue2,
+				},
+				{
+					Name:  hostUri,
+					Value: HeaderPrefix + header1 + CommaSeparator + HeaderPrefix + header2,
+				},
+			},
+		},
+	}
+
+	for name, scenario := range scenarios {
+		envs := BuildSecretEnvs(scenario.secret)
+
+		if diff := cmp.Diff(scenario.expected, envs); diff != "" {
+			t.Errorf("Test %q unexpected result (-want +got): %v", name, diff)
+		}
+	}
+}

--- a/pkg/credentials/https/https_secret_test.go
+++ b/pkg/credentials/https/https_secret_test.go
@@ -28,7 +28,7 @@ var (
 	header2      = "password"
 	headerValue1 = "someUsername"
 	headerValue2 = "somePassword"
-	hostUri      = "www.example.com"
+	uriHost      = "example.com"
 )
 
 func TestHTTPSSecret(t *testing.T) {
@@ -36,7 +36,7 @@ func TestHTTPSSecret(t *testing.T) {
 		secret   *v1.Secret
 		expected []v1.EnvVar
 	}{
-		"noHostUri": {
+		"noUriHost": {
 			secret: &v1.Secret{
 				Data: map[string][]byte{
 					header1: []byte(headerValue1),
@@ -49,7 +49,7 @@ func TestHTTPSSecret(t *testing.T) {
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{},
 				Data: map[string][]byte{
-					HTTPSHostURI: []byte(hostUri),
+					HTTPSHost: []byte(uriHost),
 				},
 			},
 			expected: []v1.EnvVar{},
@@ -58,8 +58,8 @@ func TestHTTPSSecret(t *testing.T) {
 			secret: &v1.Secret{
 				ObjectMeta: metav1.ObjectMeta{},
 				Data: map[string][]byte{
-					HTTPSHostURI: []byte(hostUri),
-					HEADERS:      []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
+					HTTPSHost: []byte(uriHost),
+					HEADERS:   []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
 				},
 			},
 			expected: []v1.EnvVar{
@@ -72,7 +72,7 @@ func TestHTTPSSecret(t *testing.T) {
 					Value: headerValue2,
 				},
 				{
-					Name:  hostUri,
+					Name:  uriHost,
 					Value: HeaderPrefix + header1 + CommaSeparator + HeaderPrefix + header2,
 				},
 			},

--- a/pkg/credentials/https/https_secret_test.go
+++ b/pkg/credentials/https/https_secret_test.go
@@ -64,7 +64,7 @@ func TestHTTPSSecret(t *testing.T) {
 					},
 				},
 				Data: map[string][]byte{
-					HEADER: []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
+					HEADERS: []byte(header1 + ColonSeparator + headerValue1 + NEWLINE + header2 + ColonSeparator + headerValue2),
 				},
 			},
 			expected: []v1.EnvVar{

--- a/pkg/credentials/service_account_credentials.go
+++ b/pkg/credentials/service_account_credentials.go
@@ -20,6 +20,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/kubeflow/kfserving/pkg/credentials/https"
 
 	"github.com/kubeflow/kfserving/pkg/credentials/azure"
 	"github.com/kubeflow/kfserving/pkg/credentials/gcs"
@@ -68,6 +69,7 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 	}
 	s3SecretAccessKeyName := s3.AWSSecretAccessKeyName
 	gcsCredentialFileName := gcs.GCSCredentialFileName
+	httpsHostURI := https.InferenceServiceHTTPSHostURI
 
 	if c.config.S3.S3SecretAccessKeyName != "" {
 		s3SecretAccessKeyName = c.config.S3.S3SecretAccessKeyName
@@ -113,6 +115,10 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 		} else if _, ok := secret.Data[azure.AzureClientSecret]; ok {
 			log.Info("Setting secret envs for azure", "AzureSecret", secret.Name)
 			envs := azure.BuildSecretEnvs(secret)
+			container.Env = append(container.Env, envs...)
+		} else if _, ok := secret.Annotations[httpsHostURI]; ok {
+			log.Info("Setting secret volume from uri", "HTTP(S)Secret", secret.Name)
+			envs := https.BuildSecretEnvs(secret)
 			container.Env = append(container.Env, envs...)
 		} else {
 			log.V(5).Info("Skipping non gcs/s3/azure secret", "Secret", secret.Name)

--- a/pkg/credentials/service_account_credentials.go
+++ b/pkg/credentials/service_account_credentials.go
@@ -115,7 +115,7 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 			log.Info("Setting secret envs for azure", "AzureSecret", secret.Name)
 			envs := azure.BuildSecretEnvs(secret)
 			container.Env = append(container.Env, envs...)
-		} else if _, ok := secret.Data[https.HTTPSHostURI]; ok {
+		} else if _, ok := secret.Data[https.HTTPSHost]; ok {
 			log.Info("Setting secret volume from uri", "HTTP(S)Secret", secret.Name)
 			envs := https.BuildSecretEnvs(secret)
 			container.Env = append(container.Env, envs...)

--- a/pkg/credentials/service_account_credentials.go
+++ b/pkg/credentials/service_account_credentials.go
@@ -69,7 +69,6 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 	}
 	s3SecretAccessKeyName := s3.AWSSecretAccessKeyName
 	gcsCredentialFileName := gcs.GCSCredentialFileName
-	httpsHostURI := https.InferenceServiceHTTPSHostURI
 
 	if c.config.S3.S3SecretAccessKeyName != "" {
 		s3SecretAccessKeyName = c.config.S3.S3SecretAccessKeyName
@@ -116,7 +115,7 @@ func (c *CredentialBuilder) CreateSecretVolumeAndEnv(namespace string, serviceAc
 			log.Info("Setting secret envs for azure", "AzureSecret", secret.Name)
 			envs := azure.BuildSecretEnvs(secret)
 			container.Env = append(container.Env, envs...)
-		} else if _, ok := secret.Annotations[httpsHostURI]; ok {
+		} else if _, ok := secret.Data[https.HTTPSHostURI]; ok {
 			log.Info("Setting secret volume from uri", "HTTP(S)Secret", secret.Name)
 			envs := https.BuildSecretEnvs(secret)
 			container.Env = append(container.Env, envs...)

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -18,6 +18,7 @@ import tempfile
 import mimetypes
 import os
 import re
+import json
 import shutil
 import tarfile
 import zipfile
@@ -36,7 +37,7 @@ _BLOB_RE = "https://(.+?).blob.core.windows.net/(.+)"
 _LOCAL_PREFIX = "file://"
 _URI_RE = "https?://(.+)/(.+)"
 _HTTP_PREFIX = "http(s)://"
-_HEADER_PREFIX = "header."
+_HEADERS_SUFFIX = "-headers"
 
 class Storage(object): # pylint: disable=too-few-public-methods
     @staticmethod
@@ -236,11 +237,12 @@ The path or model %s does not exist." % (uri))
         # Get header information from host url
         headers = {}
         host_uri = url.hostname
-        request_arg_keys = os.getenv(host_uri, "").split(",")
 
-        for request_arg_key in request_arg_keys:
-            if request_arg_key.startswith(_HEADER_PREFIX):
-                headers[request_arg_key[len(_HEADER_PREFIX):]] = os.getenv(request_arg_key)
+        headers_json = os.getenv(host_uri + _HEADERS_SUFFIX, "{}")
+        headers_keys_values = json.loads(headers_json)
+
+        for key in headers_keys_values:
+            headers[key] = headers_keys_values[key]
 
         with requests.get(uri, stream=True, headers=headers) as response:
             if response.status_code != 200:

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -36,6 +36,7 @@ _BLOB_RE = "https://(.+?).blob.core.windows.net/(.+)"
 _LOCAL_PREFIX = "file://"
 _URI_RE = "https?://(.+)/(.+)"
 _HTTP_PREFIX = "http(s)://"
+_HEADER_PREFIX = "header."
 
 class Storage(object): # pylint: disable=too-few-public-methods
     @staticmethod
@@ -235,11 +236,11 @@ The path or model %s does not exist." % (uri))
         # Get header information from host url
         headers = {}
         host_uri = url.hostname
-        fields = os.getenv(host_uri, "").split(",")
+        request_arg_keys = os.getenv(host_uri, "").split(",")
 
-        for field in fields:
-            if field.startswith("header."):
-                headers[field[7:]] = os.getenv(field)
+        for request_arg_key in request_arg_keys:
+            if request_arg_key.startswith(_HEADER_PREFIX):
+                headers[request_arg_key[len(_HEADER_PREFIX):]] = os.getenv(request_arg_key)
 
         with requests.get(uri, stream=True, headers=headers) as response:
             if response.status_code != 200:

--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -239,10 +239,7 @@ The path or model %s does not exist." % (uri))
         host_uri = url.hostname
 
         headers_json = os.getenv(host_uri + _HEADERS_SUFFIX, "{}")
-        headers_keys_values = json.loads(headers_json)
-
-        for key in headers_keys_values:
-            headers[key] = headers_keys_values[key]
+        headers = json.loads(headers_json)
 
         with requests.get(uri, stream=True, headers=headers) as response:
             if response.status_code != 200:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:  Currently there is no header support for inference service uri request. It would be beneficial as authentication for requests may require credentials to be passed into the header.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1351

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
