### PR TITLE
Docs/hold application until proxy starts

### DIFF
--- a/docs/samples/storage/s3/README.md
+++ b/docs/samples/storage/s3/README.md
@@ -62,7 +62,7 @@ Apply the secret and service account
 kubectl apply -f s3_secret.yaml
 ```
 
-Note: if you are running kfserving with istio sidecars enabled, there can be a race condition between the istio proxy being ready and the agent pulling models. This will result in a `tcp dial connection refused` error when the agent tries to download from s3. To resolve it, istio allows the blocking of other containers in a pod until the proxy container is ready. You can enabled this by setting `holdApplicationUntilProxyStarts: true` in istio-discovery (istiod).
+Note: if you are running kfserving with istio sidecars enabled, there can be a race condition between the istio proxy being ready and the agent pulling models. This will result in a `tcp dial connection refused` error when the agent tries to download from s3. To resolve it, istio allows the blocking of other containers in a pod until the proxy container is ready. You can enabled this by setting `proxy.holdApplicationUntilProxyStarts: true` in `istio-sidecar-injector` configmap, `proxy.holdApplicationUntilProxyStarts` flag  was introduced in Istio 1.7 as an experimental feature and is turned off by default.
 
 ## Create the InferenceService
 Apply the CRD

--- a/docs/samples/storage/s3/README.md
+++ b/docs/samples/storage/s3/README.md
@@ -62,7 +62,7 @@ Apply the secret and service account
 kubectl apply -f s3_secret.yaml
 ```
 
-Note: if you are running kfserving with istio sidecars enabled, there can be a race condition between the istio proxy being ready and the agent pulling models. This will result in a `tcp dial connection refused` error when the agent tries to download fmor s3. To resolve it, istio allows the blocking of other containers in a pod until the proxy container is ready. You can enabled this by setting `holdApplicationUntilProxyStarts: true` in istio-discovery (istiod).
+Note: if you are running kfserving with istio sidecars enabled, there can be a race condition between the istio proxy being ready and the agent pulling models. This will result in a `tcp dial connection refused` error when the agent tries to download from s3. To resolve it, istio allows the blocking of other containers in a pod until the proxy container is ready. You can enabled this by setting `holdApplicationUntilProxyStarts: true` in istio-discovery (istiod).
 
 ## Create the InferenceService
 Apply the CRD

--- a/docs/samples/storage/s3/README.md
+++ b/docs/samples/storage/s3/README.md
@@ -62,6 +62,8 @@ Apply the secret and service account
 kubectl apply -f s3_secret.yaml
 ```
 
+Note: if you are running kfserving with istio sidecars enabled, there can be a race condition between the istio proxy being ready and the agent pulling models. This will result in a `tcp dial connection refused` error when the agent tries to download fmor s3. To resolve it, istio allows the blocking of other containers in a pod until the proxy container is ready. You can enabled this by setting `holdApplicationUntilProxyStarts: true` in istio-discovery (istiod).
+
 ## Create the InferenceService
 Apply the CRD
 ```bash


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1370

Add documentation for istio `holdApplicationUntilProxyStarts: true` , which can help resolved connection refused errors from the agent

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
