### PR TITLE
Watcher should not be started until models downloaded in MMS

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -282,7 +282,7 @@ func startModelPuller(logger *zap.SugaredLogger) {
 	}
 	watcher := agent.NewWatcher(*configDir, *modelDir, logger)
 	logger.Info("Starting puller")
-	agent.StartPullerAndProcessModels(downloader, watcher.ModelEvents, watcher.ModelTracker, logger)
+	agent.StartPullerAndProcessModels(downloader, watcher.ModelEvents, logger)
 	go watcher.Start()
 }
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -119,7 +119,7 @@ func main() {
 	}
 
 	if *enablePuller {
-		logger.Info("Starting model puller")
+		logger.Infof("Initializing model agent with config-dir %s, model-dir %s", *configDir, *modelDir)
 		startModelPuller(logger)
 	}
 
@@ -275,15 +275,14 @@ func startLogger(workers int, logger *zap.SugaredLogger) *loggerArgs {
 }
 
 func startModelPuller(logger *zap.SugaredLogger) {
-	logger.Infof("Initializing agent with config-dir %s, model-dir %s", *configDir, *modelDir)
-
 	downloader := agent.Downloader{
 		ModelDir:  *modelDir,
 		Providers: map[storage.Protocol]storage.Provider{},
 		Logger:    logger,
 	}
 	watcher := agent.NewWatcher(*configDir, *modelDir, logger)
-	agent.StartPuller(downloader, watcher.ModelEvents, logger)
+	logger.Info("Starting puller")
+	agent.StartPullerAndDrainEvents(downloader, watcher.ModelEvents, logger)
 	go watcher.Start()
 }
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -282,7 +282,7 @@ func startModelPuller(logger *zap.SugaredLogger) {
 	}
 	watcher := agent.NewWatcher(*configDir, *modelDir, logger)
 	logger.Info("Starting puller")
-	agent.StartPullerAndProcessModels(downloader, watcher.ModelEvents, logger)
+	agent.StartPullerAndProcessModels(downloader, watcher.ModelEvents, watcher.ModelTracker, logger)
 	go watcher.Start()
 }
 

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -282,7 +282,7 @@ func startModelPuller(logger *zap.SugaredLogger) {
 	}
 	watcher := agent.NewWatcher(*configDir, *modelDir, logger)
 	logger.Info("Starting puller")
-	agent.StartPullerAndDrainEvents(downloader, watcher.ModelEvents, logger)
+	agent.StartPullerAndProcessModels(downloader, watcher.ModelEvents, logger)
 	go watcher.Start()
 }
 

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -25,7 +25,6 @@ import (
 	"io/ioutil"
 	"net/http"
 	"path/filepath"
-	"time"
 )
 
 type OpType string
@@ -49,7 +48,7 @@ type ModelOp struct {
 	Spec      *v1.ModelSpec
 }
 
