### PR TITLE
Increase timeout for tabular explainer e2e test

### DIFF
--- a/test/e2e/explainer/test_tabular_explainer.py
+++ b/test/e2e/explainer/test_tabular_explainer.py
@@ -62,7 +62,7 @@ def test_tabular_explainer():
 
     KFServing.create(isvc)
     try:
-        KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE, timeout_seconds=300)
+        KFServing.wait_isvc_ready(service_name, namespace=KFSERVING_TEST_NAMESPACE, timeout_seconds=720)
     except RuntimeError as e:
         logging.info(KFServing.api_instance.get_namespaced_custom_object("serving.knative.dev", "v1",
                                                                          KFSERVING_TEST_NAMESPACE, "services",


### PR DESCRIPTION
This should hopefully reduce the number of timeout failures during CI.
Closes: #1594
/cc @yuzisun 