### PR TITLE
Fix broken url

### DIFF
--- a/docs/samples/v1beta1/sklearn/v2/README.md
+++ b/docs/samples/v1beta1/sklearn/v2/README.md
@@ -5,7 +5,7 @@ the `v1beta1` version of the `InferenceService` CRD.
 Note that, by default the `v1beta1` version will expose your model through an
 API compatible with the existing V1 Dataplane.
 However, this example will show you how to serve a model through an API
-compatible with the new [V2 Dataplane](../../../predict-api/v2).
+compatible with the new [V2 Dataplane](https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2).
 
 ## Training
 
@@ -121,7 +121,7 @@ kubectl apply -f ./sklearn.yaml
 We can now test our deployed model by sending a sample request.
 
 Note that this request **needs to follow the [V2 Dataplane
-protocol](../../../predict-api/v2)**.
+protocol](https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2)**.
 You can see an example payload below:
 
 ```json


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

The url to the V2 dataplane in [this doc](https://github.com/kubeflow/kfserving/tree/master/docs/samples/v1beta1/sklearn/v2) point to this outdated url https://github.com/kubeflow/kfserving/blob/master/docs/samples/predict-api/v2
Change to https://github.com/kubeflow/kfserving/tree/master/docs/predict-api/v2

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1634 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
