### PR TITLE
reconcile ingress routing virtualservice when annotations/labels are updated

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -339,8 +339,10 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 			err = ir.client.Create(context.TODO(), desiredIngress)
 		}
 	} else {
-		if !equality.Semantic.DeepEqual(desiredIngress.Spec, existing.Spec) {
+		if !routeSemanticEquals(desiredIngress, existing) {
 			existing.Spec = desiredIngress.Spec
+			existing.Annotations = desiredIngress.Annotations
+			existing.Labels = desiredIngress.Labels
 			log.Info("Update Ingress for isvc", "namespace", desiredIngress.Namespace, "name", desiredIngress.Name)
 			err = ir.client.Update(context.TODO(), existing)
 		}
@@ -378,4 +380,10 @@ func (ir *IngressReconciler) Reconcile(isvc *v1beta1.InferenceService) error {
 	} else {
 		return errors.Wrapf(err, "fails to parse service url")
 	}
+}
+
+func routeSemanticEquals(desired, existing *v1alpha3.VirtualService) bool {
+	return equality.Semantic.DeepEqual(desired.Spec, existing.Spec) &&
+		equality.Semantic.DeepEqual(desired.ObjectMeta.Labels, existing.ObjectMeta.Labels) &&
+		equality.Semantic.DeepEqual(desired.ObjectMeta.Annotations, existing.ObjectMeta.Annotations)
 }


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Reconcile ingress routing virtualservice when annotations/labels are updated

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1524 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
