### PR TITLE
Migrate alibi image from gcr.io to docker hub

### DIFF
--- a/.github/workflows/alibiexplainer-docker-publish.yml
+++ b/.github/workflows/alibiexplainer-docker-publish.yml
@@ -1,4 +1,4 @@
-name: AIXExplainer Docker Publisher
+name: Alibi Explainer Docker Publisher
 
 on:
   push:
@@ -14,7 +14,7 @@ on:
   pull_request:
 
 env:
-  IMAGE_NAME: aix-explainer 
+  IMAGE_NAME: alibi-explainer 
 
 jobs:
   # Run tests.
@@ -32,7 +32,7 @@ jobs:
             docker-compose --file docker-compose.test.yml run sut
           else
             cd python
-            docker build . --file aixexplainer.Dockerfile
+            docker build . --file alibiexplainer.Dockerfile
           fi
 
   # Push image to GitHub Packages.
@@ -50,7 +50,7 @@ jobs:
       - name: Build image
         run: |
           cd python
-          docker build . --file aixexplainer.Dockerfile --tag $IMAGE_NAME
+          docker build . --file alibiexplainer.Dockerfile --tag $IMAGE_NAME
 
       - name: Log into registry
         run: docker login -u ${{ secrets.DOCKER_USER }} -p ${{ secrets.DOCKER_PASSWORD }}

--- a/.github/workflows/artexplainer-docker-publish.yml
+++ b/.github/workflows/artexplainer-docker-publish.yml
@@ -1,4 +1,4 @@
-name: ARTExapliner Docker Publisher
+name: ARTExplainer Docker Publisher
 
 on:
   push:

--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -115,7 +115,7 @@ data:
   explainers: |-
     {
         "alibi": {
-            "image" : "gcr.io/kfserving/alibi-explainer",
+            "image" : "kfserving/alibi-explainer",
             "defaultImageVersion": "latest"
         },
         "aix": {

--- a/install/v0.5.1/kfserving.yaml
+++ b/install/v0.5.1/kfserving.yaml
@@ -15978,7 +15978,7 @@ data:
   explainers: |-
     {
         "alibi": {
-            "image" : "gcr.io/kfserving/alibi-explainer",
+            "image" : "kfserving/alibi-explainer",
             "defaultImageVersion": "v0.5.1"
         },
         "aix": {


### PR DESCRIPTION
**What this PR does / why we need it**:
We no longer have permission for gcr.io project and not able to take actions in case release builds are timed out, so we have to migrate off gcr.io. There are other images we need to migrate off as well, will create a separate issue.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1426 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
