### PR TITLE
Append "--no-cache-dir" to "pip install" in Dockerfiles

### DIFF
--- a/docs/samples/explanation/aix/mnist/rfserver/rf.Dockerfile
+++ b/docs/samples/explanation/aix/mnist/rfserver/rf.Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
 COPY . .
-RUN pip install --upgrade pip && pip install kfserving==0.4.1
-RUN pip install -e .
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir kfserving==0.4.1
+RUN pip install --no-cache-dir -e .
 ENTRYPOINT ["python", "-m", "rfserver", "--model_name", "aixserver"]

--- a/docs/samples/explanation/art/mnist/sklearnserver/sklearn.Dockerfile
+++ b/docs/samples/explanation/art/mnist/sklearnserver/sklearn.Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim
 
 COPY . sklearnserver
 
-RUN pip install --upgrade pip && pip install kfserving
-RUN pip install -e ./sklearnserver
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir kfserving
+RUN pip install --no-cache-dir -e ./sklearnserver
 
 ENTRYPOINT ["python", "-m", "sklearnserver", "--model_name", "artserver", "--model_dir", "file://sklearnserver/sklearnserver/example_model"]

--- a/docs/samples/kafka/transformer.Dockerfile
+++ b/docs/samples/kafka/transformer.Dockerfile
@@ -2,6 +2,6 @@ FROM python:3.7-slim
 
 RUN apt-get update && apt-get install -y libglib2.0-0
 COPY . .
-RUN pip install --upgrade pip && pip install kfserving
-RUN pip install -e .
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir kfserving
+RUN pip install --no-cache-dir -e .
 ENTRYPOINT ["python", "-m", "image_transformer"]

--- a/docs/samples/v1alpha2/custom/customized-urls/Dockerfile
+++ b/docs/samples/v1alpha2/custom/customized-urls/Dockerfile
@@ -8,7 +8,7 @@ WORKDIR $APP_HOME
 COPY . ./
 
 # Install production dependencies.
-RUN pip install Flask gunicorn
+RUN pip install --no-cache-dir Flask gunicorn
 
 # Run the web service on container startup. Here we use the gunicorn
 # webserver, with one worker process and 8 threads.

--- a/docs/samples/v1alpha2/transformer/image_transformer/transformer.Dockerfile
+++ b/docs/samples/v1alpha2/transformer/image_transformer/transformer.Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7-slim
 
 COPY . .
-RUN pip install --upgrade pip && pip install kfserving
-RUN pip install -e .
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir kfserving
+RUN pip install --no-cache-dir -e .
 ENTRYPOINT ["python", "-m", "image_transformer"]

