### PR TITLE
Change storage-init to use boto3

### DIFF
--- a/python/kfserving/kfserving/storage.py
+++ b/python/kfserving/kfserving/storage.py
@@ -278,4 +278,3 @@ The path or model %s does not exist." % (uri))
             os.remove(local_path)
 
         return out_dir
-

--- a/python/kfserving/requirements.txt
+++ b/python/kfserving/requirements.txt
@@ -6,7 +6,7 @@ urllib3>=1.15.1
 kubernetes>=12.0.0
 tornado>=6.0.0
 argparse>=1.4.0
-minio>=6.0.0
+minio>=4.0.9,<7.0.0
 google-cloud-storage>=1.31.0
 adal>=1.2.2
 table_logger>=0.3.5
@@ -14,5 +14,5 @@ numpy>=1.17.3
 azure-storage-blob>=1.3.0,<=2.1.0
 cloudevents>=1.2.0
 avro>=1.10.1
-boto3==1.17.9
-botocore==1.20.9
+boto3>=1.17.32
+botocore>=1.20.32

--- a/python/kfserving/requirements.txt
+++ b/python/kfserving/requirements.txt
@@ -6,7 +6,7 @@ urllib3>=1.15.1
 kubernetes>=12.0.0
 tornado>=6.0.0
 argparse>=1.4.0
-minio>=4.0.9,<7.0.0
+minio>=6.0.0
 google-cloud-storage>=1.31.0
 adal>=1.2.2
 table_logger>=0.3.5
@@ -14,3 +14,5 @@ numpy>=1.17.3
 azure-storage-blob>=1.3.0,<=2.1.0
 cloudevents>=1.2.0
 avro>=1.10.1
+boto3==1.17.9
+botocore==1.20.9

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -23,6 +23,7 @@ def create_mock_obj(path):
     mock_obj.is_dir = False
     return mock_obj
 
+
 def create_mock_boto3_bucket(mock_storage, paths):
     mock_s3_resource = mock.MagicMock()
     mock_s3_bucket = mock.MagicMock()
@@ -32,6 +33,7 @@ def create_mock_boto3_bucket(mock_storage, paths):
     mock_storage.resource.return_value = mock_s3_resource
 
     return mock_s3_bucket
+
 
 def get_call_args(call_args_list):
     arg_list = []

--- a/python/kfserving/test/test_s3_storage.py
+++ b/python/kfserving/test/test_s3_storage.py
@@ -13,21 +13,25 @@
 # limitations under the License.
 
 import unittest.mock as mock
+
 import kfserving
 
 
 def create_mock_obj(path):
     mock_obj = mock.MagicMock()
-    mock_obj.object_name = path
+    mock_obj.key = path
     mock_obj.is_dir = False
     return mock_obj
 
+def create_mock_boto3_bucket(mock_storage, paths):
+    mock_s3_resource = mock.MagicMock()
+    mock_s3_bucket = mock.MagicMock()
+    mock_s3_bucket.objects.filter.return_value = [create_mock_obj(p) for p in paths]
 
-def create_mock_minio_client(mock_storage, paths):
-    mock_minio_client = mock_storage.return_value
-    mock_minio_client.list_objects.return_value = [create_mock_obj(p) for p in paths]
-    return mock_minio_client
+    mock_s3_resource.Bucket.return_value = mock_s3_bucket
+    mock_storage.resource.return_value = mock_s3_resource
 
+    return mock_s3_bucket
 
 def get_call_args(call_args_list):
     arg_list = []
@@ -37,14 +41,14 @@ def get_call_args(call_args_list):
     return arg_list
 
 
-def expected_call_args_list(bucket_name, parent_key, dest, paths):
-    return [(bucket_name, f'{parent_key}/{p}'.strip('/'), f'{dest}/{p}'.strip('/'))
+def expected_call_args_list(parent_key, dest, paths):
+    return [(f'{parent_key}/{p}'.strip('/'), f'{dest}/{p}'.strip('/'))
             for p in paths]
 
 # pylint: disable=protected-access
 
 
-@mock.patch('kfserving.storage.Minio')
+@mock.patch('kfserving.storage.boto3')
 def test_parent_key(mock_storage):
 
     # given
@@ -53,17 +57,17 @@ def test_parent_key(mock_storage):
     object_paths = ['bar/' + p for p in paths]
 
     # when
-    mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
+    mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
     kfserving.Storage._download_s3(f's3://{bucket_name}/bar', 'dest_path')
 
     # then
-    arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
-    assert arg_list == expected_call_args_list(bucket_name, 'bar', 'dest_path', paths)
+    arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
+    assert arg_list == expected_call_args_list('bar', 'dest_path', paths)
 
-    mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='bar', recursive=True)
+    mock_boto3_bucket.objects.filter.assert_called_with(Prefix='bar')
 
 
-@mock.patch('kfserving.storage.Minio')
+@mock.patch('kfserving.storage.boto3')
 def test_no_key(mock_storage):
 
     # given
@@ -71,17 +75,17 @@ def test_no_key(mock_storage):
     object_paths = ['models/weights.pt', '0002.h5', 'a/very/long/path/config.json']
 
     # when
-    mock_minio_client = create_mock_minio_client(mock_storage, object_paths)
+    mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, object_paths)
     kfserving.Storage._download_s3(f's3://{bucket_name}/', 'dest_path')
 
     # then
-    arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
-    assert arg_list == expected_call_args_list(bucket_name, '', 'dest_path', object_paths)
+    arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
+    assert arg_list == expected_call_args_list('', 'dest_path', object_paths)
 
