### PR TITLE
Adds condition for Trained Model to check if isvc predictor supports MMS

### DIFF
--- a/pkg/apis/serving/v1alpha1/trained_model_status.go
+++ b/pkg/apis/serving/v1alpha1/trained_model_status.go
@@ -43,6 +43,8 @@ const (
 	FrameworkSupported apis.ConditionType = "FrameworkSupported"
 	// MemoryResourceAvailable is set when inference service reported resources availability
 	MemoryResourceAvailable apis.ConditionType = "MemoryResourceAvailable"
+	// InferenceServiceMMSPredictor is set when inference service predictor is set to multi-model serving
+	InferenceServiceMMSPredictor apis.ConditionType = "InferenceServiceMMSPredictor"
 )
 
 // TrainedModel Ready condition is depending on inference service readiness condition
@@ -51,6 +53,7 @@ var conditionSet = apis.NewLivingConditionSet(
 	InferenceServiceReady,
 	FrameworkSupported,
 	MemoryResourceAvailable,
+	InferenceServiceMMSPredictor,
 )
 
 var _ apis.ConditionsAccessor = (*TrainedModelStatus)(nil)

--- a/pkg/apis/serving/v1alpha1/trained_model_status.go
+++ b/pkg/apis/serving/v1alpha1/trained_model_status.go
@@ -43,8 +43,8 @@ const (
 	FrameworkSupported apis.ConditionType = "FrameworkSupported"
 	// MemoryResourceAvailable is set when inference service reported resources availability
 	MemoryResourceAvailable apis.ConditionType = "MemoryResourceAvailable"
-	// InferenceServiceMMSPredictor is set when inference service predictor is set to multi-model serving
-	InferenceServiceMMSPredictor apis.ConditionType = "InferenceServiceMMSPredictor"
+	// IsMMSPredictor is set when inference service predictor is set to multi-model serving
+	IsMMSPredictor apis.ConditionType = "IsMMSPredictor"
 )
 
 // TrainedModel Ready condition is depending on inference service readiness condition
@@ -53,7 +53,7 @@ var conditionSet = apis.NewLivingConditionSet(
 	InferenceServiceReady,
 	FrameworkSupported,
 	MemoryResourceAvailable,
-	InferenceServiceMMSPredictor,
+	IsMMSPredictor,
 )
 
 var _ apis.ConditionsAccessor = (*TrainedModelStatus)(nil)

--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -101,6 +101,11 @@ func (s *PredictorSpec) GetImplementation() ComponentImplementation {
 	return s.GetImplementations()[0]
 }
 
