### PR TITLE
Fix logger for error response case

### DIFF
--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -84,7 +84,7 @@ var _ = Describe("Watcher", func() {
 					channelMap:  make(map[string]*ModelChannel),
 					completions: make(chan *ModelOp, 4),
 					opStats:     make(map[string]map[OpType]int),
-					waitGroup: WaitGroupWrapper{sync.WaitGroup{}},
+					waitGroup:   WaitGroupWrapper{sync.WaitGroup{}},
 					Downloader: Downloader{
 						ModelDir: modelDir + "/test1",
 						Providers: map[storage.Protocol]storage.Provider{

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -53,7 +53,7 @@ func (c *CustomPredictor) validateCustomProtocol() error {
 			if envVar.Value == string(constants.ProtocolV1) || envVar.Value == string(constants.ProtocolV2) {
 				return nil
 			} else {
-				return fmt.Errorf(InvalidProtocol, strings.Join([]string {string(constants.ProtocolV1),string(constants.ProtocolV2)}, ", "), envVar.Value)
+				return fmt.Errorf(InvalidProtocol, strings.Join([]string{string(constants.ProtocolV1), string(constants.ProtocolV2)}, ", "), envVar.Value)
 			}
 		}
 	}

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -125,7 +125,11 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	} else {
 		eh.log.Info("Failed to proxy request", "status code", rr.Code)
 	}
-
+	contentType := rr.Header().Get("Content-Type")
+	if contentType != "" {
+		w.Header().Set("Content-Type", contentType)
+	}
+	w.WriteHeader(rr.Code)
 	_, err = w.Write(rr.Body.Bytes())
 	if err != nil {
 		http.Error(w, err.Error(), http.StatusInternalServerError)

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -89,3 +89,41 @@ func TestLogger(t *testing.T) {
 	// get logResponse
 	<-responseChan
 }
+
+func TestBadResponse(t *testing.T) {
+
+	g := gomega.NewGomegaWithT(t)
+
+	predictorRequest := []byte(`{"instances":[[0,0,0]]}`)
+	predictorResponse := "BadRequest\n"
+
+	// Start a local HTTP server
+	predictor := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		b, err := ioutil.ReadAll(req.Body)
+		g.Expect(err).To(gomega.BeNil())
+		g.Expect(b).To(gomega.Or(gomega.Equal(predictorRequest), gomega.Equal(predictorResponse)))
+		http.Error(rw, "BadRequest", http.StatusBadRequest)
+	}))
+	// Close the server when test finishes
+	defer predictor.Close()
+
+	reader := bytes.NewReader(predictorRequest)
+	r := httptest.NewRequest("POST", "http://a", reader)
+	w := httptest.NewRecorder()
+	logger, _ := pkglogging.NewLogger("", "INFO")
+	logf.SetLogger(zap.New())
+	logSvcUrl, err := url.Parse("http://loggersvc")
+	g.Expect(err).To(gomega.BeNil())
+	sourceUri, err := url.Parse("http://localhost:9081/")
+	g.Expect(err).To(gomega.BeNil())
+	targetUri, err := url.Parse(predictor.URL)
+	g.Expect(err).To(gomega.BeNil())
+
+	StartDispatcher(1, logger)
+	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
+	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", httpProxy)
+
+	oh.ServeHTTP(w, r)
+	g.Expect(w.Code).To(gomega.Equal(400))
+	g.Expect(w.Body.String()).To(gomega.Equal(predictorResponse))
+}

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -107,7 +107,9 @@ func (w *Worker) sendCloudEvent(logReq LogRequest) error {
 	event.SetExtension(EndpointAttr, logReq.Endpoint)
 
 	event.SetSource(logReq.SourceUri.String())
-	event.SetDataContentType(logReq.ContentType)
+	if logReq.ContentType != "" {
+		event.SetDataContentType(logReq.ContentType)
+	}
 	if err := event.SetData(*logReq.Bytes); err != nil {
 		return fmt.Errorf("while setting cloudevents data: %s", err)
 	}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
There is a regression to propagate the error response when we consolidate the logger to the agent.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1530 

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
