### PR TITLE
Ignore istio dir downloaded by hack install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -59,3 +59,6 @@ python/kfserving/tox.ini
 
 # Ignore files for MacOS
 **/.DS_Store
+
+# Downloaded by hack install
+hack/istio-*


### PR DESCRIPTION
**What this PR does / why we need it**:

Add the istio directory which is downloaded by `quick_install.sh` to the ignore list