### PR TITLE
Prevents /mnt/models/<model name> from being converted into a file

### DIFF
--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -62,6 +62,7 @@ func (g *GCSObjectDownloader) Download(client stiface.Client, it stiface.ObjectI
 	var errs []error
 	// flag to help determine if query prefix returned an empty iterator
 	var foundObject = false
+	filePath := filepath.Join(g.ModelDir, g.ModelName)
 	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
@@ -70,9 +71,12 @@ func (g *GCSObjectDownloader) Download(client stiface.Client, it stiface.ObjectI
 		if err != nil {
 			return fmt.Errorf("an error occurred while iterating: %v", err)
 		}
-		foundObject = true
 		objectValue := strings.TrimPrefix(attrs.Name, g.Item)
 		fileName := filepath.Join(g.ModelDir, g.ModelName, objectValue)
+		if fileName == filePath {
+			continue
+		}
+		foundObject = true
 		if FileExists(fileName) {
 			log.Info("Deleting", fileName)
 			if err := os.Remove(fileName); err != nil {

--- a/pkg/agent/storage/s3.go
+++ b/pkg/agent/storage/s3.go
@@ -87,9 +87,15 @@ func (s *S3ObjectDownloader) GetAllObjects(s3Svc s3iface.S3API) ([]s3manager.Bat
 		return nil, fmt.Errorf("%s has no objects or does not exist", s.StorageUri)
 	}
 
+	var foundObject = false
+	filePath := filepath.Join(s.ModelDir, s.ModelName)
+
 	for _, object := range resp.Contents {
 		subObjectKey := strings.TrimPrefix(*object.Key, s.Prefix)
 		fileName := filepath.Join(s.ModelDir, s.ModelName, subObjectKey)
+		if fileName == filePath {
+			continue
+		}
 		if FileExists(fileName) {
 			// File got corrupted or is mid-download :(
 			// TODO: Figure out if we can maybe continue?
@@ -112,8 +118,14 @@ func (s *S3ObjectDownloader) GetAllObjects(s3Svc s3iface.S3API) ([]s3manager.Bat
 				return nil
 			},
 		}
+		foundObject = true
 		results = append(results, object)
 	}
+
+	if !foundObject {
+		return nil, fmt.Errorf("%s has no objects or does not exist", s.StorageUri)
+	}
+
 	return results, nil
 }
 

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -350,11 +350,11 @@ var _ = Describe("Watcher", func() {
 					Fail("Failed to write contents.")
 				}
 				modelName := "model1"
-				modelStorageURI := "gs://testBucket/testModel1"
+				modelStorageURI := "gs://testBucket/"
 				err := cl.DownloadModel(modelDir, modelName, modelStorageURI)
 				Expect(err).To(BeNil())
 
-				testFile := filepath.Join(modelDir, "model1")
+				testFile := filepath.Join(modelDir, modelName, "testModel1")
 				dat, err := ioutil.ReadFile(testFile)
 				Expect(err).To(BeNil())
 				Expect(string(dat)).To(Equal(modelContents))


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: The model directory will be converted into a file whenever the fileName (Model dir, model name, objectName) is equal to the model directory. This will prevent that override from happening.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
