### PR TITLE
Validation for storage uri in webhook

### DIFF
--- a/pkg/agent/storage/provider.go
+++ b/pkg/agent/storage/provider.go
@@ -29,3 +29,7 @@ const (
 	//File  Protocol = "file://"
 	//HTTPS Protocol = "https://"
 )
+
+func GetAllProtocol() []string {
+	return []string{string(S3), string(GCS)}
+}

--- a/pkg/apis/serving/v1alpha1/trainedmodel_webhook.go
+++ b/pkg/apis/serving/v1alpha1/trainedmodel_webhook.go
@@ -29,9 +29,10 @@ import (
 
 // regular expressions for validation of isvc name
 const (
-	CommaSeparator                      = ", "
-	TmNameFmt                    string = "[a-z]([-a-z0-9]*[a-z0-9])?"
-	StorageUriFmt                string = "(([a-z]([-a-z0-9]*[a-z0-9])?/))*([a-z]([-a-z0-9]*[a-z0-9]))"
+	CommaSpaceSeparator                 = ", "
+	AlphaNumericDash                    = "[a-z]([-a-z0-9]*[a-z0-9])"
+	TmNameFmt                    string = AlphaNumericDash + "?"
+	StorageUriFmt                string = "(" + AlphaNumericDash + "/)?)*(" + AlphaNumericDash + ")"
 	InvalidTmNameFormatError            = "the Trained Model \"%s\" is invalid: a Trained Model name must consist of lower case alphanumeric characters or '-', and must start with alphabetical character. (e.g. \"my-name\" or \"abc-123\", regex used for validation is '%s')"
 	InvalidStorageUriFormatError        = "the Trained Model \"%s\" storageUri field is invalid. The storage uri must have the prefix %s and consist of lower case alphanumeric characters or '-' or '/', and must start with alphabetical character. (the storage uri given is \"%s\", regex used for validation is '%s')"
 	InvalidTmMemoryModification         = "the Trained Model \"%s\" memory field is immutable. The memory was \"%s\" but it is updated to \"%s\""
@@ -43,7 +44,7 @@ var (
 	// regular expressions for validation of tm name
 	TmRegexp = regexp.MustCompile("^" + TmNameFmt + "$")
 	// protocols that are accepted by storage uri
-	StorageUriProtocols = strings.Join(storage.GetAllProtocol(), CommaSeparator)
+	StorageUriProtocols = strings.Join(storage.GetAllProtocol(), CommaSpaceSeparator)
 	// prefix allowed in storage uri
 	StorageUriPrefixes = "(" + strings.Join(storage.GetAllProtocol(), "|") + ")"
 	// regular expression for validation of storageURI

--- a/pkg/apis/serving/v1alpha1/trainedmodel_webhook.go
+++ b/pkg/apis/serving/v1alpha1/trainedmodel_webhook.go
@@ -32,7 +32,7 @@ const (
 	CommaSpaceSeparator                 = ", "
 	AlphaNumericDash                    = "[a-z]([-a-z0-9]*[a-z0-9])"
 	TmNameFmt                    string = AlphaNumericDash + "?"
-	StorageUriFmt                string = "(" + AlphaNumericDash + "/)?)*(" + AlphaNumericDash + ")"
+	StorageUriFmt                string = "((" + AlphaNumericDash + "?)/)*(" + AlphaNumericDash + "?)"
 	InvalidTmNameFormatError            = "the Trained Model \"%s\" is invalid: a Trained Model name must consist of lower case alphanumeric characters or '-', and must start with alphabetical character. (e.g. \"my-name\" or \"abc-123\", regex used for validation is '%s')"
 	InvalidStorageUriFormatError        = "the Trained Model \"%s\" storageUri field is invalid. The storage uri must have the prefix %s and consist of lower case alphanumeric characters or '-' or '/', and must start with alphabetical character. (the storage uri given is \"%s\", regex used for validation is '%s')"
 	InvalidTmMemoryModification         = "the Trained Model \"%s\" memory field is immutable. The memory was \"%s\" but it is updated to \"%s\""

--- a/pkg/apis/serving/v1alpha1/trainedmodel_webhook_test.go
+++ b/pkg/apis/serving/v1alpha1/trainedmodel_webhook_test.go
@@ -30,7 +30,7 @@ func makeTestTrainModel() TrainedModel {
 		Spec: TrainedModelSpec{
 			InferenceService: "Parent",
 			Model: ModelSpec{
-				StorageURI: "gcs://kfserving/sklearn/iris",
+				StorageURI: "gs://kfserving/sklearn/iris",
 				Framework:  "sklearn",
 				Memory:     quantity,
 			},
@@ -92,6 +92,20 @@ func TestValidateCreate(t *testing.T) {
 				name: "abc 123",
 			},
 			matcher: gomega.MatchError(fmt.Errorf(InvalidTmNameFormatError, "abc 123", TmRegexp)),
+		},
+		"invalid storageURI prefix": {
+			tm: makeTestTrainModel(),
+			update: map[string]string{
+				storageURI: "https://kfserving/sklearn/iris",
+			},
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "https://kfserving/sklearn/iris", StorageUriRegex)),
+		},
+		"invalid storageURI path": {
+			tm: makeTestTrainModel(),
+			update: map[string]string{
+				storageURI: "gs://kfserving/sklearn//iris",
+			},
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "gs://kfserving/sklearn//iris", StorageUriRegex)),
 		},
 	}
 
