### PR TITLE
Added annotation to use anonymous credentials for s3

### DIFF
--- a/docs/samples/storage/s3/README.md
+++ b/docs/samples/storage/s3/README.md
@@ -16,6 +16,7 @@ metadata:
      serving.kubeflow.org/s3-endpoint: s3.amazonaws.com # replace with your s3 endpoint e.g minio-service.kubeflow:9000 
      serving.kubeflow.org/s3-usehttps: "1" # by default 1, if testing with minio you can set to 0
      serving.kubeflow.org/s3-region: "us-east-2"
+     serving.kubeflow.org/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore provided credential and use anonymous credentials
 type: Opaque
 stringData: # use `stringData` for raw credential string or `data` for base64 encoded string
   AWS_ACCESS_KEY_ID: XXXX

--- a/docs/samples/storage/s3/s3_secret.yaml
+++ b/docs/samples/storage/s3/s3_secret.yaml
@@ -6,6 +6,7 @@ metadata:
      serving.kubeflow.org/s3-endpoint: s3.amazonaws.com # replace with your s3 endpoint
      serving.kubeflow.org/s3-usehttps: "1" # by default 1, for testing with minio you need to set to 0
      serving.kubeflow.org/s3-region: "us-east-2" # replace with the region the bucket is created in
+     serving.kubeflow.org/s3-useanoncredential: "false" # omitting this is the same as false, if true will ignore credential provided and use anonymous credentials
 type: Opaque
 data:
   AWS_ACCESS_KEY_ID: bWluaW8= # replace with your base64 encoded s3 credential

