### PR TITLE
Update kubectl version used in e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -118,8 +118,6 @@ manifests: controller-gen
 	perl -pi -e 's/storedVersions: null/storedVersions: []/g' config/crd/serving.kubeflow.org_trainedmodels.yaml
 	perl -pi -e 's/conditions: null/conditions: []/g' config/crd/serving.kubeflow.org_trainedmodels.yaml
 	perl -pi -e 's/Any/string/g' config/crd/serving.kubeflow.org_trainedmodels.yaml
-	#TODO v1beta1 crd openAPIV3Schema is too big and kubectl client side apply takes long time to do diffs, need to use k8s 1.18's server side apply
-	#https://kubernetes.io/blog/2020/04/01/kubernetes-1.18-feature-server-side-apply-beta-2/#what-is-server-side-apply
 	#remove the required property on framework as name field needs to be optional
 	yq d -i config/crd/serving.kubeflow.org_inferenceservices.yaml 'spec.versions[1].schema.openAPIV3Schema.properties.spec.properties.*.properties.*.required'
 	#remove ephemeralContainers properties for compress crd size https://github.com/kubeflow/kfserving/pull/1141#issuecomment-714170602

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ generation [script](./hack/self-signed-ca.sh).
 ### Install KFServing
 <details>
   <summary>Expand to see the installation options!</summary>
-  
+
 #### Standalone KFServing Installation
 KFServing can be installed standalone if your kubernetes cluster meets the above prerequisites and KFServing controller is deployed in `kfserving-system` namespace.
 
@@ -57,10 +57,10 @@ TAG=v0.5.0
 
 Install KFServing CRD
 
-Due to [large last applied annotation issue](https://github.com/kubernetes-sigs/kubebuilder/issues/1140) with `kubectl apply` we recommend using `kubectl replace` for upgrading crd.
+Due to [a performance issue applying deeply nested CRDs](https://github.com/kubernetes/kubernetes/issues/91615), please ensure that your `kubectl` version
+fits into one of the following categories to ensure that you have the fix: `>=1.16.14,<1.17.0` or `>=1.17.11,<1.18.0` or `>=1.18.8`.
 ```shell
-CRD=https://github.com/kubeflow/kfserving/releases/download/$TAG/kfserving_crds.yaml
-kubectl replace -f $CRD || kubectl create -f $CRD
+kubectl apply -f https://github.com/kubeflow/kfserving/releases/download/$TAG/kfserving_crds.yaml
 ```
 
 Install KFServing Controller
@@ -76,7 +76,7 @@ To install standalone KFServing on [OpenShift Container Platform](https://www.op
 #### KFServing with Kubeflow Installation
 KFServing is installed by default as part of Kubeflow installation using [Kubeflow manifests](https://github.com/kubeflow/manifests/tree/master/kfserving) and KFServing controller is deployed in `kubeflow` namespace.
 Since Kubeflow Kubernetes minimal requirement is 1.14 which does not support object selector, `ENABLE_WEBHOOK_NAMESPACE_SELECTOR` is enabled in Kubeflow installation by default.
-If you are using Kubeflow dashboard or [profile controller](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/#manual-profile-creation) to create  user namespaces, labels are automatically added to enable KFServing to deploy models. 
+If you are using Kubeflow dashboard or [profile controller](https://www.kubeflow.org/docs/components/multi-tenancy/getting-started/#manual-profile-creation) to create  user namespaces, labels are automatically added to enable KFServing to deploy models.
 If you are creating namespaces manually using Kubernetes apis directly, you will need to add label `serving.kubeflow.org/inferenceservice: enabled` to allow deploying KFServing `InferenceService` in the given namespaces, and do ensure you do not deploy
 `InferenceService` in `kubeflow` namespace which is labelled as `control-plane`.
 

--- a/test/scripts/run-e2e-tests.sh
+++ b/test/scripts/run-e2e-tests.sh
@@ -25,7 +25,7 @@ AWS_REGION="${AWS_REGION}"
 
 ISTIO_VERSION="1.3.1"
 KNATIVE_VERSION="v0.17.0"
-KUBECTL_VERSION="v1.14.0"
+KUBECTL_VERSION="v1.17.11"
 CERT_MANAGER_VERSION="v0.12.0"
 # Check and wait for istio/knative/kfserving pod started normally.
 waiting_pod_running(){


### PR DESCRIPTION
Based off  https://github.com/kubeflow/kfserving/blob/master/test/scripts/create-cluster.sh#L31 , the test cluster uses Kubernetes 1.17.

This PR updates the `kubectl` version used to a matching version. This version also has the fix for the problem outlined in this issue: https://github.com/kubernetes/kubernetes/issues/91615 where re-applying a CRD with deeply nested properties took a long time. 

This PR also changes the README instructions to tell users to use a version of `kubectl` which has a fix for the above issue.