### PR TITLE
Resolve knative service diff to prevent dup revision

### DIFF
--- a/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
+++ b/pkg/apis/serving/v1alpha1/zz_generated.deepcopy.go
@@ -21,7 +21,7 @@ limitations under the License.
 package v1alpha1
 
 import (
-	runtime "k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/runtime"
 	"knative.dev/pkg/apis"
 	"knative.dev/pkg/apis/duck/v1"
 )

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/knative/ksvc_reconciler.go
@@ -168,6 +168,13 @@ func (r *KsvcReconciler) Reconcile() (*knservingv1.ServiceStatus, error) {
 	}
 
 	// Reconcile differences and update
+	// knative mutator defaults the enableServiceLinks to false which would generate a diff despite no changes on desired knative service
+	// https://github.com/knative/serving/blob/main/pkg/apis/serving/v1/revision_defaults.go#L134
+	if desired.Spec.ConfigurationSpec.Template.Spec.EnableServiceLinks == nil &&
+		existing.Spec.ConfigurationSpec.Template.Spec.EnableServiceLinks != nil &&
+		*existing.Spec.ConfigurationSpec.Template.Spec.EnableServiceLinks == false {
+		desired.Spec.ConfigurationSpec.Template.Spec.EnableServiceLinks = proto.Bool(false)
+	}
 	diff, err := kmp.SafeDiff(desired.Spec.ConfigurationSpec, existing.Spec.ConfigurationSpec)
 	if err != nil {
 		return &existing.Status, errors.Wrapf(err, "failed to diff knative service configuration spec")


### PR DESCRIPTION
**What this PR does / why we need it**:
With the latest knative version it always generates two similar looking revisions when initial inference service is created, the root cause looks like is related to the fact in inference service controller it always update the knative service immediately after that is created, the reconciliation generates a diff between created knative service and desired knative service as knative mutating webhook defaults the `enableServiceLink` to false.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1467 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
