### PR TITLE
fix(web-app): Fix Grafana detection due to HEAD request

### DIFF
--- a/web-app/frontend/src/app/pages/server-info/server-info.component.ts
+++ b/web-app/frontend/src/app/pages/server-info/server-info.component.ts
@@ -89,14 +89,27 @@ export class ServerInfoComponent implements OnInit, OnDestroy {
     });
 
     // don't show a METRICS tab if Grafana is not exposed
+    console.log('Checking if Grafana endpoint is exposed');
+    const grafanaApi = environment.grafanaPrefix + '/api/search';
+
     this.http
-      .head(environment.grafanaPrefix)
+      .get(grafanaApi)
       .pipe(timeout(1000))
       .subscribe({
-        next: () => {
+        next: resp => {
+          if (!Array.isArray(resp)) {
+            console.log(
+              'Response from the Grafana endpoint was not as expected.',
+            );
+            this.grafanaFound = false;
+            return;
+          }
+
+          console.log('Grafana endpoint detected. Will expose a metrics tab.');
           this.grafanaFound = true;
         },
         error: () => {
+          console.log('Could not detect a Grafana endpoint..');
           this.grafanaFound = false;
         },
       });


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Makes the app's logic for detecting Grafana more robust. Instead of only relying on whether the request failed or the UI should also check if the response is formatted as expected.

This will mitigate the current issue where, in Kubeflow, the Central Dashboard will be returning its own `index.html` for non-matched routes. The Central Dashboard also listens to the root URL `/` and that's why it will return a response for the `/grafana` endpoint as well.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1540

**Special notes for your reviewer**:
In order to test the changes you will have to deploy the app from it's manifests:
1. Checkout the code from #1512, or navigate to `/config` once it gets merged
2. Run `kustomize build config/overlays/kubeflow | kubectl apply -f -`
3. Connect to `$KF_IP/models/`
4. Click on the name of an InferenceService to see its details

At that point you should **not** see the `METRICS` tab in the web app.

/cc @pvaneck @StefanoFioravanzo @tasos-ale
