### PR TITLE
[xgboostserver] Convert list input to numpy array before creating DMatrix

### DIFF
--- a/python/xgbserver/setup.py
+++ b/python/xgbserver/setup.py
@@ -33,7 +33,6 @@ setup(
     python_requires='>3.4',
     packages=find_packages("xgbserver"),
     install_requires=[
-        "numpy>=1.0"
         "kfserving>=0.5.1",
         "xgboost == 0.82",
         "scikit-learn == 0.20.3",

--- a/python/xgbserver/setup.py
+++ b/python/xgbserver/setup.py
@@ -33,6 +33,7 @@ setup(
     python_requires='>3.4',
     packages=find_packages("xgbserver"),
     install_requires=[
+        "numpy>=1.0"
         "kfserving>=0.5.1",
         "xgboost == 0.82",
         "scikit-learn == 0.20.3",

--- a/python/xgbserver/xgbserver/model.py
+++ b/python/xgbserver/xgbserver/model.py
@@ -14,6 +14,7 @@
 
 import kfserving
 import xgboost as xgb
+import numpy as np
 from xgboost import XGBModel
 import os
 from typing import Dict
@@ -43,7 +44,7 @@ class XGBoostModel(kfserving.KFModel):
     def predict(self, request: Dict) -> Dict:
         try:
             # Use of list as input is deprecated see https://github.com/dmlc/xgboost/pull/3970
-            dmatrix = xgb.DMatrix(request["instances"], nthread=self.nthread)
+            dmatrix = xgb.DMatrix(np.array(request["instances"]), nthread=self.nthread)
             result: xgb.DMatrix = self._booster.predict(dmatrix)
             return {"predictions": result.tolist()}
         except Exception as e:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Due to https://github.com/dmlc/xgboost/pull/3970 , prediction calculated by current xgboost model is incorrect for some cases. The result deviates quite significantly compared to training set. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fix incorrect prediction result in xgboost server.

**Special notes for your reviewer**:

- Additional dependency (numpy) is added to xgboost server

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
