### PR TITLE
Make canary name match tensorflow.yaml

### DIFF
--- a/docs/samples/v1beta1/tensorflow/canary.yaml
+++ b/docs/samples/v1beta1/tensorflow/canary.yaml
@@ -1,7 +1,7 @@
 apiVersion: "serving.kubeflow.org/v1beta1"
 kind: "InferenceService"
 metadata:
-  name: "flower-example"
+  name: "flower-sample"
 spec:
   predictor:
     canaryTrafficPercent: 20


### PR DESCRIPTION
**What this PR does / why we need it**:

The canary should have the same name as the base tensorflow.yaml so it correctly applies as a canary
