### PR TITLE
[Predict Protocol V2] Fix rest_predict_v2.yaml definition

### DIFF
--- a/docs/predict-api/v2/rest_predict_v2.yaml
+++ b/docs/predict-api/v2/rest_predict_v2.yaml
@@ -282,10 +282,9 @@ components:
       items:
         anyOf:
           - $ref: '#/components/schemas/tensor_data'
-          - type:
-              - number
-              - string
-              - boolean
+          - type: number
+          - type: string
+          - type: boolean
     request_output:
       title: request_output
       type: object


### PR DESCRIPTION


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
The item definition of #/components/schemas/tensor_data was invalid anyOf syntax. It now correctly validates with https://apitools.dev/swagger-parser/online/


```release-note
Fixes: rest_predict_v2.yaml now correctly validates
```
