### PR TITLE
Validate trained model memory based on parent inference service

### DIFF
--- a/pkg/apis/serving/v1alpha1/trained_model.go
+++ b/pkg/apis/serving/v1alpha1/trained_model.go
@@ -68,3 +68,13 @@ type ModelSpec struct {
 	// Maximum memory this model will consume, this field is used to decide if a model server has enough memory to load this model.
 	Memory resource.Quantity `json:"memory"`
 }
+
+func (tms *TrainedModelList) TotalRequestedMemory() resource.Quantity {
+	totalMemory := resource.MustParse("0Mi")
+
+	for _, tm := range tms.Items {
+		totalMemory.Add(tm.Spec.Model.Memory)
+	}
+
+	return totalMemory
+}

--- a/pkg/apis/serving/v1alpha1/trained_model_status.go
+++ b/pkg/apis/serving/v1alpha1/trained_model_status.go
@@ -36,12 +36,13 @@ type TrainedModelStatus struct {
 }
 
 // ConditionType represents a Service condition value
-// TODO: Add conditions for memory availability
 const (
 	// InferenceServiceReady is set when inference service reported readiness
 	InferenceServiceReady apis.ConditionType = "InferenceServiceReady"
 	// FrameworkSupported is set when predictor reports framework check
 	FrameworkSupported apis.ConditionType = "FrameworkSupported"
+	// MemoryResourceAvailable is set when inference service reported resources availability
+	MemoryResourceAvailable apis.ConditionType = "MemoryResourceAvailable"
 )
 
 // TrainedModel Ready condition is depending on inference service readiness condition
@@ -49,6 +50,7 @@ const (
 var conditionSet = apis.NewLivingConditionSet(
 	InferenceServiceReady,
 	FrameworkSupported,
+	MemoryResourceAvailable,
 )
 
 var _ apis.ConditionsAccessor = (*TrainedModelStatus)(nil)

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -45,6 +45,11 @@ var (
 	InferenceServiceConfigMapName = "inferenceservice-config"
 )
 
+// TrainedModel Constants
+var (
+	TrainedModelAllocated = KFServingAPIGroupName + "/" + "trainedmodel-allocated"
+)
+
 // InferenceService MultiModel Constants
 var (
 	ModelConfigFileName = "models.json"

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -33,6 +33,7 @@ import (
 	v1beta1api "github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
 	"github.com/kubeflow/kfserving/pkg/constants"
 	"github.com/kubeflow/kfserving/pkg/controller/v1alpha1/trainedmodel/reconcilers/modelconfig"
+	v1beta1utils "github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/utils"
 	"github.com/kubeflow/kfserving/pkg/utils"
 	v1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -264,8 +265,7 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 
 	totalReqMemory := trainedModels.TotalRequestedMemory()
 	// Update Inference Service Resource Available condition
-	implementations := isvc.Spec.Predictor.GetImplementations()
-	if len(implementations) == 1 && isvc.Spec.Predictor.GetImplementation().IsMemoryResourceAvailable(totalReqMemory) {
+	if v1beta1utils.IsMemoryResourceAvailable(isvc, totalReqMemory, isvcConfig) {
 		log.Info("Parent InferenceService memory resources are available", "TrainedModel", tm.Name, "InferenceService", isvc.Name)
 		if _, ok := tm.Labels[constants.TrainedModelMemoryIncluded]; !ok {
 			tm.Labels[constants.TrainedModelMemoryIncluded] = isvc.Name

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -255,11 +255,11 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 
 	// Get trained models with same inference service
 	var trainedModels v1alpha1api.TrainedModelList
-	if err := r.List(context.TODO(), &trainedModels, client.InNamespace(tm.Namespace), client.MatchingLabels{constants.ParentInferenceServiceLabel: isvc.Name, constants.TrainedModelMemoryIncluded: isvc.Name}); err != nil {
+	if err := r.List(context.TODO(), &trainedModels, client.InNamespace(tm.Namespace), client.MatchingLabels{constants.ParentInferenceServiceLabel: isvc.Name, constants.TrainedModelAllocated: isvc.Name}); err != nil {
 		return err
 	}
 
-	if _, ok := tm.Labels[constants.TrainedModelMemoryIncluded]; !ok {
+	if _, ok := tm.Labels[constants.TrainedModelAllocated]; !ok {
 		trainedModels.Items = append(trainedModels.Items, *tm)
 	}
 
@@ -267,8 +267,8 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 	// Update Inference Service Resource Available condition
 	if v1beta1utils.IsMemoryResourceAvailable(isvc, totalReqMemory, isvcConfig) {
 		log.Info("Parent InferenceService memory resources are available", "TrainedModel", tm.Name, "InferenceService", isvc.Name)
-		if _, ok := tm.Labels[constants.TrainedModelMemoryIncluded]; !ok {
-			tm.Labels[constants.TrainedModelMemoryIncluded] = isvc.Name
+		if _, ok := tm.Labels[constants.TrainedModelAllocated]; !ok {
+			tm.Labels[constants.TrainedModelAllocated] = isvc.Name
 			if updateErr := r.Update(context.Background(), tm); updateErr != nil {
 				r.Log.Error(updateErr, "Failed to update TrainedModel label", "TrainedModel", tm.Name)
 				return updateErr

--- a/test/e2e/predictor/test_multi_model_serving.py
+++ b/test/e2e/predictor/test_multi_model_serving.py
@@ -92,7 +92,7 @@ def test_mms_sklearn_kfserving(protocol_version: str, storage_uris: List[str]):
     for model_name, storage_uri in zip(model_names, storage_uris):
         model_spec = V1alpha1ModelSpec(
             storage_uri=storage_uri,
-            memory="256Mi",
+            memory="128Mi",
             framework="sklearn",
         )
 
@@ -202,7 +202,7 @@ def test_mms_xgboost_kfserving(protocol_version: str, storage_uris: List[str]):
         # Define trained models
         model_spec = V1alpha1ModelSpec(
             storage_uri=storage_uri,
-            memory="256Mi",
+            memory="128Mi",
             framework="xgboost",
         )
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Checks to see if the inference service has enough memory resources for all children trained models. Will reject child that asks for more resources than parent can provide.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
