### PR TITLE
Validate the parent inference service is ready in trained model controller

### DIFF
--- a/pkg/apis/serving/v1alpha1/trained_model_status.go
+++ b/pkg/apis/serving/v1alpha1/trained_model_status.go
@@ -68,6 +68,7 @@ func (ss *TrainedModelStatus) GetCondition(t apis.ConditionType) *apis.Condition
 func (ss *TrainedModelStatus) IsConditionReady(t apis.ConditionType) bool {
 	return conditionSet.Manage(ss).GetCondition(t) != nil && conditionSet.Manage(ss).GetCondition(t).Status == v1.ConditionTrue
 }
+
 func (ss *TrainedModelStatus) SetCondition(conditionType apis.ConditionType, condition *apis.Condition) {
 	switch {
 	case condition == nil:

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -27,6 +27,7 @@ package trainedmodel
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/go-logr/logr"
 	v1alpha1api "github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha1"
@@ -81,6 +82,13 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 		return reconcile.Result{}, err
 	}
+
+	// Check if isvc is ready
+	if !isvc.Status.IsReady() {
+		log.Info("Parent InferenceService is not ready", "TrainedModel", tm.Name, "InferenceService", isvc.Name)
+		return reconcile.Result{}, fmt.Errorf("fails as parent inference service is not ready")
+	}
+
 	// Add parent InferenceService's name to TrainedModel's label
 	if tm.Labels == nil {
 		tm.Labels = make(map[string]string)

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -228,7 +228,7 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 	if statusErr := r.Status().Update(context.TODO(), tm); statusErr != nil {
 		r.Log.Error(statusErr, "Failed to update TrainedModel condition", "TrainedModel", tm.Name)
 		r.Recorder.Eventf(tm, v1.EventTypeWarning, "UpdateFailed",
-			"Failed to update conditions for TrainedModel %q: %v", tm.Name, statusErr)
+			"Failed to update conditions for TrainedModel: %v", statusErr)
 	}
 
 	return conditionErr

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -27,8 +27,6 @@ package trainedmodel
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/go-logr/logr"
 	v1alpha1api "github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha1"
 	v1beta1api "github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
@@ -86,7 +84,12 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 	// Check if isvc is ready
 	if !isvc.Status.IsReady() {
 		log.Info("Parent InferenceService is not ready", "TrainedModel", tm.Name, "InferenceService", isvc.Name)
-		return reconcile.Result{}, fmt.Errorf("fails as parent inference service is not ready")
+		tm.Status.SetCondition(v1alpha1api.InferenceServiceReady, &apis.Condition{
+			Type:    v1alpha1api.InferenceServiceReady,
+			Status:  v1.ConditionFalse,
+			Reason:  "InferenceServiceNotReady",
+			Message: "Inference Service needs to be ready before Trained Model can be ready",
+		})
 	}
 
 	// Add parent InferenceService's name to TrainedModel's label

--- a/pkg/controller/v1alpha1/trainedmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller_test.go
@@ -89,7 +89,17 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 			Conditions: duckv1.Conditions{
 				{
 					Type:               knservingv1.ServiceConditionReady,
-					Status:             "True",
+					Status:             v1.ConditionTrue,
+					LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(time.Now())},
+				},
+				{
+					Type:               v1beta1.PredictorReady,
+					Status:             v1.ConditionTrue,
+					LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(time.Now())},
+				},
+				{
+					Type:               v1beta1.IngressReady,
+					Status:             v1.ConditionTrue,
 					LastTransitionTime: apis.VolatileTime{Inner: metav1.NewTime(time.Now())},
 				},
 			},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Prevents the trained model from being deployed if the inference service is not ready

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**: I plan on adding a few other validation checks in controllerafter this PR

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
