### PR TITLE
Allow custom predictor to set protocol

### DIFF
--- a/pkg/apis/serving/v1beta1/component.go
+++ b/pkg/apis/serving/v1beta1/component.go
@@ -40,6 +40,7 @@ const (
 	InvalidISVCNameFormatError          = "The InferenceService \"%s\" is invalid: a InferenceService name must consist of lower case alphanumeric characters or '-', and must start with alphabetical character. (e.g. \"my-name\" or \"abc-123\", regex used for validation is '%s')"
 	MaxWorkersShouldBeLessThanMaxError  = "Workers cannot be greater than %d"
 	InvalidWorkerArgument               = "Invalid workers argument"
+	InvalidProtocol                     = "Invalid protocol %s. Must be one of [%s]"
 )
 
 // Constants

--- a/pkg/apis/serving/v1beta1/predictor_custom_test.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom_test.go
@@ -111,6 +111,69 @@ func TestCustomPredictorValidation(t *testing.T) {
 			},
 			matcher: gomega.Not(gomega.BeNil()),
 		},
+		"ValidProtocolV1": {
+			spec: PredictorSpec{
+				ComponentExtensionSpec: ComponentExtensionSpec{
+					MinReplicas:          GetIntReference(3),
+					ContainerConcurrency: proto.Int64(-1),
+				},
+				PodSpec: PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+								{
+									Name:  "PROTOCOL",
+									Value: "v1",
+								},
+							},
+						},
+					},
+				},
+			},
+			matcher: gomega.BeNil(),
+		},
+		"ValidProtocolV2": {
+			spec: PredictorSpec{
+				ComponentExtensionSpec: ComponentExtensionSpec{
+					MinReplicas:          GetIntReference(3),
+					ContainerConcurrency: proto.Int64(-1),
+				},
+				PodSpec: PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+								{
+									Name:  "PROTOCOL",
+									Value: "v2",
+								},
+							},
+						},
+					},
+				},
+			},
+			matcher: gomega.BeNil(),
+		},
+		"InvalidValidProtocol": {
+			spec: PredictorSpec{
+				ComponentExtensionSpec: ComponentExtensionSpec{
+					MinReplicas:          GetIntReference(3),
+					ContainerConcurrency: proto.Int64(-1),
+				},
+				PodSpec: PodSpec{
+					Containers: []v1.Container{
+						{
+							Env: []v1.EnvVar{
+								{
+									Name:  "PROTOCOL",
+									Value: "unknown",
+								},
+							},
+						},
+					},
+				},
+			},
+			matcher: gomega.Not(gomega.BeNil()),
+		},
 	}
 
 	for name, scenario := range scenarios {

--- a/pkg/constants/constants.go
+++ b/pkg/constants/constants.go
@@ -108,6 +108,7 @@ const (
 // InferenceService Environment Variables
 const (
 	CustomSpecStorageUriEnvVarKey = "STORAGE_URI"
+	CustomSpecProtocolEnvVarKey = "PROTOCOL"
 )
 
 type InferenceServiceComponent string


### PR DESCRIPTION


**What this PR does / why we need it**:

 * Allows custom predictor to set protocol. This will allow correct URI to be exposed in status.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1482