--- a/docs/samples/v1alpha2/triton/bert/bert_tokenizer/Dockerfile
+++ b/docs/samples/v1alpha2/triton/bert/bert_tokenizer/Dockerfile
@@ -4,9 +4,9 @@ RUN  apt-get update \
   && rm -rf /var/lib/apt/lists/*
 COPY bert_transformer bert_transformer/bert_transformer
 COPY setup.py bert_transformer/setup.py
-RUN pip install kfserving
+RUN pip install --no-cache-dir kfserving
 RUN wget https://github.com/triton-inference-server/server/releases/download/v1.11.0/v1.11.0_ubuntu1604.clients.tar.gz && tar -xvzf v1.11.0_ubuntu1604.clients.tar.gz
-RUN pip install python/tensorrtserver-1.11.0-py3-none-linux_x86_64.whl
+RUN pip install --no-cache-dir python/tensorrtserver-1.11.0-py3-none-linux_x86_64.whl
 WORKDIR bert_transformer
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 ENTRYPOINT ["python", "-m", "bert_transformer"] 

--- a/docs/samples/v1beta1/transformer/torchserve_image_transformer/transformer.Dockerfile
+++ b/docs/samples/v1beta1/transformer/torchserve_image_transformer/transformer.Dockerfile
@@ -4,7 +4,7 @@ RUN apt-get update \
 && apt-get install -y --no-install-recommends git
 
 COPY . .
-RUN pip install --upgrade pip
-RUN pip install kfserving==0.5.1
-RUN pip install -e .
+RUN pip install --no-cache-dir --upgrade pip
+RUN pip install --no-cache-dir kfserving==0.5.1
+RUN pip install --no-cache-dir -e .
 ENTRYPOINT ["python", "-m", "image_transformer"]

--- a/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/Dockerfile
+++ b/docs/samples/v1beta1/triton/bert/bert_tokenizer_v2/Dockerfile
@@ -2,10 +2,10 @@ FROM python:3.7-slim
 RUN  apt-get update \
   && apt-get install -y wget \
   && rm -rf /var/lib/apt/lists/*
-RUN pip install kfserving
-RUN pip install tritonclient[all] --extra-index-url=https://pypi.ngc.nvidia.com  
+RUN pip install --no-cache-dir kfserving
+RUN pip install --no-cache-dir tritonclient[all] --extra-index-url=https://pypi.ngc.nvidia.com  
 COPY bert_transformer_v2 bert_transformer_v2/bert_transformer_v2
 COPY setup.py bert_transformer_v2/setup.py
 WORKDIR bert_transformer_v2
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 ENTRYPOINT ["python", "-m", "bert_transformer_v2"] 

--- a/docs/samples/v1beta1/triton/torchscript/transformer.Dockerfile
+++ b/docs/samples/v1beta1/triton/torchscript/transformer.Dockerfile
@@ -2,7 +2,7 @@ FROM python:3.7-slim
 RUN apt-get update && \
     apt-get upgrade -y && \
     apt-get install -y git
-RUN pip install --upgrade pip && pip install git+https://github.com/kubeflow/kfserving@torchscript#subdirectory=python/kfserving
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir git+https://github.com/kubeflow/kfserving@torchscript#subdirectory=python/kfserving
 COPY . .
-RUN pip install -e .
+RUN pip install --no-cache-dir -e .
 ENTRYPOINT ["python", "-m", "image_transformer_v2"]

--- a/python/aiffairness.Dockerfile
+++ b/python/aiffairness.Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
 COPY . .
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./aiffairness
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./aiffairness
 ENTRYPOINT ["python", "-m", "aifserver"]

--- a/python/aixexplainer.Dockerfile
+++ b/python/aixexplainer.Dockerfile
@@ -1,6 +1,6 @@
 FROM python:3.7
 
 COPY . .
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./aixexplainer
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./aixexplainer
 ENTRYPOINT ["python", "-m", "aixserver"]

--- a/python/alibiexplainer.Dockerfile
+++ b/python/alibiexplainer.Dockerfile
@@ -4,6 +4,6 @@ COPY alibiexplainer alibiexplainer
 COPY kfserving kfserving
 COPY third_party third_party
 
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./alibiexplainer
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./alibiexplainer
 ENTRYPOINT ["python", "-m", "alibiexplainer"]

--- a/python/artexplainer.Dockerfile
+++ b/python/artexplainer.Dockerfile
@@ -3,6 +3,6 @@ FROM python:3.7
 COPY artexplainer artexplainer
 COPY kfserving kfserving
 
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./artexplainer
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./artexplainer
 ENTRYPOINT ["python", "-m", "artserver"]

--- a/python/lgb.Dockerfile
+++ b/python/lgb.Dockerfile
@@ -6,9 +6,9 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
     rm -rf /var/lib/apt/lists/* /tmp/* /var/tmp/*
 COPY third_party third_party
 COPY kfserving kfserving
-RUN pip install --upgrade pip && pip install -e ./kfserving
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
 
 COPY lgbserver lgbserver
-RUN pip install -e ./lgbserver
+RUN pip install --no-cache-dir -e ./lgbserver
 
 ENTRYPOINT ["python", "-m", "lgbserver"]

--- a/python/pmml.Dockerfile
+++ b/python/pmml.Dockerfile
@@ -24,8 +24,8 @@ RUN conda install -y python=$PYTHON_VERSION
 COPY pmmlserver pmmlserver
 COPY kfserving kfserving
 
-RUN pip install --upgrade pip && pip3 install -e ./kfserving
-RUN pip install -e ./pmmlserver
+RUN pip install --no-cache-dir --upgrade pip && pip3 install -e ./kfserving
+RUN pip install --no-cache-dir -e ./pmmlserver
 COPY third_party third_party
 
 ENTRYPOINT ["python3", "-m", "pmmlserver"]

--- a/python/pytorch-gpu.Dockerfile
+++ b/python/pytorch-gpu.Dockerfile
@@ -52,7 +52,7 @@ COPY --from=build /opt/conda/. $CONDA_DIR
 COPY pytorchserver pytorchserver
 COPY kfserving kfserving
 
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./pytorchserver
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./pytorchserver
 ENTRYPOINT ["python", "-m", "pytorchserver"]
 

--- a/python/pytorch.Dockerfile
+++ b/python/pytorch.Dockerfile
@@ -28,6 +28,6 @@ COPY pytorchserver pytorchserver
 COPY kfserving kfserving
 COPY third_party third_party
 
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./pytorchserver
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./pytorchserver
 ENTRYPOINT ["python", "-m", "pytorchserver"]

--- a/python/sklearn.Dockerfile
+++ b/python/sklearn.Dockerfile
@@ -3,8 +3,8 @@ FROM python:3.7-slim
 COPY sklearnserver sklearnserver
 COPY kfserving kfserving
 
-RUN pip install --upgrade pip && pip install -e ./kfserving
-RUN pip install -e ./sklearnserver
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./sklearnserver
 COPY third_party third_party
 
 ENTRYPOINT ["python", "-m", "sklearnserver"]

--- a/python/storage-initializer.Dockerfile
+++ b/python/storage-initializer.Dockerfile
@@ -1,7 +1,7 @@
 FROM python:3.7-slim
 
 COPY ./kfserving ./kfserving
-RUN pip install --upgrade pip && pip install ./kfserving
+RUN pip install --no-cache-dir --upgrade pip && pip install --no-cache-dir ./kfserving
 
 COPY ./storage-initializer /storage-initializer
 COPY third_party third_party

--- a/python/xgb.Dockerfile
+++ b/python/xgb.Dockerfile
@@ -6,6 +6,6 @@ COPY . .
 COPY third_party third_party
 
 # pip 20.x breaks xgboost wheels https://github.com/dmlc/xgboost/issues/5221
-RUN pip install pip==19.3.1 && pip install -e ./kfserving
-RUN pip install -e ./xgbserver
+RUN pip install --no-cache-dir pip==19.3.1 && pip install --no-cache-dir -e ./kfserving
+RUN pip install --no-cache-dir -e ./xgbserver
 ENTRYPOINT ["python", "-m", "xgbserver"]


### PR DESCRIPTION
See the rationale at https://github.com/hadolint/hadolint/wiki/DL3042

In addition to space saving, it also ensures that pip doesn't install
from local cache (especially in case of a rebuild) and reduces the
chance of creating bugs during development.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: See above

**Special notes for your reviewer**: It's difficult for me to test every image, but they shouldn't make functional changes to the built Docker images for clean build.

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Use `pip install --no-cache-dir` instead of naked `pip install` in Dockerfiles.
```
