### PR TITLE
Update and fix link in README regarding podspec

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ If you want to get up running Knative quickly or you do not need service mesh, w
 
 `cluster-local-gateway` is required to serve cluster-internal traffic for transformer and explainer use cases. Please follow instructions here to install [cluster local gateway](https://knative.dev/docs/install/installing-istio/#updating-your-install-to-use-cluster-local-gateway).
 
-If you are looking to use podTemplate fields such as `NodeAffinity` and `Toleration` which are now supported on KFServing v1beta1 API spec, this requires v0.17.0+ and you need to turn on the [feature flags]((https://knative.dev/docs/serving/feature-flags/) in Knative configurations.
+If you are looking to use [PodSpec fields](https://v1-18.docs.kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#podspec-v1-core) such as `nodeSelector`, `affinity` or `tolerations` which are now supported in the KFServing v1beta1 API spec, this requires Knative v0.17.0+, and you need to turn on the corresponding [feature flags](https://knative.dev/docs/serving/feature-flags/) in your Knative configuration.
 
 Since Knative v0.19.0 `cluster local gateway` deployment has been removed and [shared with ingress gateway](https://github.com/knative-sandbox/net-istio/pull/237),
 if you are on Knative version later than v0.19.0 you should modify `localGateway` to `knative-local-gateway` and `localGatewayService` to `knative-local-gateway.istio-system.svc.cluster.local` in the


### PR DESCRIPTION
There was broken formatting in the note about certain fields needing Knative 0.17+. Fixed the formatting and updated the note with a bit more info.
