### PR TITLE
Added validation for framework in the trained model controller

### DIFF
--- a/config/overlays/test/configmap/inferenceservice.yaml
+++ b/config/overlays/test/configmap/inferenceservice.yaml
@@ -11,22 +11,34 @@ data:
             "defaultImageVersion": "1.14.0",
             "defaultGpuImageVersion": "1.14.0-gpu",
             "defaultTimeout": "60",
+            "supportedFrameworks": [
+             "tensorflow"
+            ],
             "multiModelServer": false
         },
         "onnx": {
             "image": "mcr.microsoft.com/onnxruntime/server",
             "defaultImageVersion": "v1.0.0",
+            "supportedFrameworks": [
+              "onnx"
+            ],
             "multiModelServer": false
         },
         "sklearn": {
           "v1": {
             "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kfserving/sklearnserver",
             "defaultImageVersion": "latest",
+            "supportedFrameworks": [
+              "sklearn"
+            ],
             "multiModelServer": true
           },
           "v2": {
             "image": "docker.io/seldonio/mlserver",
             "defaultImageVersion": "0.2.1",
+            "supportedFrameworks": [
+              "sklearn"
+            ],
             "multiModelServer": true
           }
         },
@@ -34,11 +46,17 @@ data:
           "v1": {
             "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kfserving/xgbserver",
             "defaultImageVersion": "latest",
+            "supportedFrameworks": [
+              "xgboost"
+            ],
             "multiModelServer": true
           },
           "v2": {
             "image": "docker.io/seldonio/mlserver",
             "defaultImageVersion": "0.2.1",
+            "supportedFrameworks": [
+              "xgboost"
+            ],
             "multiModelServer": true
           }
         },
@@ -65,16 +83,29 @@ data:
         "triton": {
             "image": "nvcr.io/nvidia/tritonserver",
             "defaultImageVersion": "20.08-py3",
+            "supportedFrameworks": [
+              "tensorrt",
+              "tensorflow",
+              "onnx",
+              "pytorch",
+              "caffe2"
+            ],
             "multiModelServer": true
         },
         "pmml": {
             "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kfserving/pmmlserver",
             "defaultImageVersion": "latest",
+            "supportedFrameworks": [
+              "pmml"
+            ],
             "multiModelServer": false
         },
         "lightgbm": {
             "image": "809251082950.dkr.ecr.us-west-2.amazonaws.com/kfserving/lgbserver",
             "defaultImageVersion": "latest",
+            "supportedFrameworks": [
+              "lightgbm"
+            ],
             "multiModelServer": true
         }
     }

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -333,3 +333,8 @@ make: *** [manifests] Error 1
 Version: v0.3.0
 ```
 Deleting $GOPATH/bin/controller-gen helps to resolve this issue, as Makefile will fetch the correct version.
+
+7. When your able to run your changes using make deploy-dev, but it fails when running against test, checkout your `overlays/test` to verify everything is properly configured.
+
+8. When supported framework says it's not supported or multi-model serving not working:
+Check to see if `inferenceservice.yaml` has the fields properly set (supportedFramework and multiModelServer respectively).

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -334,7 +334,7 @@ Version: v0.3.0
 ```
 Deleting $GOPATH/bin/controller-gen helps to resolve this issue, as Makefile will fetch the correct version.
 
-7. When your able to run your changes using make deploy-dev, but it fails when running against test, checkout your `overlays/test` to verify everything is properly configured.
+7. When you are able to test your changes locally using make deploy-dev, but it fails when running in KFServing CI e2e tests, please checkout your `overlays/test` to verify everything is properly configured.
 
 8. When supported framework says it's not supported or multi-model serving not working:
 Check to see if `inferenceservice.yaml` has the fields properly set (supportedFramework and multiModelServer respectively).

--- a/pkg/apis/serving/v1alpha1/trained_model_status.go
+++ b/pkg/apis/serving/v1alpha1/trained_model_status.go
@@ -36,16 +36,19 @@ type TrainedModelStatus struct {
 }
 
 // ConditionType represents a Service condition value