-    mock_minio_client.list_objects.assert_called_with(bucket_name, prefix='', recursive=True)
+    mock_boto3_bucket.objects.filter.assert_called_with(Prefix='')
 
 
-@mock.patch('kfserving.storage.Minio')
+@mock.patch('kfserving.storage.boto3')
 def test_full_name_key(mock_storage):
 
     # given
@@ -89,13 +93,12 @@ def test_full_name_key(mock_storage):
     object_key = 'path/to/model/name.pt'
 
     # when
-    mock_minio_client = create_mock_minio_client(mock_storage, [object_key])
+    mock_boto3_bucket = create_mock_boto3_bucket(mock_storage, [object_key])
     kfserving.Storage._download_s3(f's3://{bucket_name}/{object_key}', 'dest_path')
 
     # then
-    arg_list = get_call_args(mock_minio_client.fget_object.call_args_list)
-    assert arg_list == expected_call_args_list(bucket_name, '', 'dest_path',
+    arg_list = get_call_args(mock_boto3_bucket.download_file.call_args_list)
+    assert arg_list == expected_call_args_list('', 'dest_path',
                                                [object_key])
 
-    mock_minio_client.list_objects.assert_called_with(bucket_name, prefix=object_key,
-                                                      recursive=True)
+    mock_boto3_bucket.objects.filter.assert_called_with(Prefix=object_key)

--- a/python/kfserving/test/test_storage.py
+++ b/python/kfserving/test/test_storage.py
@@ -21,7 +21,6 @@ import unittest.mock as mock
 import botocore
 import kfserving
 import pytest
-from google.cloud import exceptions
 
 STORAGE_MODULE = 'kfserving.storage'
 
@@ -165,6 +164,7 @@ def test_storage_blob_exception():
     blob_path = 'https://accountname.blob.core.windows.net/container/some/blob/'
     with pytest.raises(Exception):
         kfserving.Storage.download(blob_path)
+
 
 @mock.patch(STORAGE_MODULE + '.boto3')
 def test_storage_s3_exception(mock_boto3):

--- a/python/kfserving/test/test_storage.py
+++ b/python/kfserving/test/test_storage.py
@@ -16,11 +16,12 @@ import io
 import os
 import tempfile
 import binascii
-
-import pytest
-import kfserving
-from minio import Minio, error
 import unittest.mock as mock
+
+import botocore
+import kfserving
+import pytest
+from google.cloud import exceptions
 
 STORAGE_MODULE = 'kfserving.storage'
 
@@ -165,26 +166,31 @@ def test_storage_blob_exception():
     with pytest.raises(Exception):
         kfserving.Storage.download(blob_path)
 
-
-@mock.patch('urllib3.PoolManager')
-@mock.patch(STORAGE_MODULE + '.Minio')
-def test_storage_s3_exception(mock_connection, mock_minio):
-    minio_path = 's3://foo/bar'
-    # Create mock connection
-    mock_server = mock.MagicMock()
-    mock_connection.return_value = mock_server
+@mock.patch(STORAGE_MODULE + '.boto3')
+def test_storage_s3_exception(mock_boto3):
+    path = 's3://foo/bar'
     # Create mock client
-    mock_minio.return_value = Minio("s3.us.cloud-object-storage.appdomain.cloud", secure=True)
+    mock_s3_resource = mock.MagicMock()
+    mock_s3_resource.Bucket.side_effect = Exception()
+    mock_boto3.resource.return_value = mock_s3_resource
+
     with pytest.raises(Exception):
-        kfserving.Storage.download(minio_path)
+        kfserving.Storage.download(path)
 
 
+@mock.patch(STORAGE_MODULE + '.boto3')
 @mock.patch('urllib3.PoolManager')
-@mock.patch(STORAGE_MODULE + '.Minio')
-def test_no_permission_buckets(mock_connection, mock_minio):
+def test_no_permission_buckets(mock_connection, mock_boto3):
     bad_s3_path = "s3://random/path"
     # Access private buckets without credentials
-    mock_minio.return_value = Minio("s3.us.cloud-object-storage.appdomain.cloud", secure=True)
-    mock_connection.side_effect = error.AccessDenied()
-    with pytest.raises(error.AccessDenied):
+    mock_s3_resource = mock.MagicMock()
+    mock_s3_bucket = mock.MagicMock()
+    mock_s3_bucket.objects.filter.return_value = [mock.MagicMock()]
+    mock_s3_bucket.objects.filter.side_effect = botocore.exceptions.ClientError(
+        {}, "GetObject"
+    )
+    mock_s3_resource.Bucket.return_value = mock_s3_bucket
+    mock_boto3.resource.return_value = mock_s3_resource
+
+    with pytest.raises(botocore.exceptions.ClientError):
         kfserving.Storage.download(bad_s3_path)


### PR DESCRIPTION
**What this PR does / why we need it**:
Uses the boto3 library instead of minio for storage-initializer, mainly in order to allow use of IAM Roles for Service Accounts for AWS users, also changes storage tests to mock boto3 instead of minio

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #831

**Special notes for your reviewer**:

Cherrypicks the first commit from https://github.com/kubeflow/kfserving/pull/1130 since there doesn't seem to be much continuing activity there

I've also tested this by building/pushing the new image to an ECR registry, changing the image location in the inference config map, and using service accounts both with secret credentials, and IAM roles.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
- Replaces minio library with boto3 for storage-initializer container to pull models from S3 so that IRSA can be used
```
