### PR TITLE
Cherry-pick of 'Update kubeflow overlay (#1424)' into release-0.5

### DIFF
--- a/config/overlays/kubeflow/cluster-role.yaml
+++ b/config/overlays/kubeflow/cluster-role.yaml
@@ -1,0 +1,49 @@
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-kfserving-admin
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-admin: "true"
+aggregationRule:
+  clusterRoleSelectors:
+  - matchLabels:
+      rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
+rules: []
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-kfserving-edit
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-edit: "true"
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-kfserving-admin: "true"
+rules:
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch
+  - create
+  - delete
+  - deletecollection
+  - patch
+  - update
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: kubeflow-kfserving-view
+  labels:
+    rbac.authorization.kubeflow.org/aggregate-to-kubeflow-view: "true"
+rules:
+- apiGroups:
+  - serving.kubeflow.org
+  resources:
+  - inferenceservices
+  verbs:
+  - get
+  - list
+  - watch

--- a/config/overlays/kubeflow/kustomization.yaml
+++ b/config/overlays/kubeflow/kustomization.yaml
@@ -5,11 +5,19 @@ kind: Kustomization
 namespace: kubeflow
 
 # Labels to add to all resources and selectors.
-#commonLabels:
-#  someName: someValue
+commonLabels:
+  app: kfserving
+  kustomize.component: kfserving
+  app.kubernetes.io/component: kfserving
+  app.kubernetes.io/name: kfserving
 
 bases:
 - ../../default
+- cluster-role.yaml
+
+patchesStrategicMerge:
+- statefulset-patch.yaml
+- namespace-patch.yaml
 
 generatorOptions:
   disableNameSuffixHash: true
@@ -20,5 +28,5 @@ generatorOptions:
 configMapGenerator:
   - name: kfserving-config
     behavior: replace
-    envs: 
+    envs:
     - params.env

--- a/config/overlays/kubeflow/namespace-patch.yaml
+++ b/config/overlays/kubeflow/namespace-patch.yaml
@@ -1,0 +1,6 @@
+# Remove namespace resource as namespace will already exist.
+$patch: delete
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: kfserving-system

--- a/config/overlays/kubeflow/statefulset-patch.yaml
+++ b/config/overlays/kubeflow/statefulset-patch.yaml
@@ -1,0 +1,10 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: kfserving-controller-manager
+  namespace: kfserving-system
+spec:
+  template:
+    metadata:
+      annotations:
+        sidecar.istio.io/inject: "false"


### PR DESCRIPTION
I realized that the kubeflow overlay was not in the release-0.5 branch, so a commit from this branch wouldn't be useable in kubeflow/manifests. This PR cherry-picks the overlay commit.

/cc @yuzisun @animeshsingh 
