### PR TITLE
add the component label in payload logging

### DIFF
--- a/cmd/agent/main.go
+++ b/cmd/agent/main.go
@@ -46,6 +46,7 @@ var (
 	inferenceService = flag.String("inference-service", "", "The InferenceService name to add as header to log events")
 	namespace        = flag.String("namespace", "", "The namespace to add as header to log events")
 	endpoint         = flag.String("endpoint", "", "The endpoint name to add as header to log events")
+	component        = flag.String("component", "", "The component name (predictor, explainer, transformer) to add as header to log events")
 	// batcher flags
 	enableBatcher = flag.Bool("enable-batcher", false, "Enable request batcher")
 	maxBatchSize  = flag.String("max-batchsize", "32", "Max Batch Size")
@@ -77,6 +78,7 @@ type loggerArgs struct {
 	inferenceService string
 	namespace        string
 	endpoint         string
+	component        string
 }
 
 type batcherArgs struct {
@@ -272,6 +274,7 @@ func startLogger(workers int, logger *zap.SugaredLogger) *loggerArgs {
 		inferenceService: *inferenceService,
 		endpoint:         *endpoint,
 		namespace:        *namespace,
+		component:        *component,
 	}
 }
 
@@ -325,7 +328,7 @@ func buildServer(ctx context.Context, port string, userPort string, loggerArgs *
 	}
 	if loggerArgs != nil {
 		composedHandler = kfslogger.New(loggerArgs.logUrl, loggerArgs.sourceUrl, loggerArgs.loggerType,
-			loggerArgs.inferenceService, loggerArgs.namespace, loggerArgs.endpoint, composedHandler)
+			loggerArgs.inferenceService, loggerArgs.namespace, loggerArgs.endpoint, loggerArgs.component, composedHandler)
 	}
 
 	composedHandler = queue.ForwardedShimHandler(composedHandler)

--- a/pkg/logger/handler.go
+++ b/pkg/logger/handler.go
@@ -38,12 +38,13 @@ type LoggerHandler struct {
 	logMode          v1beta1.LoggerType
 	inferenceService string
 	namespace        string
+	component        string
 	endpoint         string
 	next             http.Handler
 }
 
 func New(logUrl *url.URL, sourceUri *url.URL, logMode v1beta1.LoggerType,
-	inferenceService string, namespace string, endpoint string, next http.Handler) http.Handler {
+	inferenceService string, namespace string, endpoint string, component string, next http.Handler) http.Handler {
 	logf.SetLogger(zap.New())
 	return &LoggerHandler{
 		log:              logf.Log.WithName("Logger"),
@@ -52,6 +53,7 @@ func New(logUrl *url.URL, sourceUri *url.URL, logMode v1beta1.LoggerType,
 		logMode:          logMode,
 		inferenceService: inferenceService,
 		namespace:        namespace,
+		component:        component,
 		endpoint:         endpoint,
 		next:             next,
 	}
@@ -95,6 +97,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			InferenceService: eh.inferenceService,
 			Namespace:        eh.namespace,
 			Endpoint:         eh.endpoint,
+			Component:        eh.component,
 		}); err != nil {
 			eh.log.Error(err, "Failed to log request")
 		}
@@ -122,6 +125,7 @@ func (eh *LoggerHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 				InferenceService: eh.inferenceService,
 				Namespace:        eh.namespace,
 				Endpoint:         eh.endpoint,
+				Component:        eh.component,
 			}); err != nil {
 				eh.log.Error(err, "Failed to log response")
 			}

