### PR TITLE
Update quick install to use Istio 1.9.0

### DIFF
--- a/hack/quick_install.sh
+++ b/hack/quick_install.sh
@@ -1,8 +1,8 @@
 set -e
 
-export ISTIO_VERSION=1.6.2
+export ISTIO_VERSION=1.9.0
 export KNATIVE_VERSION=v0.18.0
-export KFSERVING_VERSION=v0.5.0
+export KFSERVING_VERSION=v0.5.1
 curl -L https://git.io/getLatestIstio | sh -
 cd istio-${ISTIO_VERSION}
 
@@ -29,18 +29,6 @@ spec:
       # See: https://istio.io/docs/ops/best-practices/security/#configure-third-party-service-account-tokens
       jwtPolicy: first-party-jwt
 
-  addonComponents:
-    pilot:
-      enabled: true
-    tracing:
-      enabled: true
-    kiali:
-      enabled: true
-    prometheus:
-      enabled: true
-    grafana:
-      enabled: true
-
   components:
     ingressGateways:
       - name: istio-ingressgateway
@@ -54,15 +42,18 @@ spec:
           service:
             type: ClusterIP
             ports:
-            - port: 15020
+            - port: 15021
+              targetPort: 15021
               name: status-port
             - port: 80
               name: http2
+              targetPort: 8080
             - port: 443
               name: https
+              targetPort: 8443
 EOF
 
-bin/istioctl manifest apply -f istio-minimal-operator.yaml
+bin/istioctl manifest apply -f istio-minimal-operator.yaml -y
 
 # Install Knative
 kubectl apply --filename https://github.com/knative/serving/releases/download/${KNATIVE_VERSION}/serving-crds.yaml
@@ -74,12 +65,6 @@ kubectl apply --validate=false -f https://github.com/jetstack/cert-manager/relea
 kubectl wait --for=condition=available --timeout=600s deployment/cert-manager-webhook -n cert-manager
 cd ..
 # Install KFServing
-K8S_MINOR=$(kubectl version | perl -ne 'print $1."\n" if /Server Version:.*?Minor:"(\d+)"/')
-if [[ $K8S_MINOR -lt 16 ]]; then
-  kubectl apply -f install/${KFSERVING_VERSION}/kfserving_crds.yaml --validate=false
-else
-  kubectl apply -f install/${KFSERVING_VERSION}/kfserving_crds.yaml
-fi
 kubectl apply -f install/${KFSERVING_VERSION}/kfserving.yaml
 
 # Clean up


### PR DESCRIPTION
Also updated the script to use KFServing v0.5.1.
`addOnComponents` is now deprecated, so this section was removed from the IstioOperator definition.
Tested this on K8s 1.18 on Minikube and OpenShift 4.6