### PR TITLE
Add mms support for custom spec

### DIFF
--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -89,6 +89,10 @@ type ComponentExtensionSpec struct {
 	// Activate request batching and batching configurations
 	// +optional
 	Batcher *Batcher `json:"batcher,omitempty"`
+	// MultiModelServer can be used to override default mms behaviour specified in predictor config
+	// or to indicate Custom runtimes support MMS
+	// +optional
+	MultiModelServer *bool `json:"multiModelServer,omitempty"`
 }
 
 // Default the ComponentExtensionSpec

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -24,9 +24,9 @@ import (
 // is set or predictor config sets MMS to true and storage uri is not set
 func IsMMSPredictor(predictor *v1beta1api.PredictorSpec, isvcConfig *v1beta1api.InferenceServicesConfig) bool {
 	mmsExtension := predictor.GetExtensions().MultiModelServer
-	isStorageURISet := predictor.GetImplementation().GetStorageUri() == nil
+	storageURINotSet := predictor.GetImplementation().GetStorageUri() == nil
 	if mmsExtension != nil {
-		return *mmsExtension && isStorageURISet
+		return *mmsExtension && storageURINotSet
 	}
-	return predictor.GetImplementation().IsMMS(isvcConfig) && isStorageURISet
+	return predictor.GetImplementation().IsMMS(isvcConfig) && storageURINotSet
 }

--- a/pkg/controller/v1beta1/inferenceservice/utils/utils.go
+++ b/pkg/controller/v1beta1/inferenceservice/utils/utils.go
@@ -20,7 +20,13 @@ import (
 	v1beta1api "github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
 )
 
-// Only enable MMS predictor when predictor config sets MMS to true and storage uri is not set
+// IsMMSPredictor enables MMS predictor when MultiModelServer field in ComponentExtensions
+// is set or predictor config sets MMS to true and storage uri is not set
 func IsMMSPredictor(predictor *v1beta1api.PredictorSpec, isvcConfig *v1beta1api.InferenceServicesConfig) bool {
-	return predictor.GetImplementation().IsMMS(isvcConfig) && predictor.GetImplementation().GetStorageUri() == nil
+	mmsExtension := predictor.GetExtensions().MultiModelServer
+	isStorageURISet := predictor.GetImplementation().GetStorageUri() == nil
+	if mmsExtension != nil {
+		return *mmsExtension && isStorageURISet
+	}
+	return predictor.GetImplementation().IsMMS(isvcConfig) && isStorageURISet
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Enables Custom predictors to make use of MMS feature

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1427 

**Special notes for your reviewer**:
* Introduced a new field in `ComponentExtensionSpec` as discussed in #1427 
* Modify `IsMMSPredictor()` to check if field is set 
* Eg inference-service spec:
```yaml
apiVersion: "serving.kubeflow.org/v1beta1"
kind: "InferenceService"
metadata:
  name: "custom-sklearn"
spec:
  predictor:
    minReplicas: 1
    containers:
    - image: gcr.io/kfserving/sklearnserver
      name: kfserving-container
      ports:
        - containerPort: 8080
          protocol: TCP
      args:
      - --model_dir=/mnt/models
      - --http_port=8080
    multiModelServer: true
---
apiVersion: "serving.kubeflow.org/v1alpha1"
kind: "TrainedModel"
metadata:
  name: "model1-sklearn"
spec:
  inferenceService: "custom-sklearn"
  model:
    storageUri: "gs://kfserving-samples/models/sklearn/iris"
    framework: "sklearn"
    memory: "256Mi"
```

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
A new field 'MultiModelServer' has been added in ComponentExtensionSpec. When set 'true', it indicates that the Custom container supports multi model serving, or that the 'multiModelServer' field of the predictor in the inferenceservice-config configmap (eg. Sklearn, Triton) should be overridden.
```
