### PR TITLE
Remove unnecessary "latest" routing tag

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -394,7 +394,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						},
 					},
 					RouteSpec: knservingv1.RouteSpec{
-						Traffic: []knservingv1.TrafficTarget{{Tag: "latest", LatestRevision: proto.Bool(true), Percent: proto.Int64(100)}},
+						Traffic: []knservingv1.TrafficTarget{{LatestRevision: proto.Bool(true), Percent: proto.Int64(100)}},
 					},
 				},
 			}
@@ -612,7 +612,7 @@ var _ = Describe("v1beta1 inference service controller", func() {
 						},
 					},
 					RouteSpec: knservingv1.RouteSpec{
-						Traffic: []knservingv1.TrafficTarget{{Tag: "latest", LatestRevision: proto.Bool(true), Percent: proto.Int64(100)}},
+						Traffic: []knservingv1.TrafficTarget{{LatestRevision: proto.Bool(true), Percent: proto.Int64(100)}},
 					},
 				},
 			}
@@ -781,7 +781,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}
 			updatedService.Status.Traffic = []knservingv1.TrafficTarget{
 				{
-					Tag:            "latest",
 					LatestRevision: proto.Bool(true),
 					RevisionName:   "revision-v1",
 					Percent:        proto.Int64(100),
@@ -833,7 +832,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 
 			expectedTrafficTarget := []knservingv1.TrafficTarget{
 				{
-					Tag:            "latest",
 					LatestRevision: proto.Bool(true),
 					Percent:        proto.Int64(20),
 				},
@@ -869,7 +867,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			Expect(k8sClient.Update(context.TODO(), rolloutIsvc)).NotTo(gomega.HaveOccurred())
 			expectedTrafficTarget = []knservingv1.TrafficTarget{
 				{
-					Tag:            "latest",
 					LatestRevision: proto.Bool(true),
 					Percent:        proto.Int64(100),
 				},
@@ -892,7 +889,6 @@ var _ = Describe("v1beta1 inference service controller", func() {
 			}, timeout).Should(Equal(storageUri2))
 			serviceRevision2.Status.Traffic = []knservingv1.TrafficTarget{
 				{
-					Tag:            "latest",
 					LatestRevision: proto.Bool(true),
 					RevisionName:   "revision-v2",
 					Percent:        proto.Int64(100),

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -97,7 +97,6 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 		//canary rollout
 		trafficTargets = append(trafficTargets,
 			knservingv1.TrafficTarget{
-				Tag:            "latest",
 				LatestRevision: proto.Bool(true),
 				Percent:        proto.Int64(*componentExtension.CanaryTrafficPercent),
 			})
@@ -113,7 +112,6 @@ func createKnativeService(componentMeta metav1.ObjectMeta,
 		//blue green rollout
 		trafficTargets = append(trafficTargets,
 			knservingv1.TrafficTarget{
-				Tag:            "latest",
 				LatestRevision: proto.Bool(true),
 				Percent:        proto.Int64(100),
 			})

--- a/test/e2e/predictor/test_lightgbm.py
+++ b/test/e2e/predictor/test_lightgbm.py
@@ -33,6 +33,7 @@ api_v1beta1_version = (
 )
 KFServing = KFServingClient(config_file=os.environ.get("KUBECONFIG", "~/.kube/config"))
 
+
 def test_lightgbm_kfserving():
     service_name = "isvc-lightgbm"
     default_endpoint_spec = V1alpha2EndpointSpec(
@@ -58,17 +59,10 @@ def test_lightgbm_kfserving():
     )
 
     KFServing.create(isvc)
-    try:
-        KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE, 
-                                version=constants.KFSERVING_VERSION)
-    except RuntimeError as e:
-        KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE, 
-                                version=constants.KFSERVING_V1BETA1_VERSION)
-    try:                                
-        res = predict(service_name, "./data/iris_input_v3.json", 
-                                version=constants.KFSERVING_VERSION)
-    except KeyError:
-        res = predict(service_name, "./data/iris_input_v3.json", 
-                                version=constants.KFSERVING_V1BETA1_VERSION) 
+    KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE,
+                              version=constants.KFSERVING_VERSION)
+
+    res = predict(service_name, "./data/iris_input_v3.json",
+                  version=constants.KFSERVING_VERSION)
     assert res["predictions"][0][0] > 0.5
     KFServing.delete(service_name, KFSERVING_TEST_NAMESPACE)

--- a/test/e2e/transformer/test_transformer.py
+++ b/test/e2e/transformer/test_transformer.py
@@ -66,7 +66,7 @@ def test_transformer():
         KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE)
     except RuntimeError as e:
         print(KFServing.api_instance.get_namespaced_custom_object("serving.knative.dev", "v1", KFSERVING_TEST_NAMESPACE,
-                                                                  "services", service_name + "-predictor"))
+                                                                  "services", service_name + "-predictor-default"))
         pods = KFServing.core_api.list_namespaced_pod(KFSERVING_TEST_NAMESPACE,
                                                       label_selector='serving.kubeflow.org/inferenceservice={}'
                                                       .format(service_name))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The latest routing tag adds extra prefix "latest" to the routing host which causes the domain name exceeding the max 63 char length for some of the existing inference services with long name.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1377 


**Release note**:

```release-note
latest tag url is removed.
```
