### PR TITLE
Update logger samples for newer eventing versions

### DIFF
--- a/docs/samples/logger/basic/README.md
+++ b/docs/samples/logger/basic/README.md
@@ -1,7 +1,7 @@
 # Inference Logger Demo
 
-First let us create a message dumper KNative service which will print out the Cloud Events it receives.
-We will use the following resource yaml:
+First let us create a message dumper Knative service which will print out the CloudEvents it receives.
+We will use the following resource YAML:
 
 ```
 apiVersion: serving.knative.dev/v1
@@ -22,69 +22,47 @@ Let's apply the resource to the cluster:
 kubectl create -f message-dumper.yaml
 ```
 
-We can now create a sklearn predictor with a logger which points at the message dumper. The yaml is shown below.
+We can now create an sklearn predictor with a logger which points at the message dumper. The YAML is shown below.
 
 ```
-apiVersion: "serving.kubeflow.org/v1alpha2"
-kind: "InferenceService"
+apiVersion: serving.kubeflow.org/v1beta1
+kind: InferenceService
 metadata:
-  name: "sklearn-iris"
+  name: sklearn-iris
 spec:
-  default:
-    predictor:
-      minReplicas: 1      
-      logger:
-        url: http://message-dumper.default/
-        mode: all
-      sklearn:
-        storageUri: "gs://kfserving-samples/models/sklearn/iris"
+  predictor:
+    logger:
+      mode: all
+      url: http://message-dumper.default/
+    sklearn:
+      storageUri: gs://kfserving-samples/models/sklearn/iris
 ```
 
 (Here we set the url explicitly. otherwise it defaults to the namespace knative broker or the value of DefaultUrl in the logger section of the controller configmap.)
 
-Let's apply this yaml:
+Let's apply this YAML:
 
 ```
 kubectl create -f sklearn-logging.yaml
 ```
 
