### PR TITLE
Fix wrong name for kfserving-monitoring namespace

### DIFF
--- a/docs/samples/metrics-and-monitoring/prometheus-operator/namespace.yaml
+++ b/docs/samples/metrics-and-monitoring/prometheus-operator/namespace.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-  name: kfserving-monitoring
+  name: monitoring


### PR DESCRIPTION
**What this PR does / why we need it**:
Right now the created namespace will get a `kfserving-` prefix which will create a namespace called `kfserving-kfserving-monitoring`.

This will make subsequent object creations to fail since they will be meant for the `kfserving-monitoring` namespace.

Here's the result of running `kustomize build docs/samples/metrics-and-monitoring/prometheus-operator | k apply -f -`, as the instructions suggest https://github.com/kubeflow/kfserving/blob/master/docs/samples/metrics-and-monitoring/README.md#install-prometheus
```bash
namespace/kfserving-kfserving-monitoring created
customresourcedefinition.apiextensions.k8s.io/alertmanagerconfigs.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/alertmanagers.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/podmonitors.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/probes.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/prometheuses.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/prometheusrules.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/servicemonitors.monitoring.coreos.com created
customresourcedefinition.apiextensions.k8s.io/thanosrulers.monitoring.coreos.com created
clusterrole.rbac.authorization.k8s.io/kfserving-prometheus-operator created
clusterrolebinding.rbac.authorization.k8s.io/kfserving-prometheus-operator created
Error from server (NotFound): error when creating "STDIN": namespaces "kfserving-monitoring" not found
Error from server (NotFound): error when creating "STDIN": namespaces "kfserving-monitoring" not found
Error from server (NotFound): error when creating "STDIN": namespaces "kfserving-monitoring" not found
```

**Which issue(s) this PR fixes**
Bumped into this while working on extending the current monitoring manifests with the InferenceServices web app #1328

**Special notes for your reviewer**:

This is because the `kustomization.yaml` file for the [prometheus-operator](https://github.com/kubeflow/kfserving/blob/master/docs/samples/metrics-and-monitoring/prometheus-operator/kustomization.yaml) defines a `kfserving-` prefix and the [namespace's name](https://github.com/kubeflow/kfserving/blob/master/docs/samples/metrics-and-monitoring/prometheus-operator/namespace.yaml#L4) is also `kfserving-monitoring` as well, which results in this duplication.
