### PR TITLE
add logger in explainer and transformer

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/components/component.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/component.go
@@ -39,19 +39,6 @@ func addLoggerAnnotations(logger *v1beta1.LoggerSpec, annotations map[string]str
 	return false
 }
 
-func addLoggerContainerPort(container *v1.Container) {
-	if container != nil {
-		if container.Ports == nil || len(container.Ports) == 0 {
-			port, _ := strconv.Atoi(constants.InferenceServiceDefaultAgentPort)
-			container.Ports = []v1.ContainerPort{
-				{
-					ContainerPort: int32(port),
-				},
-			}
-		}
-	}
-}
-
 func addBatcherAnnotations(batcher *v1beta1.Batcher, annotations map[string]string) bool {
 	if batcher != nil {
 		annotations[constants.BatcherInternalAnnotationKey] = "true"
@@ -73,19 +60,6 @@ func addBatcherAnnotations(batcher *v1beta1.Batcher, annotations map[string]stri
 	return false
 }
 
-func addBatcherContainerPort(container *v1.Container) {
-	if container != nil {
-		if container.Ports == nil || len(container.Ports) == 0 {
-			port, _ := strconv.Atoi(constants.InferenceServiceDefaultAgentPort)
-			container.Ports = []v1.ContainerPort{
-				{
-					ContainerPort: int32(port),
-				},
-			}
-		}
-	}
-}
-
 func addAgentAnnotations(isvc *v1beta1.InferenceService, annotations map[string]string, isvcConfig *v1beta1.InferenceServicesConfig) bool {
 	if v1beta1utils.IsMMSPredictor(&isvc.Spec.Predictor, isvcConfig) {
 		annotations[constants.AgentShouldInjectAnnotationKey] = "true"
@@ -99,4 +73,17 @@ func addAgentAnnotations(isvc *v1beta1.InferenceService, annotations map[string]
 		return true
 	}
 	return false
+}
+
+func addAgentContainerPort(container *v1.Container) {
+	if container != nil {
+		if container.Ports == nil || len(container.Ports) == 0 {
+			port, _ := strconv.Atoi(constants.InferenceServiceDefaultAgentPort)
+			container.Ports = []v1.ContainerPort{
+				{
+					ContainerPort: int32(port),
+				},
+			}
+		}
+	}
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/component.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/component.go
@@ -13,9 +13,90 @@ limitations under the License.
 
 package components
 
-import "github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
+import (
+	"github.com/kubeflow/kfserving/pkg/apis/serving/v1beta1"
+	"github.com/kubeflow/kfserving/pkg/constants"
+	"github.com/kubeflow/kfserving/pkg/controller/v1alpha1/trainedmodel/sharding/memory"
+	v1beta1utils "github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/utils"
+	v1 "k8s.io/api/core/v1"
+	"strconv"
+)
 
 // Component can be reconciled to create underlying resources for an InferenceService
 type Component interface {
 	Reconcile(isvc *v1beta1.InferenceService) error
+}
+
+func addLoggerAnnotations(logger *v1beta1.LoggerSpec, annotations map[string]string) bool {
+	if logger != nil {
+		annotations[constants.LoggerInternalAnnotationKey] = "true"
+		if logger.URL != nil {
+			annotations[constants.LoggerSinkUrlInternalAnnotationKey] = *logger.URL
+		}
+		annotations[constants.LoggerModeInternalAnnotationKey] = string(logger.Mode)
+		return true
+	}
+	return false
+}
+
+func addLoggerContainerPort(container *v1.Container) {
+	if container != nil {
+		if container.Ports == nil || len(container.Ports) == 0 {
+			port, _ := strconv.Atoi(constants.InferenceServiceDefaultAgentPort)
+			container.Ports = []v1.ContainerPort{
+				{
+					ContainerPort: int32(port),
+				},
+			}
+		}
+	}
+}
+
+func addBatcherAnnotations(batcher *v1beta1.Batcher, annotations map[string]string) bool {
+	if batcher != nil {
+		annotations[constants.BatcherInternalAnnotationKey] = "true"
+
+		if batcher.MaxBatchSize != nil {
+			s := strconv.Itoa(*batcher.MaxBatchSize)
+			annotations[constants.BatcherMaxBatchSizeInternalAnnotationKey] = s
+		}
+		if batcher.MaxLatency != nil {
+			s := strconv.Itoa(*batcher.MaxLatency)
+			annotations[constants.BatcherMaxLatencyInternalAnnotationKey] = s
+		}
+		if batcher.Timeout != nil {
+			s := strconv.Itoa(*batcher.Timeout)
+			annotations[constants.BatcherTimeoutInternalAnnotationKey] = s
+		}
+		return true
+	}
+	return false
+}
+
+func addBatcherContainerPort(container *v1.Container) {
+	if container != nil {
+		if container.Ports == nil || len(container.Ports) == 0 {
+			port, _ := strconv.Atoi(constants.InferenceServiceDefaultAgentPort)
+			container.Ports = []v1.ContainerPort{
+				{
+					ContainerPort: int32(port),
+				},
+			}
+		}
+	}
+}
+
+func addAgentAnnotations(isvc *v1beta1.InferenceService, annotations map[string]string, isvcConfig *v1beta1.InferenceServicesConfig) bool {
+	if v1beta1utils.IsMMSPredictor(&isvc.Spec.Predictor, isvcConfig) {
+		annotations[constants.AgentShouldInjectAnnotationKey] = "true"
+		shardStrategy := memory.MemoryStrategy{}
+		for _, id := range shardStrategy.GetShard(isvc) {
+			multiModelConfigMapName := constants.ModelConfigName(isvc.Name, id)
+			annotations[constants.AgentModelConfigVolumeNameAnnotationKey] = multiModelConfigMapName
+			annotations[constants.AgentModelConfigMountPathAnnotationKey] = constants.ModelConfigDir
+			annotations[constants.AgentModelDirAnnotationKey] = constants.ModelDir
+		}
+		return true
+	}
+	return false
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -62,6 +62,7 @@ func (p *Explainer) Reconcile(isvc *v1beta1.InferenceService) error {
 	if sourceURI := explainer.GetStorageUri(); sourceURI != nil {
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
 	}
+	hasInferenceLogging := addLoggerAnnotations(isvc.Spec.Explainer.Logger, annotations)
 	objectMeta := metav1.ObjectMeta{
 		Name:      constants.DefaultExplainerServiceName(isvc.Name),
 		Namespace: isvc.Namespace,
@@ -81,6 +82,9 @@ func (p *Explainer) Reconcile(isvc *v1beta1.InferenceService) error {
 	} else {
 		container := explainer.GetContainer(isvc.ObjectMeta, isvc.Spec.Explainer.GetExtensions(), p.inferenceServiceConfig)
 		isvc.Spec.Explainer.PodSpec.Containers[0] = *container
+	}
+	if hasInferenceLogging {
+		addLoggerContainerPort(&isvc.Spec.Explainer.PodSpec.Containers[0])
 	}
 
 	podSpec := v1.PodSpec(isvc.Spec.Explainer.PodSpec)

--- a/pkg/controller/v1beta1/inferenceservice/components/explainer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/explainer.go
@@ -84,7 +84,7 @@ func (p *Explainer) Reconcile(isvc *v1beta1.InferenceService) error {
 		isvc.Spec.Explainer.PodSpec.Containers[0] = *container
 	}
 	if hasInferenceLogging {
-		addLoggerContainerPort(&isvc.Spec.Explainer.PodSpec.Containers[0])
+		addAgentContainerPort(&isvc.Spec.Explainer.PodSpec.Containers[0])
 	}
 
 	podSpec := v1.PodSpec(isvc.Spec.Explainer.PodSpec)

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -14,14 +14,10 @@ limitations under the License.
 package components
 
 import (
-	"strconv"
-
 	"github.com/go-logr/logr"
 	"github.com/kubeflow/kfserving/pkg/constants"
-	"github.com/kubeflow/kfserving/pkg/controller/v1alpha1/trainedmodel/sharding/memory"
 	"github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/reconcilers/knative"
 	modelconfig "github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/reconcilers/modelconfig"
-	v1beta1utils "github.com/kubeflow/kfserving/pkg/controller/v1beta1/inferenceservice/utils"
 	"github.com/kubeflow/kfserving/pkg/credentials"
 	"github.com/kubeflow/kfserving/pkg/utils"
 	"github.com/pkg/errors"
@@ -120,78 +116,4 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) error {
 	}
 	isvc.Status.PropagateStatus(v1beta1.PredictorComponent, status)
 	return nil
-}
-
-func addLoggerAnnotations(logger *v1beta1.LoggerSpec, annotations map[string]string) bool {
-	if logger != nil {
-		annotations[constants.LoggerInternalAnnotationKey] = "true"
-		if logger.URL != nil {
-			annotations[constants.LoggerSinkUrlInternalAnnotationKey] = *logger.URL
-		}
-		annotations[constants.LoggerModeInternalAnnotationKey] = string(logger.Mode)
-		return true
-	}
-	return false
-}
-
-func addLoggerContainerPort(container *v1.Container) {
-	if container != nil {
-		if container.Ports == nil || len(container.Ports) == 0 {
-			port, _ := strconv.Atoi(constants.InferenceServiceDefaultAgentPort)
-			container.Ports = []v1.ContainerPort{
-				{
-					ContainerPort: int32(port),
-				},
-			}
-		}
-	}
-}
-
-func addBatcherAnnotations(batcher *v1beta1.Batcher, annotations map[string]string) bool {
-	if batcher != nil {
-		annotations[constants.BatcherInternalAnnotationKey] = "true"
-
-		if batcher.MaxBatchSize != nil {
-			s := strconv.Itoa(*batcher.MaxBatchSize)
-			annotations[constants.BatcherMaxBatchSizeInternalAnnotationKey] = s
-		}
-		if batcher.MaxLatency != nil {
-			s := strconv.Itoa(*batcher.MaxLatency)
-			annotations[constants.BatcherMaxLatencyInternalAnnotationKey] = s
-		}
-		if batcher.Timeout != nil {
-			s := strconv.Itoa(*batcher.Timeout)
-			annotations[constants.BatcherTimeoutInternalAnnotationKey] = s
-		}
-		return true
-	}
-	return false
-}
-
-func addBatcherContainerPort(container *v1.Container) {
-	if container != nil {
-		if container.Ports == nil || len(container.Ports) == 0 {
-			port, _ := strconv.Atoi(constants.InferenceServiceDefaultAgentPort)
-			container.Ports = []v1.ContainerPort{
-				{
-					ContainerPort: int32(port),
-				},
-			}
-		}
-	}
-}
-
-func addAgentAnnotations(isvc *v1beta1.InferenceService, annotations map[string]string, isvcConfig *v1beta1.InferenceServicesConfig) bool {
-	if v1beta1utils.IsMMSPredictor(&isvc.Spec.Predictor, isvcConfig) {
-		annotations[constants.AgentShouldInjectAnnotationKey] = "true"
-		shardStrategy := memory.MemoryStrategy{}
-		for _, id := range shardStrategy.GetShard(isvc) {
-			multiModelConfigMapName := constants.ModelConfigName(isvc.Name, id)
-			annotations[constants.AgentModelConfigVolumeNameAnnotationKey] = multiModelConfigMapName
-			annotations[constants.AgentModelConfigMountPathAnnotationKey] = constants.ModelConfigDir
-			annotations[constants.AgentModelDirAnnotationKey] = constants.ModelDir
-		}
-		return true
-	}
-	return false
 }

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -87,12 +87,8 @@ func (p *Predictor) Reconcile(isvc *v1beta1.InferenceService) error {
 	}
 	//TODO now knative supports multi containers, consolidate logger/batcher/puller to the sidecar container
 	//https://github.com/kubeflow/kfserving/issues/973
-	if hasInferenceLogging {
-		addLoggerContainerPort(&isvc.Spec.Predictor.PodSpec.Containers[0])
-	}
-
-	if hasInferenceBatcher {
-		addBatcherContainerPort(&isvc.Spec.Predictor.PodSpec.Containers[0])
+	if hasInferenceLogging || hasInferenceBatcher {
+		addAgentContainerPort(&isvc.Spec.Predictor.PodSpec.Containers[0])
 	}
 
 	podSpec := v1.PodSpec(isvc.Spec.Predictor.PodSpec)

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -62,6 +62,8 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 	if sourceURI := transformer.GetStorageUri(); sourceURI != nil {
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
 	}
+	hasInferenceLogging := addLoggerAnnotations(isvc.Spec.Transformer.Logger, annotations)
+
 	objectMeta := metav1.ObjectMeta{
 		Name:      constants.DefaultTransformerServiceName(isvc.Name),
 		Namespace: isvc.Namespace,
@@ -83,6 +85,9 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 		isvc.Spec.Transformer.PodSpec.Containers[0] = *container
 	}
 
+	if hasInferenceLogging {
+		addLoggerContainerPort(&isvc.Spec.Transformer.PodSpec.Containers[0])
+	}
 	podSpec := corev1.PodSpec(isvc.Spec.Transformer.PodSpec)
 	r := knative.NewKsvcReconciler(p.client, p.scheme, objectMeta, &isvc.Spec.Transformer.ComponentExtensionSpec,
 		&podSpec, isvc.Status.Components[v1beta1.TransformerComponent])

--- a/pkg/controller/v1beta1/inferenceservice/components/transformer.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/transformer.go
@@ -63,6 +63,7 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 		annotations[constants.StorageInitializerSourceUriInternalAnnotationKey] = *sourceURI
 	}
 	hasInferenceLogging := addLoggerAnnotations(isvc.Spec.Transformer.Logger, annotations)
+	hasInferenceBatcher := addBatcherAnnotations(isvc.Spec.Transformer.Batcher, annotations)
 
 	objectMeta := metav1.ObjectMeta{
 		Name:      constants.DefaultTransformerServiceName(isvc.Name),
@@ -85,8 +86,8 @@ func (p *Transformer) Reconcile(isvc *v1beta1.InferenceService) error {
 		isvc.Spec.Transformer.PodSpec.Containers[0] = *container
 	}
 
-	if hasInferenceLogging {
-		addLoggerContainerPort(&isvc.Spec.Transformer.PodSpec.Containers[0])
+	if hasInferenceLogging || hasInferenceBatcher {
+		addAgentContainerPort(&isvc.Spec.Transformer.PodSpec.Containers[0])
 	}
 	podSpec := corev1.PodSpec(isvc.Spec.Transformer.PodSpec)
 	r := knative.NewKsvcReconciler(p.client, p.scheme, objectMeta, &isvc.Spec.Transformer.ComponentExtensionSpec,


### PR DESCRIPTION
**What this PR does / why we need it**:
Adds the logging functionality in explainer, by adding annotations for logger in the reconciler of the explainer, similarly to the predictor logger.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1404

**Special notes for your reviewer**:
Test results:
```
$ curl -H 'Host: german-credit.default.example.com' -H 'Content-type: application/json' -d@./input.json http://172.18.255.200/v1/models/german-credit:explain 
{"predictions": [1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 2.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0, 1.0], "metrics": {"base_rate": 0.9230769230769231, "consistency": [0.9871794871794872], "disparate_impact": 0.45454545454545453, "num_instances": 78.0, "num_negatives": 6.0, "num_positives": 72.0, "statistical_parity_difference": -0.5454545454545454}}
```

```
$ kubectl logs message-dumper-00001-deployment-5764b464c5-trr9f --tail 12 -c user-container
    "metrics": {
      "base_rate": 0.9230769230769231,
      "consistency": [
        0.9871794871794872
      ],
      "disparate_impact": 0.45454545454545453,
      "num_instances": 78.0,
      "num_negatives": 6.0,
      "num_positives": 72.0,
      "statistical_parity_difference": -0.5454545454545454
    }
  }
```



1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Logging capability on explainers
```
