### PR TITLE
Add readiness check to model agent

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -104,7 +104,10 @@ func main() {
 	}
 
 	logger, _ := pkglogging.NewLogger(env.ServingLoggingConfig, env.ServingLoggingLevel)
+	// Setup probe to run for checking user container healthiness.
 	probe := buildProbe(logger, env.ServingReadinessProbe, *componentPort)
+
+	// Poll user container health to make sure agent start after user container is ready
 	logger.Infof("Probing user container with probe %v", probe)
 	timeoutCtx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
 	defer cancel()
@@ -112,6 +115,7 @@ func main() {
 		return probe.ProbeContainer(), nil
 	}, timeoutCtx.Done()); err != nil {
 		logger.Errorf("Failed to probe user container with error %v", err)
+		os.Exit(1)
 	}
 
 	if *enablePuller {
@@ -133,7 +137,6 @@ func main() {
 	logger.Info("Starting agent http server...")
 	healthState := &health.State{}
 	ctx := signals.NewContext()
-	// Setup probe to run for checking user-application healthiness.
 	mainServer := buildServer(ctx, *port, *componentPort, loggerArgs, batcherArgs, healthState, probe, logger)
 	servers := map[string]*http.Server{
 		"main": mainServer,
@@ -184,7 +187,7 @@ func main() {
 	// to act on the first of those to reach here.
 	select {
 	case err := <-errCh:
-		logger.Errorw("Failed to bring up kfserving agent, shutting down.", zap.Error(err))
+		logger.Errorw("Failed to bring up agent, shutting down.", zap.Error(err))
 		// This extra flush is needed because defers are not handled via os.Exit calls.
 		logger.Sync()
 		os.Stdout.Sync()
@@ -272,7 +275,7 @@ func startLogger(workers int, logger *zap.SugaredLogger) *loggerArgs {
 }
 
 func startModelPuller(logger *zap.SugaredLogger) {
-	logger.Infof("Initializing model agent with config-dir %s, model-dir %s", *configDir, *modelDir)
+	logger.Infof("Initializing agent with config-dir %s, model-dir %s", *configDir, *modelDir)
 
 	downloader := agent.Downloader{
 		ModelDir:  *modelDir,
@@ -287,7 +290,7 @@ func startModelPuller(logger *zap.SugaredLogger) {
 func buildProbe(logger *zap.SugaredLogger, probeJSON string, port string) *readiness.Probe {
 	coreProbe, err := readiness.DecodeProbe(probeJSON)
 	if err != nil {
-		logger.Fatalw("Queue container failed to parse readiness probe", zap.Error(err))
+		logger.Fatalw("Agent failed to parse readiness probe", zap.Error(err))
 	}
 	if coreProbe.TCPSocket != nil {
 		coreProbe.TCPSocket.Port = intstr.FromString(port)
@@ -316,15 +319,15 @@ func buildServer(ctx context.Context, port string, userPort string, loggerArgs *
 	// Create handler chain.
 	// Note: innermost handlers are specified first, ie. the last handler in the chain will be executed first.
 	var composedHandler http.Handler = httpProxy
-	if loggerArgs != nil || batcherArgs != nil {
-		if batcherArgs != nil {
-			composedHandler = batcher.New(batcherArgs.maxBatchSize, batcherArgs.maxLatency, composedHandler, logging)
-		}
-		if loggerArgs != nil {
-			composedHandler = kfslogger.New(loggerArgs.logUrl, loggerArgs.sourceUrl, loggerArgs.loggerType,
-				loggerArgs.inferenceService, loggerArgs.namespace, loggerArgs.endpoint, composedHandler)
-		}
+
+	if batcherArgs != nil {
+		composedHandler = batcher.New(batcherArgs.maxBatchSize, batcherArgs.maxLatency, composedHandler, logging)
 	}
+	if loggerArgs != nil {
+		composedHandler = kfslogger.New(loggerArgs.logUrl, loggerArgs.sourceUrl, loggerArgs.loggerType,
+			loggerArgs.inferenceService, loggerArgs.namespace, loggerArgs.endpoint, composedHandler)
+	}
+
 	composedHandler = queue.ForwardedShimHandler(composedHandler)
 
 	composedHandler = ProbeHandler(healthState, rp.ProbeContainer, rp.IsAggressive(), false, composedHandler)

--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -125,7 +125,7 @@ func main() {
 		logger.Info("Starting batcher")
 		batcherArgs = startBatcher(logger)
 	}
-
+	logger.Info("Starting agent http server...")
 	healthState := &health.State{}
 	ctx := signals.NewContext()
 	// Setup probe to run for checking user-application healthiness.
@@ -277,7 +277,6 @@ func startModelPuller(logger *zap.SugaredLogger) {
 	}
 
 	watcher := agent.NewWatcher(*configDir, *modelDir, logger)
-	logger.Info("Starting puller")
 	agent.StartPuller(downloader, watcher.ModelEvents, logger)
 	watcher.Start()
 }

--- a/docs/samples/batcher/basic/batcher_v1beta1.yaml
+++ b/docs/samples/batcher/basic/batcher_v1beta1.yaml
@@ -6,8 +6,8 @@ spec:
   predictor:
     minReplicas: 1
     batcher:
-      maxBatchSize: 32
-      maxLatency: 5000
+      maxBatchSize: 16
+      maxLatency: 300
     pytorch:
       modelClassName: "Net"
       storageUri: "gs://kfserving-samples/models/pytorch/cifar10/"

--- a/go.mod
+++ b/go.mod
@@ -23,6 +23,7 @@ require (
 	github.com/pkg/errors v0.9.1
 	github.com/satori/go.uuid v1.2.0
 	github.com/spf13/cobra v1.0.0
+	github.com/spf13/pflag v1.0.5
 	github.com/stretchr/testify v1.5.1
 	go.uber.org/zap v1.15.0
 	golang.org/x/net v0.0.0-20200904194848-62affa334b73

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -87,6 +87,7 @@ func (w *Watcher) Start() {
 		w.logger.Error(err, "Failed to add watcher config dir")
 	}
 	w.logger.Info("Start to watch model config event")
+	done := make(chan bool)
 	go func() {
 		for {
 			select {
@@ -124,6 +125,7 @@ func (w *Watcher) Start() {
 		Op:   fsnotify.Create,
 	}
 	w.logger.Infof("Watching %s", watchPath)
+	<-done
 }
 
 func (w *Watcher) parseConfig(modelConfigs modelconfig.ModelConfigs) {

--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -87,7 +87,6 @@ func (w *Watcher) Start() {
 		w.logger.Error(err, "Failed to add watcher config dir")
 	}
 	w.logger.Info("Start to watch model config event")
-	done := make(chan bool)
 	go func() {
 		for {
 			select {
@@ -125,7 +124,6 @@ func (w *Watcher) Start() {
 		Op:   fsnotify.Create,
 	}
 	w.logger.Infof("Watching %s", watchPath)
-	<-done
 }
 
 func (w *Watcher) parseConfig(modelConfigs modelconfig.ModelConfigs) {

--- a/pkg/batcher/handler.go
+++ b/pkg/batcher/handler.go
@@ -154,7 +154,7 @@ func (handler *BatchHandler) batchPredict() {
 }
 
 func (handler *BatchHandler) batch() {
-	handler.log.Info("Starting batch loop")
+	handler.log.Infof("Starting batch loop maxLatency:%d, maxBatchSize:%d", handler.MaxLatency, handler.MaxBatchSize)
 	for {
 		select {
 		case req := <-handler.channelIn:
@@ -179,6 +179,7 @@ func (handler *BatchHandler) batch() {
 		if handler.batcherInfo.CurrentInputLen >= handler.MaxBatchSize ||
 			(handler.batcherInfo.Now.Sub(handler.batcherInfo.Start).Milliseconds() >= int64(handler.MaxLatency) &&
 				handler.batcherInfo.CurrentInputLen > 0) {
+			handler.log.Infof("batch predict with size %d %s", len(handler.batcherInfo.Instances), handler.batcherInfo.Path)
 			handler.batchPredict()
 		}
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -291,15 +291,15 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 		gateways = append(gateways, config.IngressGateway)
 	}
 
-	annotations :=  utils.Filter(isvc.Annotations, func(key string) bool {
+	annotations := utils.Filter(isvc.Annotations, func(key string) bool {
 		return !utils.Includes(constants.ServiceAnnotationDisallowedList, key)
 	})
 	desiredIngress := &v1alpha3.VirtualService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      isvc.Name,
-			Namespace: isvc.Namespace,
+			Name:        isvc.Name,
+			Namespace:   isvc.Namespace,
 			Annotations: annotations,
-			Labels: isvc.Labels,
+			Labels:      isvc.Labels,
 		},
 		Spec: istiov1alpha3.VirtualService{
 			Hosts:    hosts,

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -465,10 +465,10 @@ func TestCreateVirtualService(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			testIsvc := &v1beta1.InferenceService{
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      serviceName,
-					Namespace: namespace,
+					Name:        serviceName,
+					Namespace:   namespace,
 					Annotations: isvcAnnotions,
-					Labels: labels,
+					Labels:      labels,
 				},
 				Spec: v1beta1.InferenceServiceSpec{
 					Predictor: v1beta1.PredictorSpec{},

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -224,16 +224,14 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 			Exec: &v1.ExecAction{
 				Command: []string{
 					"/agent",
-					"-probe-period",
+					"--probe-period",
 					"0",
 				},
 			},
 		},
 		TimeoutSeconds: 10,
 	}
-	if injectLogger || injectBatcher {
-		agentContainer.ReadinessProbe = readinessProbe
-	}
+	agentContainer.ReadinessProbe = readinessProbe
 
 	// Inject credentials
 	if err := ag.credentialBuilder.CreateSecretVolumeAndEnv(

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -132,7 +132,6 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 	var args []string
 	if injectPuller {
 		args = append(args, constants.AgentEnableFlag)
-		args = append(args, "true")
 		modelConfig, ok := pod.ObjectMeta.Annotations[constants.AgentModelConfigMountPathAnnotationKey]
 		if ok {
 			args = append(args, constants.AgentConfigDirArgName)
@@ -148,7 +147,6 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 	// Only inject if the batcher required annotations are set
 	if injectBatcher {
 		args = append(args, BatcherEnableFlag)
-		args = append(args, "true")
 		maxBatchSize, ok := pod.ObjectMeta.Annotations[constants.BatcherMaxBatchSizeInternalAnnotationKey]
 		if ok {
 			args = append(args, BatcherArgumentMaxBatchSize)

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -121,7 +121,7 @@ func TestAgentInjector(t *testing.T) {
 									MountPath: constants.ModelConfigDir,
 								},
 							},
-							Args: []string{"--enable-puller", "true", "--config-dir", "/mnt/configs", "--model-dir", "/mnt/models"},
+							Args: []string{"--enable-puller", "--config-dir", "/mnt/configs", "--model-dir", "/mnt/models"},
 							Env:  []v1.EnvVar{},
 						},
 					},

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -123,6 +123,18 @@ func TestAgentInjector(t *testing.T) {
 							},
 							Args: []string{"--enable-puller", "--config-dir", "/mnt/configs", "--model-dir", "/mnt/models"},
 							Env:  []v1.EnvVar{},
+							ReadinessProbe: &v1.Probe{
+								Handler: v1.Handler{
+									Exec: &v1.ExecAction{
+										Command: []string{
+											"/agent",
+											"--probe-period",
+											"0",
+										},
+									},
+								},
+								TimeoutSeconds: 10,
+							},
 						},
 					},
 					Volumes: []v1.Volume{
@@ -228,7 +240,7 @@ func TestAgentInjector(t *testing.T) {
 									Exec: &v1.ExecAction{
 										Command: []string{
 											"/agent",
-											"-probe-period",
+											"--probe-period",
 											"0",
 										},
 									},


### PR DESCRIPTION
**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1041 

**Special notes for your reviewer**:

1. Use sflag instead and fix usages
2. Poll user container health before starting the agent as model puller calls load/unload endpoint when syncing the model config on startup
3. Add readiness probe for MMS
4. Fix ko-app issue in development mode #1435 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