-// TODO: Add conditions for framework supported and memory availability
+// TODO: Add conditions for memory availability
 const (
 	// InferenceServiceReady is set when inference service reported readiness
 	InferenceServiceReady apis.ConditionType = "InferenceServiceReady"
+	// FrameworkSupported is set when predictor reports framework check
+	FrameworkSupported apis.ConditionType = "FrameworkSupported"
 )
 
 // TrainedModel Ready condition is depending on inference service readiness condition
 // TODO: Similar to above, add the constants here
 var conditionSet = apis.NewLivingConditionSet(
 	InferenceServiceReady,
+	FrameworkSupported,
 )
 
 var _ apis.ConditionsAccessor = (*TrainedModelStatus)(nil)

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -65,6 +65,8 @@ type PredictorConfig struct {
 	DefaultTimeout int64 `json:"defaultTimeout,string,omitempty"`
 	// Flag to determine if multi-model serving is supported
 	MultiModelServer bool `json:"multiModelServer,boolean,omitempty"`
+	// frameworks the model agent is able to run
+	SupportedFrameworks []string `json:"supportedFrameworks"`
 }
 
 // +kubebuilder:object:generate=false

--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -19,7 +19,14 @@ package v1beta1
 import (
 	"github.com/kubeflow/kfserving/pkg/constants"
 	v1 "k8s.io/api/core/v1"
+	"reflect"
 )
+
+// PredictorImplementation defines common functions for all predictors e.g Tensorflow, Triton, etc
+// +kubebuilder:object:generate=false
+type PredictorImplementation interface {
+	IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool
+}
 
 // PredictorSpec defines the configuration for a predictor,
 // The following fields follow a "1-of" semantic. Users must specify exactly one spec.
@@ -97,4 +104,49 @@ func (s *PredictorSpec) GetImplementation() ComponentImplementation {
 // GetExtensions returns the extensions for the component
 func (s *PredictorSpec) GetExtensions() *ComponentExtensionSpec {
 	return &s.ComponentExtensionSpec
+}
+
+// GetPredictor returns the implementation for the predictor
+func (s *PredictorSpec) GetPredictors() []PredictorImplementation {
+	implementations := NonNilPredictors([]PredictorImplementation{
+		s.XGBoost,
+		s.PyTorch,
+		s.Triton,
+		s.SKLearn,
+		s.Tensorflow,
+		s.ONNX,
+		s.PMML,
+		s.LightGBM,
+	})
+	// This struct is not a pointer, so it will never be nil; include if containers are specified
+	if len(s.PodSpec.Containers) != 0 {
+		implementations = append(implementations, NewCustomPredictor(&s.PodSpec))
+	}
+	return implementations
+}
+
+func (s *PredictorSpec) GetPredictor() *PredictorImplementation {
+	predictors := s.GetPredictors()
+	if len(predictors) == 0 {
+		return nil
+	}
+	return &s.GetPredictors()[0]
+}
+
+func NonNilPredictors(objects []PredictorImplementation) (results []PredictorImplementation) {
+	for _, object := range objects {
+		if !reflect.ValueOf(object).IsNil() {
+			results = append(results, object)
+		}
+	}
+	return results
+}
+
+func isFrameworkIncluded(supportedFrameworks []string, framework string) bool {
+	for _, supportedFramework := range supportedFrameworks {
+		if supportedFramework == framework {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -79,5 +79,5 @@ func (c *CustomPredictor) IsMMS(config *InferenceServicesConfig) bool {
 
 func (c *CustomPredictor) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
 	//TODO: Figure out how to check if custom predictor is supports framework
-	return false
+	return true
 }

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -79,5 +79,5 @@ func (c *CustomPredictor) IsMMS(config *InferenceServicesConfig) bool {
 
 func (c *CustomPredictor) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
 	//TODO: Figure out how to check if custom predictor is supports framework
-	return true
+	return false
 }

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -28,7 +28,10 @@ type CustomPredictor struct {
 	v1.PodSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &CustomPredictor{}
+var (
+	_ ComponentImplementation = &CustomPredictor{}
+	_ PredictorImplementation = &CustomPredictor{}
+)
 
 func NewCustomPredictor(podSpec *PodSpec) *CustomPredictor {
 	return &CustomPredictor{PodSpec: v1.PodSpec(*podSpec)}
@@ -72,4 +75,9 @@ func (c *CustomPredictor) GetProtocol() constants.InferenceServiceProtocol {
 func (c *CustomPredictor) IsMMS(config *InferenceServicesConfig) bool {
 	//TODO: Figure out how to check if custom predictor is mms
 	return false
+}
+
+func (c *CustomPredictor) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	//TODO: Figure out how to check if custom predictor is supports framework
+	return true
 }

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -347,7 +347,7 @@ func TestCustomPredictorIsFrameworkSupported(t *testing.T) {
 					},
 				},
 			},
-			expected: true,
+			expected: false,
 		},
 	}
 

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -347,7 +347,7 @@ func TestCustomPredictorIsFrameworkSupported(t *testing.T) {
 					},
 				},
 			},