-We can now send a request to the sklearn model.
+We can now send a request to the sklearn model. Check the README [here](https://github.com/kubeflow/kfserving#determine-the-ingress-ip-and-ports)
+to learn how to determine the INGRESS_HOST and INGRESS_PORT used in curling the InferenceService.
 
 ```
 MODEL_NAME=sklearn-iris
 INPUT_PATH=@./iris-input.json
-INGRESS_GATEWAY=istio-ingressgateway
-CLUSTER_IP=$(kubectl -n istio-system get service $INGRESS_GATEWAY -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
 SERVICE_HOSTNAME=$(kubectl get inferenceservice sklearn-iris -o jsonpath='{.status.url}' | cut -d "/" -f 3)
-curl -v -H "Host: ${SERVICE_HOSTNAME}" http://$CLUSTER_IP/v1/models/$MODEL_NAME:predict -d $INPUT_PATH -H "Content-Type: application/json"
+curl -v -H "Host: ${SERVICE_HOSTNAME}" http://${INGRESS_HOST}:${INGRESS_PORT}/v1/models/$MODEL_NAME:predict -d $INPUT_PATH
 ```
 
-Expected Output
+Expected response:
 
 ```
-*   Trying 169.63.251.68...
-* TCP_NODELAY set
-* Connected to 169.63.251.68 (169.63.251.68) port 80 (#0)
-> POST /models/sklearn-iris:predict HTTP/1.1
-> Host: sklearn-iris.default.svc.cluster.local
-> User-Agent: curl/7.60.0
-> Accept: */*
-> Content-Length: 76
-> Content-Type: application/x-www-form-urlencoded
->
-* upload completely sent off: 76 out of 76 bytes
-< HTTP/1.1 200 OK
-< content-length: 23
-< content-type: application/json; charset=UTF-8
-< date: Mon, 20 May 2019 20:49:02 GMT
-< server: istio-envoy
-< x-envoy-upstream-service-time: 1943
-<
-* Connection #0 to host 169.63.251.68 left intact
 {"predictions": [1, 1]}
 ```
 
-If we now check the logs of the message dumper:
+If we now check the logs of the message dumper, we can see the CloudEvents associated with our previous curl request.
 
 ```
 kubectl logs $(kubectl get pod -l serving.knative.dev/service=message-dumper -o jsonpath='{.items[0].metadata.name}') user-container
@@ -96,12 +74,17 @@ Expected output:
 ☁️  cloudevents.Event
 Validation: valid
 Context Attributes,
-  cloudEventsVersion: 0.1
-  eventType: org.kubeflow.serving.inference.request
-  source: http://localhost:8080/
-  eventID: 462af46b-d582-4f3a-9f2a-6851d4143e3d
-  eventTime: 2019-10-21T12:12:49.82518115Z
-  contentType: application/json
+  specversion: 1.0
+  type: org.kubeflow.serving.inference.request
+  source: http://localhost:9081/
+  id: 0009174a-24a8-4603-b098-09c8799950e9
+  time: 2021-04-10T00:23:26.0789529Z
+  datacontenttype: application/json
+Extensions,
+  endpoint:
+  inferenceservicename: sklearn-iris
+  namespace: default
+  traceparent: 00-90bdf848647d50283394155d2df58f19-84dacdfdf07cadfc-00
 Data,
   {
     "instances": [
@@ -122,12 +105,17 @@ Data,
 ☁️  cloudevents.Event
 Validation: valid
 Context Attributes,
-  cloudEventsVersion: 0.1
-  eventType: org.kubeflow.serving.inference.response
-  source: http://localhost:8080/
-  eventID: 462af46b-d582-4f3a-9f2a-6851d4143e3d
-  eventTime: 2019-10-21T12:12:49.83269988Z
-  contentType: application/json; charset=UTF-8
+  specversion: 1.0
+  type: org.kubeflow.serving.inference.response
+  source: http://localhost:9081/
+  id: 0009174a-24a8-4603-b098-09c8799950e9
+  time: 2021-04-10T00:23:26.080736102Z
+  datacontenttype: application/json
+Extensions,
+  endpoint:
+  inferenceservicename: sklearn-iris
+  namespace: default
+  traceparent: 00-55de1514e1d23ee17eb50dda6167bb8c-b6c6e0f6dd8f741d-00
 Data,
   {
     "predictions": [

--- a/docs/samples/logger/basic/logger_demo.ipynb
+++ b/docs/samples/logger/basic/logger_demo.ipynb
@@ -11,7 +11,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We create a message dumper KNaive service to print out CloudEvents it receives:"
+    "We create a message dumper Knative service to print out CloudEvents it receives:"
    ]
   },
   {
@@ -36,7 +36,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a SkLearn model with associated logger to push events to the message logger URL"
+    "Create an sklearn model with associated logger to push events to the message logger URL."
    ]
   },
   {

--- a/docs/samples/logger/basic/message-dumper.yaml
+++ b/docs/samples/logger/basic/message-dumper.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: message-dumper

--- a/docs/samples/logger/basic/sklearn-logging.yaml
+++ b/docs/samples/logger/basic/sklearn-logging.yaml
@@ -1,13 +1,11 @@
-apiVersion: "serving.kubeflow.org/v1alpha2"
-kind: "InferenceService"
+apiVersion: serving.kubeflow.org/v1beta1
+kind: InferenceService
 metadata:
-  name: "sklearn-iris"
+  name: sklearn-iris
 spec:
-  default:
-    predictor:
-      minReplicas: 1      
-      logger:
-        url: http://message-dumper.default/
-        mode: all
-      sklearn:
-        storageUri: "gs://kfserving-samples/models/sklearn/iris"
+  predictor:
+    logger:
+      mode: all
+      url: http://message-dumper.default/
+    sklearn:
+      storageUri: gs://kfserving-samples/models/sklearn/iris

--- a/docs/samples/logger/knative-eventing/broker.yaml
+++ b/docs/samples/logger/knative-eventing/broker.yaml
@@ -1,0 +1,4 @@
+apiVersion: eventing.knative.dev/v1
+kind: broker
+metadata:
+ name: default

--- a/docs/samples/logger/knative-eventing/logger_demo.ipynb
+++ b/docs/samples/logger/knative-eventing/logger_demo.ipynb
@@ -4,14 +4,14 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# KfServing KNative Logger demo"
+    "# KFServing Knative Logger Demo"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We create a message dumper KNaive service to print out CloudEvents it receives:"
+    "We create a message dumper Knative service to print out CloudEvents it receives:"
    ]
   },
   {
@@ -33,10 +33,19 @@
    ]
   },
   {
-   "cell_type": "markdown",
-   "metadata": {},
    "source": [
-    "Label the default namespace to activate KNative eventing broker"
+    "Create a channel broker."
+   ],
+   "cell_type": "markdown",
+   "metadata": {}
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "!pygmentize broker.yaml"
    ]
   },
   {
@@ -45,14 +54,14 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "!kubectl label namespace default knative-eventing-injection=enabled"
+    "!kubectl create -f broker.yaml"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a knative trigger to pass events to the message logger"
+    "Create a Knative trigger to pass events to the message logger."
    ]
   },
   {
@@ -77,7 +86,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "Create a SkLearn model with associated logger to push events to the message logger URL"
+    "Create an sklearn model with associated logger to push events to the message logger URL."
    ]
   },
   {

--- a/docs/samples/logger/knative-eventing/message-dumper.yaml
+++ b/docs/samples/logger/knative-eventing/message-dumper.yaml
@@ -1,4 +1,4 @@
-apiVersion: serving.knative.dev/v1alpha1
+apiVersion: serving.knative.dev/v1
 kind: Service
 metadata:
   name: message-dumper
@@ -6,4 +6,4 @@ spec:
   template:
     spec:
       containers:
-      - image: gcr.io/knative-releases/github.com/knative/eventing-sources/cmd/event_display
+      - image: gcr.io/knative-releases/knative.dev/eventing-contrib/cmd/event_display

--- a/docs/samples/logger/knative-eventing/sklearn-logging.yaml
+++ b/docs/samples/logger/knative-eventing/sklearn-logging.yaml
@@ -1,12 +1,11 @@
-apiVersion: "serving.kubeflow.org/v1alpha2"
-kind: "InferenceService"
+apiVersion: serving.kubeflow.org/v1beta1
+kind: InferenceService
 metadata:
-  name: "sklearn-iris"
+  name: sklearn-iris
 spec:
-  default:
-    predictor:
-      minReplicas: 1
-      logger:
-        mode: all
-      sklearn:
-        storageUri: "gs://kfserving-samples/models/sklearn/iris"
+  predictor:
+    logger:
+      mode: all
+      url: http://broker-ingress.knative-eventing.svc.cluster.local/default/default
+    sklearn:
+      storageUri: gs://kfserving-samples/models/sklearn/iris

--- a/docs/samples/logger/knative-eventing/trigger.yaml
+++ b/docs/samples/logger/knative-eventing/trigger.yaml
@@ -1,11 +1,11 @@
-apiVersion: eventing.knative.dev/v1alpha1
+apiVersion: eventing.knative.dev/v1
 kind: Trigger
 metadata:
   name: message-dumper-trigger
-  namespace: default
 spec:
+  broker: default
   subscriber:
     ref:
-      apiVersion: serving.knative.dev/v1alpha1
+      apiVersion: serving.knative.dev/v1
       kind: Service
       name: message-dumper


### PR DESCRIPTION
The logger samples were updated to be able to work with newer Knative Eventing versions, and InferenceService YAMLs were also updated to use the v1beta1 API.
