### PR TITLE
Fix warnings for deprecated apis with kube 1.16+

### DIFF
--- a/python/custom_model/model_remote.py
+++ b/python/custom_model/model_remote.py
@@ -9,7 +9,7 @@ from ray import serve
 
 
 # the model handle name should match the model endpoint name
-@serve.deployment(name="custom-model", config={"num_replicas": 2})
+@serve.deployment(name="custom-model", num_replicas=2)
 class AlexNetModel(kfserving.KFModel):
     def __init__(self):
         self.name = "custom-model"

--- a/python/kfserving/kfserving/kfserver.py
+++ b/python/kfserving/kfserving/kfserver.py
@@ -103,7 +103,7 @@ class KFServer:
                 else:
                     raise RuntimeError("Model type should be KFModel")
         elif isinstance(models, dict):
-            if all([issubclass(v, Deployment) for v in models.values()]):
+            if all([isinstance(v, Deployment) for v in models.values()]):
                 serve.start(detached=True, http_host='0.0.0.0', http_port=9071)
                 for key in models:
                     models[key].deploy()


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1591 

**Special notes for your reviewer**:

1. Fix deprecated api group for validating/mutating webhooks
2. Fix deprecated format for istio gateway resource

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
