### PR TITLE
Limit number of asyncio workers in custom transformers

### DIFF
--- a/python/kfserving/kfserving/utils/utils.py
+++ b/python/kfserving/kfserving/utils/utils.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 
 import os
+import sys
+import psutil
 
 
 def is_running_in_k8s():
@@ -34,3 +36,36 @@ def set_isvc_namespace(inferenceservice):
     isvc_namespace = inferenceservice.metadata.namespace
     namespace = isvc_namespace or get_default_target_namespace()
     return namespace
+
+
+def cpu_count():
+    """Get the available CPU count for this system.
+    Takes the minimum value from the following locations:
+    - Total system cpus available on the host.
+    - CPU Affinity (if set)
+    - Cgroups limit (if set)
+    """
+    count = os.cpu_count()
+
+    # Check CPU affinity if available
+    try:
+        affinity_count = len(psutil.Process().cpu_affinity())
+        if affinity_count > 0:
+            count = min(count, affinity_count)
+    except Exception:
+        pass
+
+    # Check cgroups if available
+    if sys.platform == "linux":
+        try:
+            with open("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_quota_us") as f:
+                quota = int(f.read())
+            with open("/sys/fs/cgroup/cpu,cpuacct/cpu.cfs_period_us") as f:
+                period = int(f.read())
+            cgroups_count = int(quota / period)
+            if cgroups_count > 0:
+                count = min(count, cgroups_count)
+        except Exception:
+            pass
+
+    return count

--- a/python/kfserving/requirements.txt
+++ b/python/kfserving/requirements.txt
@@ -16,3 +16,4 @@ cloudevents>=1.2.0
 avro>=1.10.1
 boto3>=1.17.32
 botocore>=1.20.32
+psutil>=5.0


### PR DESCRIPTION
**What this PR does / why we need it**:

For linux platforms, infer cpu-limit for the container from 'cfs_quota_us'
and 'cfs_quota_us' files. Use min(32, cpu_count + 4) to limit number of
max asyncio workers. Refer https://bugs.python.org/issue35279 for formula
source.

Python (and asyncio) is not container aware and thus ends up creating
asyncio workers proportional to cpu core count of the machine and not the
container. This spawns too many asyncio workers on high cpu core machines
running containers with low cpu-limit causing throttling.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1690 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

```release-note
Limit number of asyncio workers in custom transformers
```