-func StartPullerAndDrainEvents(downloader Downloader, commands <-chan ModelOp, logger *zap.SugaredLogger) {
+func StartPullerAndProcessModels(downloader Downloader, commands <-chan ModelOp, logger *zap.SugaredLogger) {
 	puller := Puller{
 		channelMap:  make(map[string]*ModelChannel),
 		completions: make(chan *ModelOp, 4),
@@ -58,10 +57,6 @@ func StartPullerAndDrainEvents(downloader Downloader, commands <-chan ModelOp, l
 		logger:      logger,
 	}
 	go puller.processCommands(commands)
-	// Wait until all original models in config map have been downloaded, i.e. all events have been drained
-	for len(puller.channelMap) > 0 {
-		time.Sleep(1 * time.Second)
-	}
 }
 
 func (p *Puller) processCommands(commands <-chan ModelOp) {

--- a/pkg/agent/puller.go
+++ b/pkg/agent/puller.go
@@ -101,8 +101,8 @@ func (p *Puller) enqueueModelOp(modelOp *ModelOp) {
 }
 
 func (p *Puller) modelOpComplete(modelOp *ModelOp, closed bool) {
+	// During startup, the puller will wait until all models have been loaded before starting the watcher
 	if modelOp.OnStartup {
-		p.logger.Info("Deferring workergroup done.")
 		defer p.workerGroup.Done()
 	}
 	if opMap, ok := p.opStats[modelOp.ModelName]; ok {

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -101,7 +101,7 @@ var _ = Describe("Watcher", func() {
 				Eventually(func() int { return puller.opStats["model1"][Add] }).Should(Equal(1))
 				Eventually(func() int { return puller.opStats["model2"][Add] }).Should(Equal(1))
 				modelSpecMap, _ := SyncModelDir(modelDir+"/test1", watcher.logger)
-				Expect(watcher.modelTracker).Should(Equal(modelSpecMap))
+				Expect(watcher.ModelTracker).Should(Equal(modelSpecMap))
 			})
 		})
 	})
@@ -516,15 +516,16 @@ var _ = Describe("Watcher", func() {
 					},
 				}
 				watcher.parseConfig(modelConfigs)
-				logger.Printf("Watcher events length: %v", len(watcher.ModelEvents))
 				go puller.processCommands(watcher.ModelEvents)
-				// Wait until all original models in config map have been downloaded, i.e. all events have been drained
-				for len(watcher.ModelEvents) > 0 {
-					time.Sleep(1 * time.Second)
+				models := [2]string{"model1", "model2"}
+				for _, modelName := range models {
+					for puller.opStats[modelName][Add] != 1 {
+						time.Sleep(1 * time.Second)
+					}
 				}
 				Expect(len(puller.channelMap)).To(Equal(0))
-				Expect(func() int { return puller.opStats["model1"][Add] }).Should(Equal(1))
-				Expect(func() int { return puller.opStats["model2"][Add] }).Should(Equal(1))
+				Expect(puller.opStats["model1"][Add]).Should(Equal(1))
+				Expect(puller.opStats["model2"][Add]).Should(Equal(1))
 			})
 		})
 	})

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -80,12 +80,11 @@ var _ = Describe("Watcher", func() {
 					},
 				}
 				watcher.parseConfig(modelConfigs, false)