@@ -176,9 +190,23 @@ func TestValidateUpdate(t *testing.T) {
 		"storageURI": {
 			tm: makeTestTrainModel(),
 			update: map[string]string{
-				storageURI: "gcs://kfserving/sklearn2/iris",
+				storageURI: "gs://kfserving/sklearn2/iris",
 			},
 			matcher: gomega.MatchError(nil),
+		},
+		"invalid storageURI prefix": {
+			tm: makeTestTrainModel(),
+			update: map[string]string{
+				storageURI: "https://kfserving/sklearn/iris",
+			},
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "https://kfserving/sklearn/iris", StorageUriRegex)),
+		},
+		"invalid storageURI path": {
+			tm: makeTestTrainModel(),
+			update: map[string]string{
+				storageURI: "gs://kfserving/sklearn//iris",
+			},
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "gs://kfserving/sklearn//iris", StorageUriRegex)),
 		},
 		"framework": {
 			tm: makeTestTrainModel(),

--- a/pkg/apis/serving/v1alpha1/trainedmodel_webhook_test.go
+++ b/pkg/apis/serving/v1alpha1/trainedmodel_webhook_test.go
@@ -98,14 +98,14 @@ func TestValidateCreate(t *testing.T) {
 			update: map[string]string{
 				storageURI: "https://kfserving/sklearn/iris",
 			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "https://kfserving/sklearn/iris", StorageUriRegex)),
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "https://kfserving/sklearn/iris", StorageUriRegex)),
 		},
 		"invalid storageURI path": {
 			tm: makeTestTrainModel(),
 			update: map[string]string{
 				storageURI: "gs://kfserving/sklearn//iris",
 			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "gs://kfserving/sklearn//iris", StorageUriRegex)),
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "gs://kfserving/sklearn//iris", StorageUriRegex)),
 		},
 	}
 
@@ -199,14 +199,14 @@ func TestValidateUpdate(t *testing.T) {
 			update: map[string]string{
 				storageURI: "https://kfserving/sklearn/iris",
 			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "https://kfserving/sklearn/iris", StorageUriRegex)),
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "https://kfserving/sklearn/iris", StorageUriRegex)),
 		},
 		"invalid storageURI path": {
 			tm: makeTestTrainModel(),
 			update: map[string]string{
 				storageURI: "gs://kfserving/sklearn//iris",
 			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", "gs://kfserving/sklearn//iris", StorageUriRegex)),
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "gs://kfserving/sklearn//iris", StorageUriRegex)),
 		},
 		"framework": {
 			tm: makeTestTrainModel(),

--- a/pkg/apis/serving/v1alpha1/trainedmodel_webhook_test.go
+++ b/pkg/apis/serving/v1alpha1/trainedmodel_webhook_test.go
@@ -98,14 +98,7 @@ func TestValidateCreate(t *testing.T) {
 			update: map[string]string{
 				storageURI: "https://kfserving/sklearn/iris",
 			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "https://kfserving/sklearn/iris", StorageUriRegex)),
-		},
-		"invalid storageURI path": {
-			tm: makeTestTrainModel(),
-			update: map[string]string{
-				storageURI: "gs://kfserving/sklearn//iris",
-			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "gs://kfserving/sklearn//iris", StorageUriRegex)),
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "https://kfserving/sklearn/iris")),
 		},
 	}
 
@@ -199,14 +192,7 @@ func TestValidateUpdate(t *testing.T) {
 			update: map[string]string{
 				storageURI: "https://kfserving/sklearn/iris",
 			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "https://kfserving/sklearn/iris", StorageUriRegex)),
-		},
-		"invalid storageURI path": {
-			tm: makeTestTrainModel(),
-			update: map[string]string{
-				storageURI: "gs://kfserving/sklearn//iris",
-			},
-			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "gs://kfserving/sklearn//iris", StorageUriRegex)),
+			matcher: gomega.MatchError(fmt.Errorf(InvalidStorageUriFormatError, "bar", StorageUriProtocols, "https://kfserving/sklearn/iris")),
 		},
 		"framework": {
 			tm: makeTestTrainModel(),

--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -120,14 +120,21 @@ func validateStorageURI(storageURI *string) error {
 			return nil
 		}
 	} else {
-		for _, prefix := range SupportedStorageURIPrefixList {
-			if strings.HasPrefix(*storageURI, prefix) {
-				return nil
-			}
+		if IsPrefixStorageURISupported(*storageURI, SupportedStorageURIPrefixList) {
+			return nil
 		}
 	}
 
 	return fmt.Errorf(UnsupportedStorageURIFormatError, strings.Join(SupportedStorageURIPrefixList, ", "), *storageURI)
+}
+
+func IsPrefixStorageURISupported(storageURI string, supportedStorageURIPrefixes []string) bool {
+	for _, prefix := range supportedStorageURIPrefixes {
+		if strings.HasPrefix(storageURI, prefix) {
+			return true
+		}
+	}
+	return false
 }
 
 func validateReplicas(minReplicas *int, maxReplicas int) error {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The webbook will validate the storageURI passed in the trained model

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
