### PR TITLE
Fix explainer_url to use explainer_host

### DIFF
--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/README.md
@@ -98,7 +98,7 @@ and the downloaded artifacts are stored under `/mnt/models`.
 
 Apply the CRD
 ```
-kubectl apply -f image_transformer.yaml
+kubectl apply -f transformer.yaml
 ```
 
 Expected Output

--- a/python/kfserving/kfserving/kfmodel.py
+++ b/python/kfserving/kfserving/kfmodel.py
@@ -128,15 +128,15 @@ class KFModel:
     async def explain(self, request: Dict) -> Dict:
         """
         The explain handler can be overridden to implement the model explanation.
-        The default implementation makes an call to the explainer if predictor_host is specified
+        The default implementation makes an call to the explainer if explainer_host is specified
         :param request: Dict passed from preprocess handler
         :return: Dict
         """
         if self.explainer_host is None:
             raise NotImplementedError
-        explain_url = EXPLAINER_URL_FORMAT.format(self.predictor_host, self.name)
+        explain_url = EXPLAINER_URL_FORMAT.format(self.explainer_host, self.name)
         if self.protocol == "v2":
-            explain_url = EXPLAINER_V2_URL_FORMAT.format(self.predictor_host, self.name)
+            explain_url = EXPLAINER_V2_URL_FORMAT.format(self.explainer_host, self.name)
         response = await self._http_client.fetch(
             url=explain_url,
             method='POST',


### PR DESCRIPTION
Fix a couple of typos
 * explainer_url to use explainer_host insteand predictor_host in
the default/base explain handler
 * yaml file name in readme for the transformer sample

Signed-off-by: Chin Huang <chhuang@us.ibm.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
