### PR TITLE
Use custom local gateway for isvc external service

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -110,14 +110,14 @@ func getServiceUrl(isvc *v1beta1.InferenceService) string {
 	}
 }
 
-func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceService) error {
+func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig) error {
 	desired := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isvc.Name,
 			Namespace: isvc.Namespace,
 		},
 		Spec: corev1.ServiceSpec{
-			ExternalName:    constants.LocalGatewayHost,
+			ExternalName:    config.LocalGatewayServiceName,
 			Type:            corev1.ServiceTypeExternalName,
 			SessionAffinity: corev1.ServiceAffinityNone,
 		},
@@ -316,7 +316,7 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	}
 
 	//Create external service which points to local gateway
-	if err := ir.reconcileExternalService(isvc); err != nil {
+	if err := ir.reconcileExternalService(isvc, ir.ingressConfig); err != nil {
 		return errors.Wrapf(err, "fails to reconcile external name service")
 	}
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

InferenceService expose an option to customise the istio local gateway that is used with them, however the reconviler still points to the hard coded local gateway specified in constants. This fixes that by using the local gateway from config instead.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1383

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