--- a/pkg/logger/handler_test.go
+++ b/pkg/logger/handler_test.go
@@ -78,7 +78,7 @@ func TestLogger(t *testing.T) {
 
 	StartDispatcher(5, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
-	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", httpProxy)
+	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", "default", httpProxy)
 
 	oh.ServeHTTP(w, r)
 
@@ -121,7 +121,7 @@ func TestBadResponse(t *testing.T) {
 
 	StartDispatcher(1, logger)
 	httpProxy := httputil.NewSingleHostReverseProxy(targetUri)
-	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", httpProxy)
+	oh := New(logSvcUrl, sourceUri, v1beta1.LogAll, "mymodel", "default", "default", "default", httpProxy)
 
 	oh.ServeHTTP(w, r)
 	g.Expect(w.Code).To(gomega.Equal(400))

--- a/pkg/logger/types.go
+++ b/pkg/logger/types.go
@@ -36,5 +36,6 @@ type LogRequest struct {
 	SourceUri        *url.URL
 	InferenceService string
 	Namespace        string
+	Component        string
 	Endpoint         string
 }

--- a/pkg/logger/worker.go
+++ b/pkg/logger/worker.go
@@ -34,6 +34,7 @@ const (
 	//TODO: ideally request id would have its own header but make do with ce-id for now
 	InferenceServiceAttr = "inferenceservicename"
 	NamespaceAttr        = "namespace"
+	ComponentAttr        = "component"
 	//endpoint would be either default or canary
 	EndpointAttr = "endpoint"
 
@@ -104,6 +105,7 @@ func (w *Worker) sendCloudEvent(logReq LogRequest) error {
 
 	event.SetExtension(InferenceServiceAttr, logReq.InferenceService)
 	event.SetExtension(NamespaceAttr, logReq.Namespace)
+	event.SetExtension(ComponentAttr, logReq.Component)
 	event.SetExtension(EndpointAttr, logReq.Endpoint)
 
 	event.SetSource(logReq.SourceUri.String())

--- a/pkg/webhook/admission/pod/agent_injector.go
+++ b/pkg/webhook/admission/pod/agent_injector.go
@@ -35,6 +35,7 @@ const (
 	LoggerArgumentInferenceService = "--inference-service"
 	LoggerArgumentNamespace        = "--namespace"
 	LoggerArgumentEndpoint         = "--endpoint"
+	LoggerArgumentComponent        = "--component"
 )
 
 type AgentConfig struct {
@@ -174,6 +175,7 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 		inferenceServiceName, _ := pod.ObjectMeta.Labels[constants.InferenceServiceLabel]
 		namespace := pod.ObjectMeta.Namespace
 		endpoint := pod.ObjectMeta.Labels[constants.KServiceEndpointLabel]
+		component := pod.ObjectMeta.Labels[constants.KServiceComponentLabel]
 
 		loggerArgs := []string{
 			LoggerArgumentLogUrl,
@@ -188,6 +190,8 @@ func (ag *AgentInjector) InjectAgent(pod *v1.Pod) error {
 			namespace,
 			LoggerArgumentEndpoint,
 			endpoint,
+			LoggerArgumentComponent,
+			component,
 		}
 		args = append(args, loggerArgs...)
 	}

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -233,7 +233,7 @@ func TestAgentInjector(t *testing.T) {
 								LoggerArgumentEndpoint,
 								"default",
 								LoggerArgumentComponent,
-								"default",
+								"predictor",
 							},
 							Env:       []v1.EnvVar{},
 							Resources: agentResourceRequirement,

--- a/pkg/webhook/admission/pod/agent_injector_test.go
+++ b/pkg/webhook/admission/pod/agent_injector_test.go
@@ -232,6 +232,8 @@ func TestAgentInjector(t *testing.T) {
 								"default",
 								LoggerArgumentEndpoint,
 								"default",
+								LoggerArgumentComponent,
+								"default",
 							},
 							Env:       []v1.EnvVar{},
 							Resources: agentResourceRequirement,


### PR DESCRIPTION
Signed-off-by: Theofilos Papapanagiotou <theofilos@gmail.com>

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
Adds the `component` label (predictor, transformer, explainer) in the cloudevent extension so we can tell the source of the payload logging event.

**Special notes for your reviewer**:
This is a follow-up on #1597

Two example cloudevent inference requests, one as seen in the `component: transformer` with the base64 payload and one as seen in the `component: predictor` with the npy array as a list in json:
```
☁️  cloudevents.Event
Validation: valid
Context Attributes,
  specversion: 1.0
  type: org.kubeflow.serving.inference.request
  source: http://localhost:9081/
  id: 9e4163ad-f543-427e-bfed-5a122cf41bab
  time: 2021-05-29T22:23:58.461696863Z
  datacontenttype: application/json
Extensions,
  component: transformer
  endpoint: 
  inferenceservicename: torchserve-transformer
  namespace: default
  traceparent: 00-4d804dc930b9ebfc656cc5362a296541-1d517e071e0b6b56-00
Data,
  {
    "instances": [
      {
        "data": "iVBORw0KGgoAAAANSUhEUgAAABwAAAA...

☁️  cloudevents.Event
Validation: valid
Context Attributes,
  specversion: 1.0
  type: org.kubeflow.serving.inference.request
  source: http://localhost:9081/
  id: f9759e95-4c66-4dab-84c4-e5b3de5d78a6
  time: 2021-05-29T22:23:58.61429954Z
  datacontenttype: application/x-www-form-urlencoded
Extensions,
  component: predictor
  endpoint: 
  inferenceservicename: torchserve-transformer
  namespace: default
  traceparent: 00-d4471356e1556d35f6e46648cb8d8a88-0502aa4468501d1d-00
Data,
  {"instances": [{"data": [[[-0.4242129623889923, -0.4242129623889923, ...
```

Introducing the `component` extension instead of changing the cloudevent `type` to avoid the introduction of a breaking change.

Eventually we need to discuss and agree on a new event `type` format, that carries the component in it. Such a way, the user will be able to filter only the [knative EventType](https://knative.dev/docs/eventing/event-registry/) they want for further processing.