### PR TITLE
Improvements to self-signed-ca.sh

### DIFF
--- a/hack/self-signed-ca.sh
+++ b/hack/self-signed-ca.sh
@@ -150,3 +150,9 @@ validatingPatchString=$(echo ${validatingPatchString} | sed "s|{{CA_BUNDLE}}|${c
 echo "patching ca bundle for validating webhook configuration..."
 kubectl patch validatingwebhookconfiguration ${webhookConfigName} \
     --type='json' -p="${validatingPatchString}"
+
+echo "patching ca bundler for conversion webhook configuration.."
+conversionPatchString='[{"op": "replace", "path": "/spec/conversion/webhook/clientConfig/caBundle", "value":"{{CA_BUNDLE}}"}]'
+conversionPatchString=$(echo ${conversionPatchString} | sed "s|{{CA_BUNDLE}}|${caBundle}|g")
+kubectl patch CustomResourceDefinition inferenceservices.serving.kubeflow.org \
+    --type='json' -p="${conversionPatchString}"

--- a/hack/self-signed-ca.sh
+++ b/hack/self-signed-ca.sh
@@ -94,7 +94,7 @@ openssl genrsa -out ${tmpdir}/server.key 2048
 openssl req -new -key ${tmpdir}/server.key -subj "/CN=${service}.${namespace}.svc" -out ${tmpdir}/server.csr -config ${tmpdir}/csr.conf
 
 # Self sign
-openssl x509 -req -days 365 -in ${tmpdir}/server.csr -CA ${tmpdir}/ca.crt -CAkey ${tmpdir}/ca.key -CAcreateserial -out ${tmpdir}/server.crt -extfile ${tmpdir}/csr.conf
+openssl x509 -extensions v3_req -req -days 365 -in ${tmpdir}/server.csr -CA ${tmpdir}/ca.crt -CAkey ${tmpdir}/ca.key -CAcreateserial -out ${tmpdir}/server.crt -extfile ${tmpdir}/csr.conf
 # create the secret with server cert/key
 kubectl create secret generic ${secret} \
         --from-file=tls.key=${tmpdir}/server.key \


### PR DESCRIPTION
On my testing environment (debian 11, openssl 1.1.1k, minikube with k8s 1.20,
go 1.15, kfserving 0.5) I get some TLS errors when testing kfserving,
namely
"x509: certificate relies on legacy Common Name field, use SANs or temporarily enable Common Name matching"
when trying to deploy a simple InferenceService resource.

After some digging I found this problem:

```
openssl req -noout -text -in server.csr | grep "Subject Alternative Name" -A 1
            X509v3 Subject Alternative Name:
                DNS:kfserving-webhook-server-service, DNS:kfserving-webhook-server-service.kfserving-system, DNS:kfserving-webhook-server-service.kfserving-system.svc, DNS:kfserving-webhook-server-service.kfserving-system.svc.cluster, DNS:kfserving-webhook-server-service.kfserving-system.svc.cluster.local

openssl x509 -in server.crt -text -noout | grep "Subject Alternative Name" -A 1
```

Meanwhile if I add this patch:

```
openssl x509 -in server.crt -text -noout | grep "Subject Alternative Name" -A 1
            X509v3 Subject Alternative Name:
                DNS:kfserving-webhook-server-service, DNS:kfserving-webhook-server-service.kfserving-system, DNS:kfserving-webhook-server-service.kfserving-system.svc, DNS:kfserving-webhook-server-service.kfserving-system.svc.cluster, DNS:kfserving-webhook-server-service.kfserving-system.svc.cluster.local

```

As far as I got go 1.15 introduces a stricter policy for TLS certs, and
openssl by default doesn't copy SANs from a .csr to .crt if not
explicitly told.

Also updated the self-signed-ca.sh script to patch the caBundle of the conversion webhook to avoid runtime issues when deploying v1alpha2 services on a recent version of kfserving.

gh: #1657


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
