### PR TITLE
Use index instead of element when searching for a volume

### DIFF
--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -67,8 +67,8 @@ func IncludesArg(slice []string, arg string) bool {
 }
 
 func AppendVolumeIfNotExists(slice []v1.Volume, volume v1.Volume) []v1.Volume {
-	for _, ele := range slice {
-		if ele.Name == volume.Name {
+	for i := range slice {
+		if slice[i].Name == volume.Name {
 			return slice
 		}
 	}


### PR DESCRIPTION
`range` copies the elements by value. Avoid using it when searching for
volumes. This should potentially improve overall performance when
`AppendVolumeIfNotExists` is used.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: above


**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Performance improvements for AppendVolumeIfNotExists.
```
