### PR TITLE
#1593: Remove hard coded isvc default resource requests/limits

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -177,3 +177,8 @@ data:
         "cpuRequest": "100m",
         "cpuLimit": "1"
     }
+  defaults: |-
+    {
+        "cpu": "1",
+        "memory": "2Gi"
+    }

--- a/pkg/apis/serving/v1beta1/configmap.go
+++ b/pkg/apis/serving/v1beta1/configmap.go
@@ -23,6 +23,7 @@ import (
 
 	"github.com/kubeflow/kfserving/pkg/constants"
 	v1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/api/resource"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
@@ -32,6 +33,7 @@ const (
 	PredictorConfigKeyName   = "predictors"
 	TransformerConfigKeyName = "transformers"
 	ExplainerConfigKeyName   = "explainers"
+	DefaultsConfigKeyName    = "defaults"
 )
 
 const (
@@ -108,6 +110,8 @@ type InferenceServicesConfig struct {
 	Predictors PredictorsConfig `json:"predictors"`
 	// Explainer configurations
 	Explainers ExplainersConfig `json:"explainers"`
+	// Default configurations
+	Defaults map[v1.ResourceName]resource.Quantity `json:"defaults,omitempty"`
 }
 
 // +kubebuilder:object:generate=false
@@ -124,11 +128,14 @@ func NewInferenceServicesConfig(cli client.Client) (*InferenceServicesConfig, er
 	if err != nil {
 		return nil, err
 	}
-	icfg := &InferenceServicesConfig{}
+	icfg := &InferenceServicesConfig{
+		Defaults: make(map[v1.ResourceName]resource.Quantity),
+	}
 	for _, err := range []error{
 		getComponentConfig(PredictorConfigKeyName, configMap, &icfg.Predictors),
 		getComponentConfig(ExplainerConfigKeyName, configMap, &icfg.Explainers),
 		getComponentConfig(TransformerConfigKeyName, configMap, &icfg.Transformers),
+		getComponentConfig(DefaultsConfigKeyName, configMap, &icfg.Defaults),
 	} {
 		if err != nil {
 			return nil, err

--- a/pkg/apis/serving/v1beta1/explainer_aix360.go
+++ b/pkg/apis/serving/v1beta1/explainer_aix360.go
@@ -103,7 +103,7 @@ func (s *AIXExplainerSpec) Default(config *InferenceServicesConfig) {
 	if s.RuntimeVersion == nil {
 		s.RuntimeVersion = proto.String(config.Explainers.AIXExplainer.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&s.Resources)
+	setResourceRequirementDefaults(&s.Resources, config)
 }
 
 // Validate the spec

--- a/pkg/apis/serving/v1beta1/explainer_alibi.go
+++ b/pkg/apis/serving/v1beta1/explainer_alibi.go
@@ -120,7 +120,7 @@ func (s *AlibiExplainerSpec) Default(config *InferenceServicesConfig) {
 	if s.RuntimeVersion == nil {
 		s.RuntimeVersion = proto.String(config.Explainers.AlibiExplainer.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&s.Resources)
+	setResourceRequirementDefaults(&s.Resources, config)
 }
 
 // Validate the spec

--- a/pkg/apis/serving/v1beta1/explainer_art.go
+++ b/pkg/apis/serving/v1beta1/explainer_art.go
@@ -101,7 +101,7 @@ func (s *ARTExplainerSpec) Default(config *InferenceServicesConfig) {
 	if s.RuntimeVersion == nil {
 		s.RuntimeVersion = proto.String(config.Explainers.ARTExplainer.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&s.Resources)
+	setResourceRequirementDefaults(&s.Resources, config)
 }
 
 // Validate the spec

--- a/pkg/apis/serving/v1beta1/explainer_custom.go
+++ b/pkg/apis/serving/v1beta1/explainer_custom.go
@@ -49,7 +49,7 @@ func (c *CustomExplainer) Default(config *InferenceServicesConfig) {
 		c.Containers = append(c.Containers, v1.Container{})
 	}
 	c.Containers[0].Name = constants.InferenceServiceContainerName
-	setResourceRequirementDefaults(&c.Containers[0].Resources)
+	setResourceRequirementDefaults(&c.Containers[0].Resources, config)
 }
 
 func (c *CustomExplainer) GetStorageUri() *string {

--- a/pkg/apis/serving/v1beta1/inference_service_defaults.go
+++ b/pkg/apis/serving/v1beta1/inference_service_defaults.go
@@ -20,7 +20,6 @@ import (
 	"reflect"
 
 	v1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/resource"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	logf "sigs.k8s.io/controller-runtime/pkg/log"
@@ -28,10 +27,6 @@ import (
 )
 
 var (
-	defaultResource = v1.ResourceList{
-		v1.ResourceCPU:    resource.MustParse("1"),
-		v1.ResourceMemory: resource.MustParse("2Gi"),
-	}
 	// logger for the mutating webhook.
 	mutatorLogger = logf.Log.WithName("inferenceservice-v1beta1-mutating-webhook")
 )
@@ -39,11 +34,11 @@ var (
 // +kubebuilder:webhook:path=/mutate-inferenceservices,mutating=true,failurePolicy=fail,groups=serving.kubeflow.org,resources=inferenceservices,verbs=create;update,versions=v1beta1,name=inferenceservice.kfserving-webhook-server.defaulter
 var _ webhook.Defaulter = &InferenceService{}
 
-func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
+func setResourceRequirementDefaults(requirements *v1.ResourceRequirements, config *InferenceServicesConfig) {
 	if requirements.Requests == nil {
 		requirements.Requests = v1.ResourceList{}
 	}
-	for k, v := range defaultResource {
+	for k, v := range config.Defaults {
 		if _, ok := requirements.Requests[k]; !ok {
 			requirements.Requests[k] = v
 		}
@@ -52,7 +47,7 @@ func setResourceRequirementDefaults(requirements *v1.ResourceRequirements) {
 	if requirements.Limits == nil {
 		requirements.Limits = v1.ResourceList{}
 	}
-	for k, v := range defaultResource {
+	for k, v := range config.Defaults {
 		if _, ok := requirements.Limits[k]; !ok {
 			requirements.Limits[k] = v
 		}

--- a/pkg/apis/serving/v1beta1/predictor_custom.go
+++ b/pkg/apis/serving/v1beta1/predictor_custom.go
@@ -66,7 +66,7 @@ func (c *CustomPredictor) Default(config *InferenceServicesConfig) {
 		c.Containers = append(c.Containers, v1.Container{})
 	}
 	c.Containers[0].Name = constants.InferenceServiceContainerName
-	setResourceRequirementDefaults(&c.Containers[0].Resources)
+	setResourceRequirementDefaults(&c.Containers[0].Resources, config)
 }
 
 func (c *CustomPredictor) GetStorageUri() *string {

--- a/pkg/apis/serving/v1beta1/predictor_lightgbm.go
+++ b/pkg/apis/serving/v1beta1/predictor_lightgbm.go
@@ -51,7 +51,7 @@ func (x *LightGBMSpec) Default(config *InferenceServicesConfig) {
 	if x.RuntimeVersion == nil {
 		x.RuntimeVersion = proto.String(config.Predictors.LightGBM.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&x.Resources)
+	setResourceRequirementDefaults(&x.Resources, config)
 
 }
 

--- a/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
+++ b/pkg/apis/serving/v1beta1/predictor_onnxruntime.go
@@ -64,7 +64,7 @@ func (o *ONNXRuntimeSpec) Default(config *InferenceServicesConfig) {
 	if o.RuntimeVersion == nil {
 		o.RuntimeVersion = proto.String(config.Predictors.ONNX.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&o.Resources)
+	setResourceRequirementDefaults(&o.Resources, config)
 }
 
 // GetContainers transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_pmml.go
+++ b/pkg/apis/serving/v1beta1/predictor_pmml.go
@@ -50,7 +50,7 @@ func (p *PMMLSpec) Default(config *InferenceServicesConfig) {
 	if p.RuntimeVersion == nil {
 		p.RuntimeVersion = proto.String(config.Predictors.PMML.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&p.Resources)
+	setResourceRequirementDefaults(&p.Resources, config)
 }
 
 // GetContainer transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_sklearn.go
+++ b/pkg/apis/serving/v1beta1/predictor_sklearn.go
@@ -62,7 +62,7 @@ func (k *SKLearnSpec) Default(config *InferenceServicesConfig) {
 		k.ProtocolVersion = &defaultProtocol
 	}
 
-	setResourceRequirementDefaults(&k.Resources)
+	setResourceRequirementDefaults(&k.Resources, config)
 }
 
 // GetContainer transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_tfserving.go
+++ b/pkg/apis/serving/v1beta1/predictor_tfserving.go
@@ -78,7 +78,7 @@ func (t *TFServingSpec) Default(config *InferenceServicesConfig) {
 			t.RuntimeVersion = proto.String(config.Predictors.Tensorflow.DefaultImageVersion)
 		}
 	}
-	setResourceRequirementDefaults(&t.Resources)
+	setResourceRequirementDefaults(&t.Resources, config)
 }
 
 func (t *TFServingSpec) GetStorageUri() *string {

--- a/pkg/apis/serving/v1beta1/predictor_torchserve.go
+++ b/pkg/apis/serving/v1beta1/predictor_torchserve.go
@@ -108,7 +108,7 @@ func (t *TorchServeSpec) Default(config *InferenceServicesConfig) {
 		}
 	}
 
-	setResourceRequirementDefaults(&t.Resources)
+	setResourceRequirementDefaults(&t.Resources, config)
 }
 
 // GetContainers transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_triton.go
+++ b/pkg/apis/serving/v1beta1/predictor_triton.go
@@ -55,7 +55,7 @@ func (t *TritonSpec) Default(config *InferenceServicesConfig) {
 	if t.RuntimeVersion == nil {
 		t.RuntimeVersion = proto.String(config.Predictors.Triton.DefaultImageVersion)
 	}
-	setResourceRequirementDefaults(&t.Resources)
+	setResourceRequirementDefaults(&t.Resources, config)
 }
 
 // GetContainers transforms the resource into a container spec

--- a/pkg/apis/serving/v1beta1/predictor_xgboost.go
+++ b/pkg/apis/serving/v1beta1/predictor_xgboost.go
@@ -62,7 +62,7 @@ func (x *XGBoostSpec) Default(config *InferenceServicesConfig) {
 		x.RuntimeVersion = &defaultVersion
 	}
 
-	setResourceRequirementDefaults(&x.Resources)
+	setResourceRequirementDefaults(&x.Resources, config)
 
 }
 

--- a/pkg/apis/serving/v1beta1/transformer_custom.go
+++ b/pkg/apis/serving/v1beta1/transformer_custom.go
@@ -50,7 +50,7 @@ func (c *CustomTransformer) Default(config *InferenceServicesConfig) {
 		c.Containers = append(c.Containers, v1.Container{})
 	}
 	c.Containers[0].Name = constants.InferenceServiceContainerName
-	setResourceRequirementDefaults(&c.Containers[0].Resources)
+	setResourceRequirementDefaults(&c.Containers[0].Resources, config)
 }
 
 func (c *CustomTransformer) GetStorageUri() *string {


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

Removed hard coded isvc default resource requests/limits and extended the `inferenceservice-config` config map with these values. The administrators can use the config map to set default resource limits for all inferenceservice services.


**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1593

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
