### PR TITLE
patch inferenceservice annotations to kfserving routing virtualservice

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -293,6 +293,8 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isvc.Name,
 			Namespace: isvc.Namespace,
+			Annotations: isvc.Annotations,
+			Labels: isvc.Labels,
 		},
 		Spec: istiov1alpha3.VirtualService{
 			Hosts:    hosts,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -294,16 +294,12 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 	annotations :=  utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
 	})
-	labels := utils.Filter(isvc.Labels, func(key string) bool {
-		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
-	})
-
 	desiredIngress := &v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isvc.Name,
 			Namespace: isvc.Namespace,
 			Annotations: annotations,
-			Labels: labels,
+			Labels: isvc.Labels,
 		},
 		Spec: istiov1alpha3.VirtualService{
 			Hosts:    hosts,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -21,7 +21,8 @@ import (
 	"fmt"
 	"github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
 	"github.com/kubeflow/kfserving/pkg/constants"
-	"github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/utils"
+	isvcutils "github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/utils"
+	utils "github.com/kubeflow/kfserving/pkg/utils"
 	"github.com/pkg/errors"
 	istiov1alpha3 "istio.io/api/networking/v1alpha3"
 	"istio.io/client-go/pkg/apis/networking/v1alpha3"
@@ -289,12 +290,20 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 		hosts = append(hosts, serviceHost)
 		gateways = append(gateways, config.IngressGateway)
 	}
+
+	annotations :=  utils.Filter(isvc.Annotations, func(key string) bool {
+		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
+	})
+	labels := utils.Filter(isvc.Labels, func(key string) bool {
+		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
+	})
+
 	desiredIngress := &v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      isvc.Name,
 			Namespace: isvc.Namespace,
-			Annotations: isvc.Annotations,
-			Labels: isvc.Labels,
+			Annotations: annotations,
+			Labels: labels,
 		},
 		Spec: istiov1alpha3.VirtualService{
 			Hosts:    hosts,
@@ -351,7 +360,7 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 		if err != nil {
 			return err
 		}
-		if !utils.IsMMSPredictor(&isvc.Spec.Predictor, isvcConfig) {
+		if !isvcutils.IsMMSPredictor(&isvc.Spec.Predictor, isvcConfig) {
 			if isvc.Spec.Predictor.GetImplementation().GetProtocol() == constants.ProtocolV2 {
 				path = constants.PredictPath(isvc.Name, constants.ProtocolV2)
 			} else {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -34,7 +34,9 @@ func TestCreateVirtualService(t *testing.T) {
 	serviceName := "my-model"
 	namespace := "test"
 	annotations := map[string]string{"test": "test"}
+	isvcAnnotions := map[string]string{"test": "test", "kubectl.kubernetes.io/last-applied-configuration": "test"}
 	labels := map[string]string{"test": "test"}
+	isvcLabels := map[string]string{"test": "test", "kubectl.kubernetes.io/last-applied-configuration": "test"}
 	domain := "example.com"
 	serviceHostName := constants.InferenceServiceHostName(serviceName, namespace, domain)
 	serviceInternalHostName := network.GetServiceHostname(serviceName, namespace)
@@ -466,8 +468,8 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceName,
 					Namespace: namespace,
-					Annotations: annotations,
-					Labels: labels,
+					Annotations: isvcAnnotions,
+					Labels: isvcLabels,
 				},
 				Spec: v1beta1.InferenceServiceSpec{
 					Predictor: v1beta1.PredictorSpec{},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -33,6 +33,8 @@ import (
 func TestCreateVirtualService(t *testing.T) {
 	serviceName := "my-model"
 	namespace := "test"
+	annotations := map[string]string{"test": "test"}
+	labels := map[string]string{"test": "test"}
 	domain := "example.com"
 	serviceHostName := constants.InferenceServiceHostName(serviceName, namespace, domain)
 	serviceInternalHostName := network.GetServiceHostname(serviceName, namespace)
@@ -100,7 +102,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 		expectedService: &v1alpha3.VirtualService{
-			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 			Spec: istiov1alpha3.VirtualService{
 				Hosts:    []string{serviceInternalHostName, serviceHostName},
 				Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
@@ -148,7 +150,7 @@ func TestCreateVirtualService(t *testing.T) {
 			},
 		},
 		expectedService: &v1alpha3.VirtualService{
-			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+			ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 			Spec: istiov1alpha3.VirtualService{
 				Hosts:    []string{serviceInternalHostName},
 				Gateways: []string{constants.KnativeLocalGateway},
@@ -242,7 +244,7 @@ func TestCreateVirtualService(t *testing.T) {
 				},
 			},
 			expectedService: &v1alpha3.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1alpha3.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
 					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
@@ -307,7 +309,7 @@ func TestCreateVirtualService(t *testing.T) {
 				},
 			},
 			expectedService: &v1alpha3.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1alpha3.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
 					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
@@ -392,7 +394,7 @@ func TestCreateVirtualService(t *testing.T) {
 				},
 			},
 			expectedService: &v1alpha3.VirtualService{
-				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace},
+				ObjectMeta: metav1.ObjectMeta{Name: serviceName, Namespace: namespace, Annotations: annotations, Labels: labels},
 				Spec: istiov1alpha3.VirtualService{
 					Hosts:    []string{serviceInternalHostName, serviceHostName},
 					Gateways: []string{constants.KnativeLocalGateway, constants.KnativeIngressGateway},
@@ -464,6 +466,8 @@ func TestCreateVirtualService(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      serviceName,
 					Namespace: namespace,
+					Annotations: annotations,
+					Labels: labels,
 				},
 				Spec: v1beta1.InferenceServiceSpec{
 					Predictor: v1beta1.PredictorSpec{},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -36,7 +36,6 @@ func TestCreateVirtualService(t *testing.T) {
 	annotations := map[string]string{"test": "test"}
 	isvcAnnotions := map[string]string{"test": "test", "kubectl.kubernetes.io/last-applied-configuration": "test"}
 	labels := map[string]string{"test": "test"}
-	isvcLabels := map[string]string{"test": "test", "kubectl.kubernetes.io/last-applied-configuration": "test"}
 	domain := "example.com"
 	serviceHostName := constants.InferenceServiceHostName(serviceName, namespace, domain)
 	serviceInternalHostName := network.GetServiceHostname(serviceName, namespace)
@@ -469,7 +468,7 @@ func TestCreateVirtualService(t *testing.T) {
 					Name:      serviceName,
 					Namespace: namespace,
 					Annotations: isvcAnnotions,
-					Labels: isvcLabels,
+					Labels: labels,
 				},
 				Spec: v1beta1.InferenceServiceSpec{
 					Predictor: v1beta1.PredictorSpec{},


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
This PR is to patch Inferenceservice annotations/labels to the kfserving routing VirtualService. It is already patched in [v1alpha2](https://github.com/kubeflow/kfserving/blob/master/pkg/controller/v1alpha2/inferenceservice/resources/istio/virtualservice.go#L276-L277).

**Which issue(s) this PR fixes** *(optional, in `fixes #1406 (, fixes #1406 , ...)` format, will close the issue(s) when PR gets merged)*:
Fixes # https://github.com/kubeflow/kfserving/issues/1406

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
