### PR TITLE
`ContainsString` and `Includes` utils are duplicates

### DIFF
--- a/pkg/controller/v1alpha1/trainedmodel/controller.go
+++ b/pkg/controller/v1alpha1/trainedmodel/controller.go
@@ -108,7 +108,7 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// registering our finalizer.
-		if !utils.ContainsString(tm.GetFinalizers(), tmFinalizerName) {
+		if !utils.Includes(tm.GetFinalizers(), tmFinalizerName) {
 			tm.SetFinalizers(append(tm.GetFinalizers(), tmFinalizerName))
 			if err := r.Update(context.Background(), tm); err != nil {
 				return ctrl.Result{}, err
@@ -116,7 +116,7 @@ func (r *TrainedModelReconciler) Reconcile(ctx context.Context, req ctrl.Request
 		}
 	} else {
 		// The object is being deleted
-		if utils.ContainsString(tm.GetFinalizers(), tmFinalizerName) {
+		if utils.Includes(tm.GetFinalizers(), tmFinalizerName) {
 			//reconcile configmap to remove the model
 			if err := r.ModelConfigReconciler.Reconcile(req, tm); err != nil {
 				return reconcile.Result{}, err

--- a/pkg/controller/v1beta1/inferenceservice/controller.go
+++ b/pkg/controller/v1beta1/inferenceservice/controller.go
@@ -89,7 +89,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		// The object is not being deleted, so if it does not have our finalizer,
 		// then lets add the finalizer and update the object. This is equivalent
 		// registering our finalizer.
-		if !utils.ContainsString(isvc.ObjectMeta.Finalizers, finalizerName) {
+		if !utils.Includes(isvc.ObjectMeta.Finalizers, finalizerName) {
 			isvc.ObjectMeta.Finalizers = append(isvc.ObjectMeta.Finalizers, finalizerName)
 			if err := r.Update(context.Background(), isvc); err != nil {
 				return ctrl.Result{}, err
@@ -97,7 +97,7 @@ func (r *InferenceServiceReconciler) Reconcile(ctx context.Context, req ctrl.Req
 		}
 	} else {
 		// The object is being deleted
-		if utils.ContainsString(isvc.ObjectMeta.Finalizers, finalizerName) {
+		if utils.Includes(isvc.ObjectMeta.Finalizers, finalizerName) {
 			// our finalizer is present, so lets handle any external dependency
 			if err := r.deleteExternalResources(isvc); err != nil {
 				// if fail to delete the external dependency here, return with error

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -90,16 +90,7 @@ func FirstNonNilError(objects []error) error {
 	return nil
 }
 
-// Helper functions to check and remove string from a slice of strings.
-func ContainsString(slice []string, s string) bool {
-	for _, item := range slice {
-		if item == s {
-			return true
-		}
-	}
-	return false
-}
-
+// Helper functions to remove string from a slice of strings.
 func RemoveString(slice []string, s string) (result []string) {
 	for _, item := range slice {
 		if item == s {


### PR DESCRIPTION
They achieve exactly the same functionality.

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**: Above

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
None
```