-			expected: false,
+			expected: true,
 		},
 	}
 

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm.go
@@ -33,7 +33,10 @@ type LightGBMSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &LightGBMSpec{}
+var (
+	_ ComponentImplementation = &LightGBMSpec{}
+	_ PredictorImplementation = &LightGBMSpec{}
+)
 
 // Validate returns an error if invalid
 func (x *LightGBMSpec) Validate() error {
@@ -85,4 +88,10 @@ func (x *LightGBMSpec) GetProtocol() constants.InferenceServiceProtocol {
 
 func (x *LightGBMSpec) IsMMS(config *InferenceServicesConfig) bool {
 	return config.Predictors.LightGBM.MultiModelServer
+}
+
+func (x *LightGBMSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	predictorConfig := config.Predictors.LightGBM
+	supportedFrameworks := predictorConfig.SupportedFrameworks
+	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm.go
@@ -91,7 +91,6 @@ func (x *LightGBMSpec) IsMMS(config *InferenceServicesConfig) bool {
 }
 
 func (x *LightGBMSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
-	predictorConfig := config.Predictors.LightGBM
-	supportedFrameworks := predictorConfig.SupportedFrameworks
+	supportedFrameworks := config.Predictors.LightGBM.SupportedFrameworks
 	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -104,7 +104,6 @@ func (o *ONNXRuntimeSpec) IsMMS(config *InferenceServicesConfig) bool {
 }
 
 func (o *ONNXRuntimeSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
-	predictorConfig := config.Predictors.ONNX
-	supportedFrameworks := predictorConfig.SupportedFrameworks
+	supportedFrameworks := config.Predictors.ONNX.SupportedFrameworks
 	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -40,7 +40,10 @@ type ONNXRuntimeSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &ONNXRuntimeSpec{}
+var (
+	_ ComponentImplementation = &ONNXRuntimeSpec{}
+	_ PredictorImplementation = &ONNXRuntimeSpec{}
+)
 
 // Validate returns an error if invalid
 func (o *ONNXRuntimeSpec) Validate() error {
@@ -98,4 +101,10 @@ func (o *ONNXRuntimeSpec) GetProtocol() constants.InferenceServiceProtocol {
 
 func (o *ONNXRuntimeSpec) IsMMS(config *InferenceServicesConfig) bool {
 	return config.Predictors.ONNX.MultiModelServer
+}
+
+func (o *ONNXRuntimeSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	predictorConfig := config.Predictors.ONNX
+	supportedFrameworks := predictorConfig.SupportedFrameworks
+	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_pmml.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml.go
@@ -33,7 +33,10 @@ type PMMLSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &PMMLSpec{}
+var (
+	_ ComponentImplementation = &PMMLSpec{}
+	_ PredictorImplementation = &PMMLSpec{}
+)
 
 // Validate returns an error if invalid
 func (p *PMMLSpec) Validate() error {
@@ -81,4 +84,10 @@ func (p *PMMLSpec) GetProtocol() constants.InferenceServiceProtocol {
 
 func (p *PMMLSpec) IsMMS(config *InferenceServicesConfig) bool {
 	return config.Predictors.PMML.MultiModelServer
+}
+
+func (p *PMMLSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	predictorConfig := config.Predictors.PMML
+	supportedFrameworks := predictorConfig.SupportedFrameworks
+	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_pmml.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml.go
@@ -87,7 +87,6 @@ func (p *PMMLSpec) IsMMS(config *InferenceServicesConfig) bool {
 }
 
 func (p *PMMLSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
-	predictorConfig := config.Predictors.PMML
-	supportedFrameworks := predictorConfig.SupportedFrameworks
+	supportedFrameworks := config.Predictors.PMML.SupportedFrameworks
 	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_sklearn.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn.go
@@ -32,7 +32,10 @@ type SKLearnSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &SKLearnSpec{}
+var (
+	_ ComponentImplementation = &SKLearnSpec{}
+	_ PredictorImplementation = &SKLearnSpec{}
+)
 
 // Validate returns an error if invalid
 func (k *SKLearnSpec) Validate() error {
@@ -182,10 +185,21 @@ func (k *SKLearnSpec) GetProtocol() constants.InferenceServiceProtocol {
 }
 
 func (k *SKLearnSpec) IsMMS(config *InferenceServicesConfig) bool {
-	if k.GetProtocol() == constants.ProtocolV1 {
-		return config.Predictors.SKlearn.V1.MultiModelServer
-	} else if k.GetProtocol() == constants.ProtocolV2 {
-		return config.Predictors.SKlearn.V2.MultiModelServer
+	predictorConfig := k.getPredictorConfig(config)
+	return predictorConfig.MultiModelServer
+}
+
+func (k *SKLearnSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	predictorConfig := k.getPredictorConfig(config)
+	supportedFrameworks := predictorConfig.SupportedFrameworks
+	return isFrameworkIncluded(supportedFrameworks, framework)
+}
+
+func (k *SKLearnSpec) getPredictorConfig(config *InferenceServicesConfig) *PredictorConfig {
+	protocol := k.GetProtocol()
+	if protocol == constants.ProtocolV1 {
+		return config.Predictors.SKlearn.V1
+	} else {
+		return config.Predictors.SKlearn.V2
 	}
-	return false
 }

--- a/pkg/apis/serving/v1beta1/predictor_tfserving.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving.go
@@ -44,7 +44,10 @@ type TFServingSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &TFServingSpec{}
+var (
+	_ ComponentImplementation = &TFServingSpec{}
+	_ PredictorImplementation = &TFServingSpec{}
+)
 
 // Validate returns an error if invalid
 func (t *TFServingSpec) Validate() error {
@@ -112,4 +115,9 @@ func (t *TFServingSpec) GetProtocol() constants.InferenceServiceProtocol {
 
 func (t *TFServingSpec) IsMMS(config *InferenceServicesConfig) bool {
 	return config.Predictors.Tensorflow.MultiModelServer
+}
+
+func (t *TFServingSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	supportedFrameworks := config.Predictors.Tensorflow.SupportedFrameworks
+	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -37,7 +37,10 @@ type TritonSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &TritonSpec{}
+var (
+	_ ComponentImplementation = &TritonSpec{}
+	_ PredictorImplementation = &TritonSpec{}
+)
 
 // Validate returns an error if invalid
 func (t *TritonSpec) Validate() error {
@@ -91,4 +94,10 @@ func (t *TritonSpec) GetProtocol() constants.InferenceServiceProtocol {
 
 func (t *TritonSpec) IsMMS(config *InferenceServicesConfig) bool {
 	return config.Predictors.Triton.MultiModelServer
+}
+
+func (t *TritonSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	predictorConfig := config.Predictors.Triton
+	supportedFrameworks := predictorConfig.SupportedFrameworks
+	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -97,7 +97,6 @@ func (t *TritonSpec) IsMMS(config *InferenceServicesConfig) bool {
 }
 
 func (t *TritonSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
-	predictorConfig := config.Predictors.Triton
-	supportedFrameworks := predictorConfig.SupportedFrameworks
+	supportedFrameworks := config.Predictors.Triton.SupportedFrameworks
 	return isFrameworkIncluded(supportedFrameworks, framework)
 }

--- a/pkg/apis/serving/v1beta1/predictor_xgboost.go
+++ b/pkg/apis/serving/v1beta1/predictor_xgboost.go
@@ -32,7 +32,10 @@ type XGBoostSpec struct {
 	PredictorExtensionSpec `json:",inline"`
 }
 
-var _ ComponentImplementation = &XGBoostSpec{}
+var (
+	_ ComponentImplementation = &XGBoostSpec{}
+	_ PredictorImplementation = &XGBoostSpec{}
+)
 
 // Validate returns an error if invalid
 func (x *XGBoostSpec) Validate() error {
@@ -187,10 +190,21 @@ func (x *XGBoostSpec) GetProtocol() constants.InferenceServiceProtocol {
 }
 
 func (x *XGBoostSpec) IsMMS(config *InferenceServicesConfig) bool {
-	if x.GetProtocol() == constants.ProtocolV1 {
-		return config.Predictors.XGBoost.V1.MultiModelServer
-	} else if x.GetProtocol() == constants.ProtocolV2 {
-		return config.Predictors.XGBoost.V2.MultiModelServer
+	predictorConfig := x.getPredictorConfig(config)
+	return predictorConfig.MultiModelServer
+}
+
+func (x *XGBoostSpec) IsFrameworkSupported(framework string, config *InferenceServicesConfig) bool {
+	predictorConfig := x.getPredictorConfig(config)
+	supportedFrameworks := predictorConfig.SupportedFrameworks
+	return isFrameworkIncluded(supportedFrameworks, framework)
+}
+
+func (x *XGBoostSpec) getPredictorConfig(config *InferenceServicesConfig) *PredictorConfig {
+	protocol := x.GetProtocol()
+	if protocol == constants.ProtocolV1 {
+		return config.Predictors.XGBoost.V1
+	} else {
+		return config.Predictors.XGBoost.V2
 	}
-	return false
 }

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -230,10 +230,7 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 	// Update Framework Supported condition
 	isvcConfig, err := v1beta1api.NewInferenceServicesConfig(r.Client)
 	if err != nil {
-		conditionErr = utils.FirstNonNilError([]error{
-			conditionErr,
-			err,
-		})
+		return err
 	} else {
 		predictor := isvc.Spec.Predictor.GetPredictor()
 		if predictor != nil && (*predictor).IsFrameworkSupported(tm.Spec.Model.Framework, isvcConfig) {
@@ -250,10 +247,7 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 				Message: "Inference Service does not support the Trained Model framework",
 			})
 
-			conditionErr = utils.FirstNonNilError([]error{
-				conditionErr,
-				fmt.Errorf(FrameworkNotSupported, isvc.Name, tm.Name, tm.Spec.Model.Framework),
-			})
+			conditionErr = fmt.Errorf(FrameworkNotSupported, isvc.Name, tm.Name, tm.Spec.Model.Framework)
 		}
 	}
 

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -235,9 +235,6 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 		})
 	} else {
 		predictor := isvc.Spec.Predictor.GetPredictor()
-		if predictor == nil {
-
-		}
 		if predictor != nil && (*predictor).IsFrameworkSupported(tm.Spec.Model.Framework, isvcConfig) {
 			log.Info("Framework is supported", "TrainedModel", tm.Name, "InferenceService", isvc.Name, "Framework", tm.Spec.Model.Framework)
 			tm.Status.SetCondition(v1alpha1api.FrameworkSupported, &apis.Condition{

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -87,10 +87,6 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		return reconcile.Result{}, err
 	}
 
-	if err := r.updateConditions(req, tm); err != nil {
-		return reconcile.Result{}, err
-	}
-
 	// Add parent InferenceService's name to TrainedModel's label
 	if tm.Labels == nil {
 		tm.Labels = make(map[string]string)
@@ -131,6 +127,11 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 
 		// Stop reconciliation as the item is being deleted
 		return ctrl.Result{}, nil
+	}
+
+	// Update InferenceServiceReady and FrameworkSupported conditions
+	if err := r.updateConditions(req, tm); err != nil {
+		return reconcile.Result{}, err
 	}
 
 	// update URL and Address fo TrainedModel

--- a/pkg/controller/v1alpha1/trainedmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller_test.go
@@ -19,7 +19,6 @@ package trainedmodel
 import (
 	"context"
 	"github.com/golang/protobuf/proto"
-	"github.com/google/go-cmp/cmp"
 	v1alpha1api "github.com/kubeflow/kfserving/pkg/apis/serving/v1alpha1"
 	"github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
 	"github.com/kubeflow/kfserving/pkg/constants"
@@ -60,7 +59,8 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 		configs = map[string]string{
 			"predictors": `{
                "tensorflow": {
-                  "image": "tensorflow/serving"
+                  "image": "tensorflow/serving",
+				  "supportedFrameworks": ["tensorflow"]
                },
                "sklearn": {
                   "image": "kfserving/sklearnserver"
@@ -82,7 +82,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 		}
 		namespace       = "default"
 		storageUri      = "s3//model1"
-		framework       = "pytorch"
+		framework       = "tensorflow"
 		memory, _       = resource.ParseQuantity("1G")
 		shardId         = 0
 		readyConditions = duckv1.Status{
@@ -110,8 +110,6 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 		It("Should not add a model to the model configmap", func() {
 			modelName := "model0-create"
 			parentInferenceService := modelName + "-parent"
-			modelConfigName := constants.ModelConfigName(parentInferenceService, shardId)
-			configmapKey := types.NamespacedName{Name: modelConfigName, Namespace: namespace}
 			tmKey := types.NamespacedName{Name: modelName, Namespace: namespace}
 
 			// Create InferenceService configmap
@@ -134,35 +132,8 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 					Name:      serviceKey.Name,
 					Namespace: serviceKey.Namespace,
 				},
-				Spec: v1beta1.InferenceServiceSpec{
-					Predictor: v1beta1.PredictorSpec{
-						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
-							MinReplicas: v1beta1.GetIntReference(1),
-							MaxReplicas: 3,
-						},
-						Tensorflow: &v1beta1.TFServingSpec{
-							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
-								StorageURI:     &storageUri,
-								RuntimeVersion: proto.String("1.14.0"),
-								Container: v1.Container{
-									Name:      "kfserving-container",
-									Resources: defaultResource,
-								},
-							},
-						},
-					},
-				},
 			}
 			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
-
-			// Create modelConfig
-			modelConfig := &v1.ConfigMap{
-				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
-				Data: map[string]string{
-					constants.ModelConfigFileName: "",
-				},
-			}
 
 			tmInstance := &v1alpha1api.TrainedModel{
 				ObjectMeta: metav1.ObjectMeta{
@@ -179,8 +150,6 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				},
 			}
 
-			Expect(k8sClient.Create(context.TODO(), modelConfig)).NotTo(HaveOccurred())
-			defer k8sClient.Delete(context.TODO(), modelConfig)
 			Expect(k8sClient.Create(context.TODO(), tmInstance)).NotTo(HaveOccurred())
 			defer k8sClient.Delete(context.TODO(), tmInstance)
 
@@ -194,23 +163,6 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				isvcReadyCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.InferenceServiceReady)
 				return isvcReadyCondition != nil && isvcReadyCondition.Status == v1.ConditionFalse
 			}, timeout).Should(BeTrue())
-
-			// Verify that the model configmap is updated with the TrainedModel
-			configmapActual := &v1.ConfigMap{}
-			tmActual := &v1alpha1api.TrainedModel{}
-			expected := &v1.ConfigMap{
-				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
-				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
-				Data: map[string]string{
-					constants.ModelConfigFileName: ``,
-				},
-			}
-			Eventually(func() map[string]string {
-				ctx := context.Background()
-				k8sClient.Get(ctx, configmapKey, configmapActual)
-				k8sClient.Get(ctx, tmKey, tmActual)
-				return configmapActual.Data
-			}, timeout, interval).Should(Equal(expected.Data))
 		})
 	})
 
@@ -250,7 +202,6 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 						},
 						Tensorflow: &v1beta1.TFServingSpec{
 							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
-								StorageURI:     &storageUri,
 								RuntimeVersion: proto.String("1.14.0"),
 								Container: v1.Container{
 									Name:      "kfserving-container",
@@ -311,7 +262,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
 				Data: map[string]string{
-					constants.ModelConfigFileName: `[{"modelName":"model1-create","modelSpec":{"storageUri":"s3//model1","framework":"pytorch","memory":"1G"}}]`,
+					constants.ModelConfigFileName: `[{"modelName":"model1-create","modelSpec":{"storageUri":"s3//model1","framework":"tensorflow","memory":"1G"}}]`,
 				},
 			}
 			Eventually(func() map[string]string {
@@ -359,7 +310,6 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 						},
 						Tensorflow: &v1beta1.TFServingSpec{
 							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
-								StorageURI:     &storageUri,
 								RuntimeVersion: proto.String("1.14.0"),
 								Container: v1.Container{
 									Name:      "kfserving-container",
@@ -429,6 +379,11 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 					return false
 				}
 
+				// Condition FrameworkSupported should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.FrameworkSupported) {
+					return false
+				}
+
 				if len(tmInstanceUpdate.Finalizers) > 0 {
 					if tmInstanceUpdate.Status.Address != nil {
 						return tmInstanceUpdate.Status.Address.URL != nil && tmInstanceUpdate.Status.URL != nil
@@ -436,11 +391,6 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				}
 				return false
 			}, timeout).Should(BeTrue())
-
-			tmExpectedURL := predictorUrl.String() + constants.PredictPath(tmInstanceUpdate.Name, isvc.Spec.Predictor.GetImplementation().GetProtocol())
-			tmExpectedAddressURL := clusterURL.String() + constants.PredictPath(tmInstanceUpdate.Name, isvc.Spec.Predictor.GetImplementation().GetProtocol())
-			Expect(cmp.Diff(tmInstanceUpdate.Status.URL.String(), tmExpectedURL)).To(Equal(""))
-			Expect(cmp.Diff(tmInstanceUpdate.Status.Address.URL.String(), tmExpectedAddressURL)).To(Equal(""))
 
 			updatedModelUri := "s3//model2"
 			tmInstanceUpdate.Spec.Model.StorageURI = updatedModelUri
@@ -454,7 +404,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
 				Data: map[string]string{
-					constants.ModelConfigFileName: `[{"modelName":"model1-update","modelSpec":{"storageUri":"s3//model2","framework":"pytorch","memory":"1G"}}]`,
+					constants.ModelConfigFileName: `[{"modelName":"model1-update","modelSpec":{"storageUri":"s3//model2","framework":"tensorflow","memory":"1G"}}]`,
 				},
 			}
 			Eventually(func() map[string]string {
@@ -504,7 +454,6 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 						},
 						Tensorflow: &v1beta1.TFServingSpec{
 							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
-								StorageURI:     &storageUri,
 								RuntimeVersion: proto.String("1.14.0"),
 								Container: v1.Container{
 									Name:      "kfserving-container",
@@ -564,7 +513,7 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
 				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
 				Data: map[string]string{
-					constants.ModelConfigFileName: `[{"modelName":"model1-delete","modelSpec":{"storageUri":"s3//model1","framework":"pytorch","memory":"1G"}}]`,
+					constants.ModelConfigFileName: `[{"modelName":"model1-delete","modelSpec":{"storageUri":"s3//model1","framework":"tensorflow","memory":"1G"}}]`,
 				},
 			}
 			Eventually(func() map[string]string {
@@ -592,6 +541,132 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				ctx := context.Background()
 				k8sClient.Get(ctx, configmapKey, configmapActual)
 				k8sClient.Get(ctx, tmKey, tmActual)
+				return configmapActual.Data
+			}, timeout, interval).Should(Equal(expected.Data))
+		})
+	})
+
+	Context("When creating a TrainedModel with an unsupported framework", func() {
+		It("Should not add the model to the model configmap", func() {
+			modelName := "model0-framework-unsupported"
+			parentInferenceService := modelName + "-parent"
+			modelConfigName := constants.ModelConfigName(parentInferenceService, shardId)
+			configmapKey := types.NamespacedName{Name: modelConfigName, Namespace: namespace}
+			tmKey := types.NamespacedName{Name: modelName, Namespace: namespace}
+
+			// Create InferenceService configmap
+			var configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KFServingNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			// Create the parent InferenceService
+			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: parentInferenceService, Namespace: namespace}}
+			var serviceKey = expectedRequest.NamespacedName
+			ctx := context.Background()
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: v1beta1.GetIntReference(1),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								RuntimeVersion: proto.String("1.14.0"),
+								Container: v1.Container{
+									Name:      "kfserving-container",
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+
+			inferenceService := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, inferenceService)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			inferenceService.Status.Status = readyConditions
+			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
+
+			// Create modelConfig
+			modelConfig := &v1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
+				Data: map[string]string{
+					constants.ModelConfigFileName: "",
+				},
+			}
+
+			unsupportedFramework := "unsupportedFramework"
+			tmInstance := &v1alpha1api.TrainedModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1api.TrainedModelSpec{
+					InferenceService: parentInferenceService,
+					Model: v1alpha1api.ModelSpec{
+						StorageURI: storageUri,
+						Framework:  unsupportedFramework,
+						Memory:     memory,
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(context.TODO(), modelConfig)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), modelConfig)
+			Expect(k8sClient.Create(context.TODO(), tmInstance)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), tmInstance)
+
+			Eventually(func() bool {
+				tmInstanceUpdate := &v1alpha1api.TrainedModel{}
+				if err := k8sClient.Get(context.TODO(), tmKey, tmInstanceUpdate); err != nil {
+					return false
+				}
+
+				// Condition for inferenceserviceready should be true
+				if tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceReady) {
+					frameworkSupportedCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.FrameworkSupported)
+					return frameworkSupportedCondition != nil && frameworkSupportedCondition.Status == v1.ConditionFalse
+				}
+
+				return false
+			}, timeout).Should(BeTrue())
+
+			// Verify that the model configmap is updated with the TrainedModel
+			configmapActual := &v1.ConfigMap{}
+			tmActual := &v1alpha1api.TrainedModel{}
+			expected := &v1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
+				Data: map[string]string{
+					constants.ModelConfigFileName: ``,
+				},
+			}
+
+			Eventually(func() map[string]string {
+				ctx := context.Background()
+				k8sClient.Get(ctx, configmapKey, configmapActual)
+				k8sClient.Get(ctx, tmKey, tmActual)
+
 				return configmapActual.Data
 			}, timeout, interval).Should(Equal(expected.Data))
 		})


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: We need to verify the framework based on the model server. Should reject if the framework does not. Logs the condition of the trained model (FrameworkSupported) when reconciling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1422 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
