### PR TITLE
ingress reconciler compability with istio 1.10

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller_test.go
@@ -253,18 +253,18 @@ var _ = Describe("v1beta1 inference service controller", func() {
 							},
 							Route: []*istiov1alpha3.HTTPRouteDestination{
 								{
-									Headers: &istiov1alpha3.Headers{
-										Request: &istiov1alpha3.Headers_HeaderOperations{
-											Set: map[string]string{
-												"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace),
-											},
-										},
-									},
 									Destination: &istiov1alpha3.Destination{
 										Host: network.GetServiceHostname("knative-local-gateway", "istio-system"),
 										Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort},
 									},
 									Weight: 100,
+								},
+							},
+							Headers: &istiov1alpha3.Headers{
+								Request: &istiov1alpha3.Headers_HeaderOperations{
+									Set: map[string]string{
+										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceKey.Name), serviceKey.Namespace),
+									},
 								},
 							},
 						},

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -159,17 +159,11 @@ func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceServ
 	}
 
 	return nil
+	return nil
 }
 
 func createHTTPRouteDestination(targetHost, namespace string, gatewayService string) *istiov1alpha3.HTTPRouteDestination {
 	httpRouteDestination := &istiov1alpha3.HTTPRouteDestination{
-		Headers: &istiov1alpha3.Headers{
-			Request: &istiov1alpha3.Headers_HeaderOperations{
-				Set: map[string]string{
-					"Host": network.GetServiceHostname(targetHost, namespace),
-				},
-			},
-		},
 		Destination: &istiov1alpha3.Destination{
 			Host: gatewayService,
 			Port: &istiov1alpha3.PortSelector{
@@ -269,6 +263,13 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 			Route: []*istiov1alpha3.HTTPRouteDestination{
 				createHTTPRouteDestination(constants.DefaultExplainerServiceName(isvc.Name), isvc.Namespace, config.LocalGatewayServiceName),
 			},
+			Headers: &istiov1alpha3.Headers{
+				Request: &istiov1alpha3.Headers_HeaderOperations{
+					Set: map[string]string{
+						"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(isvc.Name), isvc.Namespace),
+					},
+				},
+			},
 		}
 		httpRoutes = append(httpRoutes, &explainerRouter)
 	}
@@ -278,6 +279,13 @@ func createIngress(isvc *v1beta1.InferenceService, config *v1beta1.IngressConfig
 			network.GetServiceHostname(isvc.Name, isvc.Namespace), isInternal, config),
 		Route: []*istiov1alpha3.HTTPRouteDestination{
 			createHTTPRouteDestination(backend, isvc.Namespace, config.LocalGatewayServiceName),
+		},
+		Headers: &istiov1alpha3.Headers{
+			Request: &istiov1alpha3.Headers_HeaderOperations{
+				Set: map[string]string{
+					"Host": network.GetServiceHostname(backend, isvc.Namespace),
+				},
+			},
 		},
 	})
 	hosts := []string{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler.go
@@ -159,7 +159,6 @@ func (r *IngressReconciler) reconcileExternalService(isvc *v1beta1.InferenceServ
 	}
 
 	return nil
-	return nil
 }
 
 func createHTTPRouteDestination(targetHost, namespace string, gatewayService string) *istiov1alpha3.HTTPRouteDestination {

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/ingress_reconciler_test.go
@@ -114,11 +114,11 @@ func TestCreateVirtualService(t *testing.T) {
 							{
 								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
 								Weight:      100,
-								Headers: &istiov1alpha3.Headers{
-									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
-								},
 							},
+						},
+						Headers: &istiov1alpha3.Headers{
+							Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+								"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
 						},
 					},
 				},
@@ -171,11 +171,11 @@ func TestCreateVirtualService(t *testing.T) {
 							{
 								Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
 								Weight:      100,
-								Headers: &istiov1alpha3.Headers{
-									Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-										"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
-								},
 							},
+						},
+						Headers: &istiov1alpha3.Headers{
+							Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+								"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)}},
 						},
 					},
 				},
@@ -256,12 +256,12 @@ func TestCreateVirtualService(t *testing.T) {
 								{
 									Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
-									Headers: &istiov1alpha3.Headers{
-										Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-											"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
-										}},
-									},
 								},
+							},
+							Headers: &istiov1alpha3.Headers{
+								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+									"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+								}},
 							},
 						},
 					},
@@ -321,12 +321,12 @@ func TestCreateVirtualService(t *testing.T) {
 								{
 									Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
-									Headers: &istiov1alpha3.Headers{
-										Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-											"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
-										}},
-									},
 								},
+							},
+							Headers: &istiov1alpha3.Headers{
+								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+									"Host": network.GetServiceHostname(constants.DefaultTransformerServiceName(serviceName), namespace),
+								}},
 							},
 						},
 					},
@@ -433,11 +433,11 @@ func TestCreateVirtualService(t *testing.T) {
 								{
 									Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
-									Headers: &istiov1alpha3.Headers{
-										Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-											"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(serviceName), namespace)},
-										},
-									},
+								},
+							},
+							Headers: &istiov1alpha3.Headers{
+								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+									"Host": network.GetServiceHostname(constants.DefaultExplainerServiceName(serviceName), namespace)},
 								},
 							},
 						},
@@ -447,11 +447,11 @@ func TestCreateVirtualService(t *testing.T) {
 								{
 									Destination: &istiov1alpha3.Destination{Host: constants.LocalGatewayHost, Port: &istiov1alpha3.PortSelector{Number: constants.CommonDefaultHttpPort}},
 									Weight:      100,
-									Headers: &istiov1alpha3.Headers{
-										Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
-											"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)},
-										},
-									},
+								},
+							},
+							Headers: &istiov1alpha3.Headers{
+								Request: &istiov1alpha3.Headers_HeaderOperations{Set: map[string]string{
+									"Host": network.GetServiceHostname(constants.DefaultPredictorServiceName(serviceName), namespace)},
 								},
 							},
 						},


### PR DESCRIPTION
Signed-off-by: Theofilos Papapanagiotou <theofilos@gmail.com>

**What this PR does / why we need it**:
Makes the ingress reconciler compatible with Istio 1.10.

By moving the host header rewrite of the main istio virtualservice from the HTTPRouteDestination to the HTTPRoute.

**Which issue(s) this PR fixes**:
Fixes #1643

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Support for Istio 1.10
```
