### PR TITLE
Corrected links to Iter8 KFServing extensions

### DIFF
--- a/README.md
+++ b/README.md
@@ -243,7 +243,7 @@ Error Set:
 
 ### Setup Monitoring
 - [Prometheus based monitoring for KFServing](https://github.com/kubeflow/kfserving/blob/master/docs/samples/metrics-and-monitoring/README.md#install-prometheus)
-- [Metrics driven automated rollouts using Iter8](https://github.com/kubeflow/kfserving/blob/master/docs/samples/metrics-and-monitoring/README.md#metrics-driven-experiments-and-progressive-delivery)
+- [Metrics driven automated rollouts using Iter8](https://iter8.tools)
 - [Dashboard for ServiceMesh](https://istio.io/latest/docs/tasks/observability/kiali/)
 
 ### Use KFServing SDK

--- a/docs/samples/metrics-and-monitoring/README.md
+++ b/docs/samples/metrics-and-monitoring/README.md
@@ -67,7 +67,7 @@ You should see a response similar to the following.
 ![Request count](requestlatency.png)
 
 ## Metrics-driven experiments and progressive delivery
-See [iter8-kfserving](https://github.com/iter8-tools/iter8-kfserving).
+See [Iter8 extensions for kfserving](https://iter8.tools).
 
 ## Removal
 Remove Prometheus and Prometheus Operator as follows.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

This PR fixes a documentation bug in KFServing (outdated links to Iter8)

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1631 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Links to Iter8 extensions that support live experiments and progressive delivery for KFServing models
```