-				var wg sync.WaitGroup
 				puller := Puller{
 					channelMap:  make(map[string]*ModelChannel),
 					completions: make(chan *ModelOp, 4),
 					opStats:     make(map[string]map[OpType]int),
-					workerGroup: wg,
+					waitGroup: WaitGroupWrapper{sync.WaitGroup{}},
 					Downloader: Downloader{
 						ModelDir: modelDir + "/test1",
 						Providers: map[storage.Protocol]storage.Provider{
@@ -114,12 +113,11 @@ var _ = Describe("Watcher", func() {
 				defer GinkgoRecover()
 				logger.Printf("Sync model config using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
-				var wg sync.WaitGroup
 				puller := Puller{
 					channelMap:  make(map[string]*ModelChannel),
 					completions: make(chan *ModelOp, 4),
 					opStats:     make(map[string]map[OpType]int),
-					workerGroup: wg,
+					waitGroup:   WaitGroupWrapper{sync.WaitGroup{}},
 					Downloader: Downloader{
 						ModelDir: modelDir + "/test1",
 						Providers: map[storage.Protocol]storage.Provider{
@@ -161,12 +159,11 @@ var _ = Describe("Watcher", func() {
 				defer GinkgoRecover()
 				logger.Printf("Sync delete models using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
-				var wg sync.WaitGroup
 				puller := Puller{
 					channelMap:  make(map[string]*ModelChannel),
 					completions: make(chan *ModelOp, 4),
 					opStats:     make(map[string]map[OpType]int),
-					workerGroup: wg,
+					waitGroup:   WaitGroupWrapper{sync.WaitGroup{}},
 					Downloader: Downloader{
 						ModelDir: modelDir + "/test2",
 						Providers: map[storage.Protocol]storage.Provider{
@@ -220,12 +217,11 @@ var _ = Describe("Watcher", func() {
 				defer GinkgoRecover()
 				logger.Printf("Sync update models using temp dir %v\n", modelDir)
 				watcher := NewWatcher("/tmp/configs", modelDir, sugar)
-				var wg sync.WaitGroup
 				puller := Puller{
 					channelMap:  make(map[string]*ModelChannel),
 					completions: make(chan *ModelOp, 4),
 					opStats:     make(map[string]map[OpType]int),
-					workerGroup: wg,
+					waitGroup:   WaitGroupWrapper{sync.WaitGroup{}},
 					Downloader: Downloader{
 						ModelDir: modelDir + "/test3",
 						Providers: map[storage.Protocol]storage.Provider{
@@ -238,9 +234,9 @@ var _ = Describe("Watcher", func() {
 					},
 					logger: sugar,
 				}
-				puller.workerGroup.Add(len(watcher.ModelEvents))
+				puller.waitGroup.wg.Add(len(watcher.ModelEvents))
 				go puller.processCommands(watcher.ModelEvents)
-				puller.workerGroup.Wait()
+				puller.waitGroup.wg.Wait()
 				modelConfigs := modelconfig.ModelConfigs{
 					{
 						Name: "model1",
@@ -497,6 +493,7 @@ var _ = Describe("Watcher", func() {
 					channelMap:  make(map[string]*ModelChannel),
 					completions: make(chan *ModelOp, 4),
 					opStats:     make(map[string]map[OpType]int),
+					waitGroup:   WaitGroupWrapper{sync.WaitGroup{}},
 					Downloader: Downloader{
 						ModelDir: modelDir + "/test2",
 						Providers: map[storage.Protocol]storage.Provider{
@@ -525,10 +522,10 @@ var _ = Describe("Watcher", func() {
 						},
 					},
 				}
-				puller.workerGroup.Add(len(modelConfigs))
+				puller.waitGroup.wg.Add(len(modelConfigs))
 				watcher.parseConfig(modelConfigs, true)
 				go puller.processCommands(watcher.ModelEvents)
-				puller.workerGroup.Wait()
+				puller.waitGroup.wg.Wait()
 				Expect(len(puller.channelMap)).To(Equal(0))
 				Expect(puller.opStats["model1"][Add]).Should(Equal(1))
 				Expect(puller.opStats["model2"][Add]).Should(Equal(1))

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -35,7 +35,6 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
-	"time"
 )
 
 var _ = Describe("Watcher", func() {
@@ -526,14 +525,10 @@ var _ = Describe("Watcher", func() {
 						},
 					},
 				}
-				watcher.parseConfig(modelConfigs, false)
+				puller.workerGroup.Add(len(modelConfigs))
+				watcher.parseConfig(modelConfigs, true)
 				go puller.processCommands(watcher.ModelEvents)
-				models := [2]string{"model1", "model2"}
-				for _, modelName := range models {
-					for puller.opStats[modelName][Add] != 1 {
-						time.Sleep(1 * time.Second)
-					}
-				}
+				puller.workerGroup.Wait()
 				Expect(len(puller.channelMap)).To(Equal(0))
 				Expect(puller.opStats["model1"][Add]).Should(Equal(1))
 				Expect(puller.opStats["model2"][Add]).Should(Equal(1))


### PR DESCRIPTION
**What this PR does / why we need it**:
Makes sure models are downloaded before starting the watcher for the model agent. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1338

**Manual Test**
These changes were run locally and checked by looking at the agent container logs on the predictor pod. Once the train models were deployed, I checked the logs for the agent and made sure that all models were downloaded before the watcher was started, which the logs confirmed.

```
{"level":"info","ts":"2021-03-21T17:21:22.764Z","caller":"logging/config.go:110","msg":"Successfully created the logger."}
{"level":"info","ts":"2021-03-21T17:21:22.765Z","caller":"logging/config.go:111","msg":"Logging level set to: info"}
{"level":"info","ts":"2021-03-21T17:21:22.765Z","caller":"logging/config.go:78","msg":"Fetch GitHub commit ID from kodata failed","error":"\"KO_DATA_PATH\" does not exist or is empty"}
{"level":"info","ts":"2021-03-21T17:21:22.765Z","caller":"agent/main.go:107","msg":"Initializing model agent with config-dir /mnt/configs, model-dir /mnt/models"}
{"level":"info","ts":"2021-03-21T17:21:22.765Z","caller":"agent/syncer.go:36","msg":"Syncing from model dir /mnt/models"}
{"level":"info","ts":"2021-03-21T17:21:22.766Z","caller":"agent/watcher.go:173","msg":"adding model model1-sklearn"}
{"level":"info","ts":"2021-03-21T17:21:22.766Z","caller":"agent/watcher.go:173","msg":"adding model model2-sklearn"}
{"level":"info","ts":"2021-03-21T17:21:22.766Z","caller":"agent/main.go:274","msg":"Starting puller"}
{"level":"info","ts":"2021-03-21T17:21:22.766Z","caller":"agent/puller.go:132","msg":"Worker is started for model2-sklearn"}
{"level":"info","ts":"2021-03-21T17:21:22.766Z","caller":"agent/puller.go:140","msg":"Downloading model from gs://kfserving-samples/models/sklearn/iris"}
{"level":"info","ts":"2021-03-21T17:21:22.766Z","caller":"agent/downloader.go:47","msg":"Downloading gs://kfserving-samples/models/sklearn/iris to model dir /mnt/models"}
{"level":"info","ts":"2021-03-21T17:21:22.766Z","caller":"agent/puller.go:132","msg":"Worker is started for model1-sklearn"}
{"level":"info","ts":"2021-03-21T17:21:22.767Z","caller":"agent/puller.go:140","msg":"Downloading model from gs://kfserving-samples/models/sklearn/iris"}
{"level":"info","ts":"2021-03-21T17:21:22.767Z","caller":"agent/downloader.go:47","msg":"Downloading gs://kfserving-samples/models/sklearn/iris to model dir /mnt/models"}
{"level":"info","ts":"2021-03-21T17:21:28.743Z","caller":"agent/downloader.go:67","msg":"Creating successFile /mnt/models/model1-sklearn/SUCCESS.66a3b6130a51a4de6f899f4e464e76d3d3f945f49aa7344af05e69d29ff4b7c8"}
{"level":"error","ts":"2021-03-21T17:21:28.744Z","caller":"agent/puller.go:153","msg":"Failed to Load model model1-sklearn","stacktrace":"github.com/kubeflow/kfserving/pkg/agent.(*Puller).modelProcessor\n\t/go/src/github.com/kubeflow/kfserving/pkg/agent/puller.go:153"}
{"level":"info","ts":"2021-03-21T17:21:28.744Z","caller":"agent/puller.go:105","msg":"Deferring workergroup done."}
{"level":"info","ts":"2021-03-21T17:21:28.744Z","caller":"agent/puller.go:125","msg":"completion event for model model1-sklearn, in flight ops 0"}
{"level":"info","ts":"2021-03-21T17:21:28.829Z","caller":"agent/downloader.go:67","msg":"Creating successFile /mnt/models/model2-sklearn/SUCCESS.66a3b6130a51a4de6f899f4e464e76d3d3f945f49aa7344af05e69d29ff4b7c8"}
{"level":"error","ts":"2021-03-21T17:21:28.831Z","caller":"agent/puller.go:153","msg":"Failed to Load model model2-sklearn","stacktrace":"github.com/kubeflow/kfserving/pkg/agent.(*Puller).modelProcessor\n\t/go/src/github.com/kubeflow/kfserving/pkg/agent/puller.go:153"}
{"level":"info","ts":"2021-03-21T17:21:28.831Z","caller":"agent/puller.go:105","msg":"Deferring workergroup done."}
{"level":"info","ts":"2021-03-21T17:21:28.831Z","caller":"agent/puller.go:125","msg":"completion event for model model2-sklearn, in flight ops 0"}
{"level":"info","ts":"2021-03-21T17:21:28.832Z","caller":"agent/main.go:112","msg":"Starting watcher."}
{"level":"info","ts":"2021-03-21T17:21:28.832Z","caller":"agent/watcher.go:89","msg":"Start to watch model config event"}
{"level":"info","ts":"2021-03-21T17:21:28.832Z","caller":"agent/watcher.go:127","msg":"Watching /mnt/data/models.json"}
```

Note: In order to differentiate events that take place during startup vs events that are picked up by the watcher if the configmap is edited, I've added a Startup attribute to the modelOp, so that the puller will wait until all startup modelsOps are processed before starting the watcher.