### PR TITLE
Update pipelines documentation

### DIFF
--- a/docs/samples/pipelines/README.md
+++ b/docs/samples/pipelines/README.md
@@ -12,7 +12,7 @@ Additional usage instructions can be found in the component [README](https://git
 To dive into the source behind the KFServing Kubeflow Pipelines Component, please look into the YAML for the [KFServing Component](https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/kfserving/component.yaml) and the [source code](https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/kfserving/src/kfservingdeployer.py).
 
 
-**Note**: For those still using an older version of KFServing less than v0.5.0, an older version of of the KFServing Pipelines component must be used
+**Note**: For those still using an older version of KFServing less than v0.5.0, an older version of the KFServing Pipelines component must be used
 as demonstrated in [this notebook](./kfs-pipeline-v1alpha2.ipynb). The source code for this version of the component can be found [here](https://github.com/kubeflow/pipelines/tree/65bed9b6d1d676ef2d541a970d3edc0aee12400d/components/kubeflow/kfserving).
 
 

--- a/docs/samples/pipelines/README.md
+++ b/docs/samples/pipelines/README.md
@@ -1,12 +1,23 @@
-# Deploy to KFserving from [Kubeflow Pipelines](https://www.kubeflow.org/docs/pipelines/overview/pipelines-overview/)
+# Deploy to KFServing from [Kubeflow Pipelines](https://www.kubeflow.org/docs/pipelines/overview/pipelines-overview/)
 
-These examples illustrate how to use the Kubeflow Pipelines component for KFServing.
+## Kubeflow Pipelines KFServing component
+
+The following examples illustrate how to use the Kubeflow Pipelines component for KFServing using the v1beta1 API.
+These assume your cluster has a KFServing version >= v0.5.0.
 
 * Deploy a [custom model](./sample-custom-model.py).
-* Deploy a [Tensorflow model](./sample-tf-pipeline.py). There is also [a notebook](./sample-tf-pipeline.py) which illustrates this.
-* Deploy a sample [MNIST model end to end using Kubeflow Pipelines with Tekton](https://github.com/kubeflow/kfp-tekton/tree/master/samples/e2e-mnist). The [notebook](https://github.com/kubeflow/kfp-tekton/blob/master/samples/e2e-mnist/mnist.ipynb) demonstrates how to compile and execute an End to End Machine Learning workflow that uses Katib, TFJob, KFServing, and Tekton pipeline. This pipeline contains 5 steps, it finds the best hyperparameter using Katib, creates PVC for storing models, processes the hyperparameter results, distributedly trains the model on TFJob with the best hyperparameter using more iterations, and finally serves the model using KFServing. You can visit this medium blog for more details on this pipeline.
-
-![kfserving-mnist-pipeline](images/kfserving-mnist-pipeline.png)
+* Deploy a [TensorFlow model](./sample-tf-pipeline.py). There is also [a notebook](./kfs-pipeline.ipynb) which illustrates this.
 
 Additional usage instructions can be found in the component [README](https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/kfserving/README.md).
 To dive into the source behind the KFServing Kubeflow Pipelines Component, please look into the YAML for the [KFServing Component](https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/kfserving/component.yaml) and the [source code](https://github.com/kubeflow/pipelines/blob/master/components/kubeflow/kfserving/src/kfservingdeployer.py).
+
+
+**Note**: For those still using an older version of KFServing less than v0.5.0, an older version of of the KFServing Pipelines component must be used
+as demonstrated in [this notebook](./kfs-pipeline-v1alpha2.ipynb). The source code for this version of the component can be found [here](https://github.com/kubeflow/pipelines/tree/65bed9b6d1d676ef2d541a970d3edc0aee12400d/components/kubeflow/kfserving).
+
+
+## End to end pipeline example using KFServing
+
+Deploy a sample [MNIST model end to end using Kubeflow Pipelines with Tekton](https://github.com/kubeflow/kfp-tekton/tree/master/samples/e2e-mnist). The [notebook](https://github.com/kubeflow/kfp-tekton/blob/master/samples/e2e-mnist/mnist.ipynb) demonstrates how to compile and execute an End to End Machine Learning workflow that uses Katib, TFJob, KFServing, and Tekton pipeline. This pipeline contains 5 steps, it finds the best hyperparameter using Katib, creates PVC for storing models, processes the hyperparameter results, distributedly trains the model on TFJob with the best hyperparameter using more iterations, and finally serves the model using KFServing. You can visit [this medium blog](https://medium.com/@liuhgxa/an-end-to-end-use-case-by-kubeflow-b2f72b0b587) for more details on this pipeline.
+
+![kfserving-mnist-pipeline](images/kfserving-mnist-pipeline.png)

--- a/docs/samples/pipelines/kfs-pipeline-v1alpha2.ipynb
+++ b/docs/samples/pipelines/kfs-pipeline-v1alpha2.ipynb
@@ -1,0 +1,189 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# KFServing Pipeline samples\n",
+    "\n",
+    "This notebook uses an older version of the KFServing Pipelines component meant for clusters using a KFServing version less than v0.5.0 which only supports the v1alpha2 API."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Install the necessary kfp library"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pip3 install kfp --upgrade"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import kfp.dsl as dsl\n",
+    "import kfp\n",
+    "from kfp import components\n",
+    "import json\n",
+    "\n",
+    "# Create kfp client\n",
+    "# Note: Add the KubeFlow Pipeline endpoint below if the client is not running on the same cluster.\n",
+    "client = kfp.Client('kfserving_endpoint')\n",
+    "EXPERIMENT_NAME = 'KFServing Experiments'\n",
+    "experiment = client.create_experiment(name=EXPERIMENT_NAME)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### TensorFlow example\n",
+    "\n",
+    "Note: Change the action from `update` to `create` if you are deploying the model for the first time."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kfserving_op = components.load_component_from_url(\n",
+    "  'https://raw.githubusercontent.com/kubeflow/pipelines/65bed9b6d1d676ef2d541a970d3edc0aee12400d/components/kubeflow/kfserving/component.yaml'\n",
+    ")\n",
+    "\n",
+    "@dsl.pipeline(\n",
+    "  name='kfserving pipeline',\n",
+    "  description='A pipeline for kfserving.'\n",
+    ")\n",
+    "def kfservingPipeline(\n",
+    "    action = 'update',\n",
+    "    model_name='tf-sample',\n",
+    "    default_model_uri='gs://kfserving-samples/models/tensorflow/flowers',\n",
+    "    canary_model_uri='gs://kfserving-samples/models/tensorflow/flowers-2',\n",
+    "    canary_model_traffic_percentage='10',\n",
+    "    namespace='your_namespace',\n",
+    "    framework='tensorflow',\n",
+    "    default_custom_model_spec='{}',\n",
+    "    canary_custom_model_spec='{}',\n",
+    "    autoscaling_target='0',\n",
+    "    kfserving_endpoint=''\n",
+    "):\n",
+    "\n",
+    "    # define workflow\n",
+    "    kfserving = kfserving_op(action = action,\n",
+    "                             model_name=model_name,\n",
+    "                             default_model_uri=default_model_uri,\n",
+    "                             canary_model_uri=canary_model_uri,\n",
+    "                             canary_model_traffic_percentage=canary_model_traffic_percentage,\n",
+    "                             namespace=namespace,\n",
+    "                             framework=framework,\n",
+    "                             default_custom_model_spec=default_custom_model_spec,\n",
+    "                             canary_custom_model_spec=canary_custom_model_spec,\n",
+    "                             autoscaling_target=autoscaling_target,\n",
+    "                             kfserving_endpoint=kfserving_endpoint).set_image_pull_policy('Always')\n",
+    "\n",
+    "# Compile pipeline\n",
+    "import kfp.compiler as compiler\n",
+    "compiler.Compiler().compile(kfservingPipeline, 'tf-flower.tar.gz')\n",
+    "\n",
+    "# Execute pipeline\n",
+    "run = client.run_pipeline(experiment.id, 'tf-flower', 'tf-flower.tar.gz')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Custom model example"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "kfserving_op = components.load_component_from_url(\n",
+    "  'https://raw.githubusercontent.com/kubeflow/pipelines/65bed9b6d1d676ef2d541a970d3edc0aee12400d/components/kubeflow/kfserving/component.yaml'\n",
+    ")\n",
+    "\n",
+    "@dsl.pipeline(\n",
+    "  name='kfserving pipeline',\n",
+    "  description='A pipeline for kfserving.'\n",
+    ")\n",
+    "def kfservingPipeline(\n",
+    "    action = 'update',\n",
+    "    model_name='custom-sample',\n",
+    "    default_model_uri='',\n",
+    "    canary_model_uri='',\n",
+    "    canary_model_traffic_percentage='0',\n",
+    "    namespace='kubeflow',\n",
+    "    framework='custom',\n",
+    "    default_custom_model_spec='{\"name\": \"image-segmenter\", \"image\": \"codait/max-image-segmenter:latest\", \"port\": \"5000\"}',\n",
+    "    canary_custom_model_spec='{}',\n",
+    "    autoscaling_target='0',\n",
+    "    kfserving_endpoint=''\n",
+    "):\n",
+    "\n",
+    "    # define workflow\n",
+    "    kfserving = kfserving_op(action = action,\n",
+    "                             model_name=model_name,\n",
+    "                             default_model_uri=default_model_uri,\n",
+    "                             canary_model_uri=canary_model_uri,\n",
+    "                             canary_model_traffic_percentage=canary_model_traffic_percentage,\n",
+    "                             namespace=namespace,\n",
+    "                             framework=framework,\n",
+    "                             default_custom_model_spec=default_custom_model_spec,\n",
+    "                             canary_custom_model_spec=canary_custom_model_spec,\n",
+    "                             autoscaling_target=autoscaling_target,\n",
+    "                             kfserving_endpoint=kfserving_endpoint).set_image_pull_policy('Always')\n",
+    "\n",
+    "# Compile pipeline\n",
+    "import kfp.compiler as compiler\n",
+    "compiler.Compiler().compile(kfservingPipeline, 'custom.tar.gz')\n",
+    "\n",
+    "# Execute pipeline\n",
+    "run = client.run_pipeline(experiment.id, 'custom-model', 'custom.tar.gz')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": []
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.7.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 2
+}

--- a/docs/samples/pipelines/kfs-pipeline.ipynb
+++ b/docs/samples/pipelines/kfs-pipeline.ipynb
@@ -4,7 +4,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# KFServing Pipeline samples"
+    "# KFServing Pipeline samples\n",
+    "\n",
+    "This notebook assumes your cluster has KFServing >= v0.5.0 installed which supports the v1beta1 API."
    ]
   },
   {

--- a/docs/samples/pipelines/sample-custom-model.py
+++ b/docs/samples/pipelines/sample-custom-model.py
@@ -27,7 +27,7 @@ kfserving_op = components.load_component_from_url('https://raw.githubusercontent
 def kfservingPipeline(
         action='apply',
         model_name='max-image-segmenter',
-        namespace='kubeflow',
+        namespace='anonymous',
         custom_model_spec='{"name": "image-segmenter", "image": "codait/max-image-segmenter:latest", "port": "5000"}'
 ):
     kfserving_op(action=action,


### PR DESCRIPTION
An example using the v1alpha2-based component was re-added for those who have not updated to the latest KFServing yet.

Left a note in the README about the example for those not on a KFServing version >= v0.5.0.
