### PR TITLE
Defined recorder in test suite

### DIFF
--- a/pkg/controller/v1alpha1/trainedmodel/suite_test.go
+++ b/pkg/controller/v1alpha1/trainedmodel/suite_test.go
@@ -18,6 +18,7 @@ package trainedmodel
 
 import (
 	"context"
+	"k8s.io/client-go/tools/record"
 	"path/filepath"
 	"testing"
 
@@ -102,6 +103,7 @@ var _ = BeforeSuite(func(done Done) {
 		Client:                k8sManager.GetClient(),
 		Scheme:                scheme.Scheme,
 		Log:                   ctrl.Log.WithName("v1beta1TrainedModelController"),
+		Recorder:              record.NewBroadcaster().NewRecorder(scheme.Scheme, v1.EventSource{Component: "v1betaController"}),
 		ModelConfigReconciler: modelconfig.NewModelConfigReconciler(k8sManager.GetClient(), scheme.Scheme),
 	}).SetupWithManager(k8sManager)
 	Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:  Test suite did not define recorder. Lead to invalid memory access when trying to use Event() and Eventf() functions.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