--- a/pkg/agent/storage/utils.go
+++ b/pkg/agent/storage/utils.go
@@ -22,6 +22,7 @@ import (
 	"crypto/sha256"
 	"fmt"
 	"github.com/aws/aws-sdk-go/aws"
+	"github.com/aws/aws-sdk-go/aws/credentials"
 	"github.com/aws/aws-sdk-go/aws/session"
 	"github.com/aws/aws-sdk-go/service/s3"
 	"github.com/aws/aws-sdk-go/service/s3/s3manager"
@@ -111,27 +112,39 @@ func GetProvider(providers map[Protocol]Provider, protocol Protocol) (Provider, 
 			Client: stiface.AdaptClient(gcsClient),
 		}
 	case S3:
+		var sess *session.Session
+		var err error
+
+		region, _ := os.LookupEnv(s3credential.AWSRegion)
+		useVirtualBucketString, ok := os.LookupEnv(s3credential.S3UseVirtualBucket)
+		useVirtualBucket := true
+		if ok && strings.ToLower(useVirtualBucketString) == "false" {
+			useVirtualBucket = false
+		}
+
+		awsConfig := aws.Config{
+			Region:           aws.String(region),
+			S3ForcePathStyle: aws.Bool(!useVirtualBucket),
+		}
+
 		if endpoint, ok := os.LookupEnv(s3credential.AWSEndpointUrl); ok {
-			region, _ := os.LookupEnv(s3credential.AWSRegion)
-			useVirtualBucketString, ok := os.LookupEnv(s3credential.S3UseVirtualBucket)
-			useVirtualBucket := true
-			if ok && strings.ToLower(useVirtualBucketString) == "false" {
-				useVirtualBucket = false
-			}
-			sess, err := session.NewSession(&aws.Config{
-				Endpoint:         aws.String(endpoint),
-				Region:           aws.String(region),
-				S3ForcePathStyle: aws.Bool(!useVirtualBucket)},
-			)
-			if err != nil {
-				return nil, err
-			}
-			sessionClient := s3.New(sess)
-			providers[S3] = &S3Provider{
-				Client: sessionClient,
-				Downloader: s3manager.NewDownloaderWithClient(sessionClient, func(d *s3manager.Downloader) {
-				}),
-			}
+			awsConfig.Endpoint = aws.String(endpoint)
+		}
+
+		if useAnonCred, ok := os.LookupEnv(s3credential.AWSAnonymousCredential); ok && strings.ToLower(useAnonCred) == "true" {
+			awsConfig.Credentials = credentials.AnonymousCredentials
+		}
+
+		sess, err = session.NewSession(&awsConfig)
+
+		if err != nil {
+			return nil, err
+		}
+
+		sessionClient := s3.New(sess)
+		providers[S3] = &S3Provider{
+			Client:     sessionClient,
+			Downloader: s3manager.NewDownloaderWithClient(sessionClient, func(d *s3manager.Downloader) {}),
 		}
 	case HTTPS:
 		httpsClient := &http.Client{}

--- a/pkg/credentials/s3/s3_secret.go
+++ b/pkg/credentials/s3/s3_secret.go
@@ -32,6 +32,7 @@ const (
 	S3UseHttps             = "S3_USE_HTTPS"
 	S3VerifySSL            = "S3_VERIFY_SSL"
 	S3UseVirtualBucket     = "S3_USER_VIRTUAL_BUCKET"
+	AWSAnonymousCredential = "awsAnonymousCredential"
 )
 
 type S3Config struct {
@@ -47,6 +48,7 @@ var (
 	InferenceServiceS3SecretSSLAnnotation        = constants.KFServingAPIGroupName + "/" + "s3-verifyssl"
 	InferenceServiceS3SecretHttpsAnnotation      = constants.KFServingAPIGroupName + "/" + "s3-usehttps"
 	InferenceServiceS3UseVirtualBucketAnnotation = constants.KFServingAPIGroupName + "/" + "s3-usevirtualbucket"
+	InferenceServiceS3UseAnonymousCredential     = constants.KFServingAPIGroupName + "/" + "s3-useanoncredential"
 )
 
 func BuildSecretEnvs(secret *v1.Secret, s3Config *S3Config) []v1.EnvVar {
@@ -128,6 +130,13 @@ func BuildSecretEnvs(secret *v1.Secret, s3Config *S3Config) []v1.EnvVar {
 		envs = append(envs, v1.EnvVar{
 			Name:  AWSRegion,
 			Value: s3Region,
+		})
+	}
+
+	if useAnonymousCredential, ok := secret.Annotations[InferenceServiceS3UseAnonymousCredential]; ok {
+		envs = append(envs, v1.EnvVar{
+			Name:  AWSAnonymousCredential,
+			Value: useAnonymousCredential,
 		})
 	}
 

--- a/pkg/credentials/s3/s3_secret_test.go
+++ b/pkg/credentials/s3/s3_secret_test.go
@@ -126,6 +126,54 @@ func TestS3Secret(t *testing.T) {
 			},
 		},
 
+		"S3SecretEnvsWithAnonymousCredentials": {
+			secret: &v1.Secret{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: "s3-secret",
+					Annotations: map[string]string{
+						InferenceServiceS3SecretEndpointAnnotation: "s3.aws.com",
+						InferenceServiceS3UseAnonymousCredential:   "true",
+					},
+				},
+			},
+			expected: []v1.EnvVar{
+				{
+					Name: AWSAccessKeyId,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSAccessKeyIdName,
+						},
+					},
+				},
+				{
+					Name: AWSSecretAccessKey,
+					ValueFrom: &v1.EnvVarSource{
+						SecretKeyRef: &v1.SecretKeySelector{
+							LocalObjectReference: v1.LocalObjectReference{
+								Name: "s3-secret",
+							},
+							Key: AWSSecretAccessKeyName,
+						},
+					},
+				},
+				{
+					Name:  S3Endpoint,
+					Value: "s3.aws.com",
+				},
+				{
+					Name:  AWSEndpointUrl,
+					Value: "https://s3.aws.com",
+				},
+				{
+					Name:  AWSAnonymousCredential,
+					Value: "true",
+				},
+			},
+		},
+
 		"S3Config": {
 			config: S3Config{
 				S3AccessKeyIDName:     "test-keyId",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Adds option to use anonymous credentials for s3 to access public buckets

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