+// IsEmpty returns if all components does not exist
+func (s *PredictorSpec) IsEmpty() bool {
+	return len(s.GetImplementations()) == 0
+}
+
 // GetExtensions returns the extensions for the component
 func (s *PredictorSpec) GetExtensions() *ComponentExtensionSpec {
 	return &s.ComponentExtensionSpec

--- a/pkg/apis/serving/v1beta1/predictor.go
+++ b/pkg/apis/serving/v1beta1/predictor.go
@@ -101,18 +101,13 @@ func (s *PredictorSpec) GetImplementation() ComponentImplementation {
 	return s.GetImplementations()[0]
 }
 
-// IsEmpty returns if all components does not exist
-func (s *PredictorSpec) IsEmpty() bool {
-	return len(s.GetImplementations()) == 0
-}
-
 // GetExtensions returns the extensions for the component
 func (s *PredictorSpec) GetExtensions() *ComponentExtensionSpec {
 	return &s.ComponentExtensionSpec
 }
 
 // GetPredictor returns the implementation for the predictor
-func (s *PredictorSpec) GetPredictors() []PredictorImplementation {
+func (s *PredictorSpec) GetPredictorImplementations() []PredictorImplementation {
 	implementations := NonNilPredictors([]PredictorImplementation{
 		s.XGBoost,
 		s.PyTorch,
@@ -130,12 +125,12 @@ func (s *PredictorSpec) GetPredictors() []PredictorImplementation {
 	return implementations
 }
 
-func (s *PredictorSpec) GetPredictor() *PredictorImplementation {
-	predictors := s.GetPredictors()
+func (s *PredictorSpec) GetPredictorImplementation() *PredictorImplementation {
+	predictors := s.GetPredictorImplementations()
 	if len(predictors) == 0 {
 		return nil
 	}
-	return &s.GetPredictors()[0]
+	return &s.GetPredictorImplementations()[0]
 }
 
 func NonNilPredictors(objects []PredictorImplementation) (results []PredictorImplementation) {

--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -238,12 +238,10 @@ func (r *TrainedModelReconciler) updateConditions(req ctrl.Request, tm *v1alpha1
 	// Update Is MMS Predictor condition
 	implementations := isvc.Spec.Predictor.GetImplementations()
 	if len(implementations) > 0 && v1beta1utils.IsMMSPredictor(&isvc.Spec.Predictor, isvcConfig) {
-		log.Info("Predictor is multi-model serving", "TrainedModel", tm.Name, "InferenceService", isvc.Name)
 		tm.Status.SetCondition(v1alpha1api.IsMMSPredictor, &apis.Condition{
 			Status: v1.ConditionTrue,
 		})
 	} else {
-		log.Info("Predictor is not configured for multi-model serving", "TrainedModel", tm.Name, "InferenceService", isvc.Name)
 		tm.Status.SetCondition(v1alpha1api.IsMMSPredictor, &apis.Condition{
 			Type:    v1alpha1api.IsMMSPredictor,
 			Status:  v1.ConditionFalse,

--- a/pkg/controller/v1alpha1/trainedmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller_test.go
@@ -60,7 +60,8 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 			"predictors": `{
                "tensorflow": {
                   "image": "tensorflow/serving",
-				  "supportedFrameworks": ["tensorflow"]
+				  "supportedFrameworks": ["tensorflow"],
+				  "multiModelServer": true
                },
                "sklearn": {
                   "image": "kfserving/sklearnserver"
@@ -161,7 +162,15 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 
 				// Condition for inferenceserviceready should be false as isvc is not ready
 				isvcReadyCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.InferenceServiceReady)
-				return isvcReadyCondition != nil && isvcReadyCondition.Status == v1.ConditionFalse
+
+				// Condition for InferenceServiceMMSPredictor should be false as isvc is not ready
+				inferenceServiceMMSCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.InferenceServiceMMSPredictor)
+
+				if isvcReadyCondition != nil && isvcReadyCondition.Status == v1.ConditionFalse {
+					return inferenceServiceMMSCondition != nil && inferenceServiceMMSCondition.Status == v1.ConditionFalse
+				}
+
+				return false
 			}, timeout).Should(BeTrue())
 		})
 	})
@@ -376,6 +385,11 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 
 				// Condition for inferenceserviceready should be true
 				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceReady) {
+					return false
+				}
+
+				// Condition for InferenceServiceMMSPredictor should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor) {
 					return false
 				}
 
@@ -648,12 +662,18 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				}
 
 				// Condition for inferenceserviceready should be true
-				if tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceReady) {
-					frameworkSupportedCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.FrameworkSupported)
-					return frameworkSupportedCondition != nil && frameworkSupportedCondition.Status == v1.ConditionFalse
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceReady) {
+					return false
 				}
 
-				return false
+				// Condition for InferenceServiceMMSPredictor should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor) {
+					return false
+				}
+
+				frameworkSupportedCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.FrameworkSupported)
+				return frameworkSupportedCondition != nil && frameworkSupportedCondition.Status == v1.ConditionFalse
+
 			}, timeout).Should(BeTrue())
 
 			// Verify that the model configmap is updated with the TrainedModel
@@ -776,6 +796,11 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 					return false
 				}
 
+				// Condition for InferenceServiceMMSPredictor should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor) {
+					return false
+				}
+
 				// Condition for MemoryResourceAvailable should be false
 				return !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.MemoryResourceAvailable)
 
@@ -798,6 +823,114 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 
 				return configmapActual.Data
 			}, timeout, interval).Should(Equal(expected.Data))
+		})
+	})
+
+	Context("When creating a new TrainedModel with a non-mms predictor", func() {
+		It("Should not add a model to the model configmap", func() {
+			modelName := "model1-non-mms"
+			parentInferenceService := modelName + "-parent"
+			modelConfigName := constants.ModelConfigName(parentInferenceService, shardId)
+			tmKey := types.NamespacedName{Name: modelName, Namespace: namespace}
+
+			// Create InferenceService configmap
+			var configMap = &v1.ConfigMap{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      constants.InferenceServiceConfigMapName,
+					Namespace: constants.KFServingNamespace,
+				},
+				Data: configs,
+			}
+			Expect(k8sClient.Create(context.TODO(), configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), configMap)
+
+			// Create the parent InferenceService
+			var expectedRequest = reconcile.Request{NamespacedName: types.NamespacedName{Name: parentInferenceService, Namespace: namespace}}
+			var serviceKey = expectedRequest.NamespacedName
+			ctx := context.Background()
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: v1beta1.GetIntReference(1),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								RuntimeVersion: proto.String("1.14.0"),
+								Container: v1.Container{
+									Name:      "kfserving-container",
+									Resources: defaultResource,
+								},
+								StorageURI: &storageUri,
+							},
+						},
+					},
+				},
+			}
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+
+			inferenceService := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, inferenceService)
+				if err != nil {
+					return false
+				}
+				return true
+			}, timeout, interval).Should(BeTrue())
+
+			inferenceService.Status.Status = readyConditions
+			Expect(k8sClient.Status().Update(context.TODO(), inferenceService)).To(BeNil())
+
+			// Create modelConfig
+			modelConfig := &v1.ConfigMap{
+				TypeMeta:   metav1.TypeMeta{Kind: "ConfigMap", APIVersion: "v1"},
+				ObjectMeta: metav1.ObjectMeta{Name: modelConfigName, Namespace: namespace},
+				Data: map[string]string{
+					constants.ModelConfigFileName: "",
+				},
+			}
+
+			tmInstance := &v1alpha1api.TrainedModel{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      modelName,
+					Namespace: namespace,
+				},
+				Spec: v1alpha1api.TrainedModelSpec{
+					InferenceService: parentInferenceService,
+					Model: v1alpha1api.ModelSpec{
+						StorageURI: storageUri,
+						Framework:  framework,
+						Memory:     memory,
+					},
+				},
+			}
+
+			Expect(k8sClient.Create(context.TODO(), modelConfig)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), modelConfig)
+			Expect(k8sClient.Create(context.TODO(), tmInstance)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(context.TODO(), tmInstance)
+
+			Eventually(func() bool {
+				tmInstanceUpdate := &v1alpha1api.TrainedModel{}
+				if err := k8sClient.Get(context.TODO(), tmKey, tmInstanceUpdate); err != nil {
+					return false
+				}
+
+				// Condition for inferenceserviceready should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceReady) {
+					return false
+				}
+
+				// Condition for InferenceServiceMMSPredictor should be true
+				return !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor)
+
+			}, timeout).Should(BeTrue())
+
 		})
 	})
 })

--- a/pkg/controller/v1alpha1/trainedmodel/controller_test.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller_test.go
@@ -163,11 +163,11 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 				// Condition for inferenceserviceready should be false as isvc is not ready
 				isvcReadyCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.InferenceServiceReady)
 
-				// Condition for InferenceServiceMMSPredictor should be false as isvc is not ready
-				inferenceServiceMMSCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.InferenceServiceMMSPredictor)
+				// Condition for IsMMSPredictor should be false as isvc is not ready
+				isMMSPredictorCondition := tmInstanceUpdate.Status.GetCondition(v1alpha1api.IsMMSPredictor)
 
 				if isvcReadyCondition != nil && isvcReadyCondition.Status == v1.ConditionFalse {
-					return inferenceServiceMMSCondition != nil && inferenceServiceMMSCondition.Status == v1.ConditionFalse
+					return isMMSPredictorCondition != nil && isMMSPredictorCondition.Status == v1.ConditionFalse
 				}
 
 				return false
@@ -388,8 +388,8 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 					return false
 				}
 
-				// Condition for InferenceServiceMMSPredictor should be true
-				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor) {
+				// Condition for IsMMSPredictor should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.IsMMSPredictor) {
 					return false
 				}
 
@@ -666,8 +666,8 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 					return false
 				}
 
-				// Condition for InferenceServiceMMSPredictor should be true
-				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor) {
+				// Condition for IsMMSPredictor should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.IsMMSPredictor) {
 					return false
 				}
 
@@ -796,8 +796,8 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 					return false
 				}
 
-				// Condition for InferenceServiceMMSPredictor should be true
-				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor) {
+				// Condition for IsMMSPredictor should be true
+				if !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.IsMMSPredictor) {
 					return false
 				}
 
@@ -926,8 +926,8 @@ var _ = Describe("v1beta1 TrainedModel controller", func() {
 					return false
 				}
 
-				// Condition for InferenceServiceMMSPredictor should be true
-				return !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.InferenceServiceMMSPredictor)
+				// Condition for IsMMSPredictor should be true
+				return !tmInstanceUpdate.Status.IsConditionReady(v1alpha1api.IsMMSPredictor)
 
 			}, timeout).Should(BeTrue())
 


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Trained Model requires the parent inference service to enable multi-model serving. This PR adds a condition to let users know that their model is not Ready if parent's predictor is not configured to mms.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
