### PR TITLE
accept configmap violation

### DIFF
--- a/hack/violation_exceptions.list
+++ b/hack/violation_exceptions.list
@@ -9,6 +9,7 @@ API rule violation: list_type_missing,./pkg/apis/serving/v1beta1,PodSpec,InitCon
 API rule violation: list_type_missing,./pkg/apis/serving/v1beta1,PodSpec,ReadinessGates
 API rule violation: list_type_missing,./pkg/apis/serving/v1beta1,PodSpec,Tolerations
 API rule violation: list_type_missing,./pkg/apis/serving/v1beta1,PodSpec,Volumes
+API rule violation: list_type_missing,./pkg/apis/serving/v1beta1,PredictorConfig,SupportedFrameworks
 API rule violation: names_match,./pkg/apis/serving/v1alpha1,ModelSpec,StorageURI
 API rule violation: names_match,./pkg/apis/serving/v1beta1,AlibiExplainerSpec,StorageURI
 API rule violation: names_match,./pkg/apis/serving/v1beta1,ComponentExtensionSpec,TimeoutSeconds


### PR DESCRIPTION
**What this PR does / why we need it**:
Accept violation of PredictorConfig.SupportedFrameworks' list type (introduced by #1413) to fix the openapi generator error

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1565