### PR TITLE
Use v1 instead of v1beta1 of deprecated v1.16+ APIs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -244,7 +244,7 @@ ifeq (, $(shell which controller-gen))
 	CONTROLLER_GEN_TMP_DIR=$$(mktemp -d) ;\
 	cd $$CONTROLLER_GEN_TMP_DIR ;\
 	go mod init tmp ;\
-	go get sigs.k8s.io/controller-tools/cmd/controller-gen@5c0c6ae3b64bccf89fb16353880376d3ce9d9128 ;\
+	go get sigs.k8s.io/controller-tools/cmd/controller-gen@04609bddfe9a8e8658ed6a7ba1382d38e6acfbe8 ;\
 	rm -rf $$CONTROLLER_GEN_TMP_DIR ;\
 	}
 CONTROLLER_GEN=$(GOPATH)/bin/controller-gen

--- a/config/crd/kustomization.yaml
+++ b/config/crd/kustomization.yaml
@@ -15,7 +15,7 @@ patchesJson6902:
   # Fix for https://github.com/kubernetes/kubernetes/issues/91395
   - target:
       group: apiextensions.k8s.io
-      version: v1beta1
+      version: v1
       kind: CustomResourceDefinition
       name: inferenceservices.serving.kubeflow.org
     path: patches/protocol.yaml

--- a/config/crd/serving.kubeflow.org_inferenceservices.yaml
+++ b/config/crd/serving.kubeflow.org_inferenceservices.yaml
@@ -1,8 +1,8 @@
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200528125929-5c0c6ae3b64b
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: inferenceservices.serving.kubeflow.org
 spec:
@@ -15,24 +15,21 @@ spec:
       - isvc
     singular: inferenceservice
   scope: Namespaced
-  subresources:
-    status: {}
-  version: v1alpha2
   versions:
     - additionalPrinterColumns:
-        - JSONPath: .status.url
+        - jsonPath: .status.url
           name: URL
           type: string
-        - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
           name: Ready
           type: string
-        - JSONPath: .status.traffic
+        - jsonPath: .status.traffic
           name: Default Traffic
           type: integer
-        - JSONPath: .status.canaryTraffic
+        - jsonPath: .status.canaryTraffic
           name: Canary Traffic
           type: integer
-        - JSONPath: .metadata.creationTimestamp
+        - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
       name: v1alpha2
@@ -4170,26 +4167,28 @@ spec:
           type: object
       served: true
       storage: false
+      subresources:
+        status: {}
     - additionalPrinterColumns:
-        - JSONPath: .status.url
+        - jsonPath: .status.url
           name: URL
           type: string
-        - JSONPath: .status.conditions[?(@.type=='Ready')].status
+        - jsonPath: .status.conditions[?(@.type=='Ready')].status
           name: Ready
           type: string
-        - JSONPath: .status.components.predictor.traffic[?(@.tag=='prev')].percent
+        - jsonPath: .status.components.predictor.traffic[?(@.tag=='prev')].percent
           name: Prev
           type: integer
-        - JSONPath: .status.components.predictor.traffic[?(@.latestRevision==true)].percent
+        - jsonPath: .status.components.predictor.traffic[?(@.latestRevision==true)].percent
           name: Latest
           type: integer
-        - JSONPath: .status.components.predictor.traffic[?(@.tag=='prev')].revisionName
+        - jsonPath: .status.components.predictor.traffic[?(@.tag=='prev')].revisionName
           name: PrevRolledoutRevision
           type: string
-        - JSONPath: .status.components.predictor.traffic[?(@.latestRevision==true)].revisionName
+        - jsonPath: .status.components.predictor.traffic[?(@.latestRevision==true)].revisionName
           name: LatestReadyRevision
           type: string
-        - JSONPath: .metadata.creationTimestamp
+        - jsonPath: .metadata.creationTimestamp
           name: Age
           type: date
       name: v1beta1
@@ -15975,6 +15974,8 @@ spec:
           type: object
       served: true
       storage: true
+      subresources:
+        status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/crd/serving.kubeflow.org_trainedmodels.yaml
+++ b/config/crd/serving.kubeflow.org_trainedmodels.yaml
@@ -1,23 +1,13 @@
 
 ---
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.3.1-0.20200528125929-5c0c6ae3b64b
+    controller-gen.kubebuilder.io/version: v0.4.0
   creationTimestamp: null
   name: trainedmodels.serving.kubeflow.org
 spec:
-  additionalPrinterColumns:
-  - JSONPath: .status.url
-    name: URL
-    type: string
-  - JSONPath: .status.conditions[?(@.type=='Ready')].status
-    name: Ready
-    type: string
-  - JSONPath: .metadata.creationTimestamp
-    name: Age
-    type: date
   group: serving.kubeflow.org
   names:
     kind: TrainedModel
@@ -27,85 +17,94 @@ spec:
     - tm
     singular: trainedmodel
   scope: Namespaced
-  subresources:
-    status: {}
-  validation:
-    openAPIV3Schema:
-      properties:
-        apiVersion:
-          type: string
-        kind:
-          type: string
-        metadata:
-          type: object
-        spec:
-          properties:
-            inferenceService:
-              type: string
-            model:
-              properties:
-                framework:
-                  type: string
-                memory:
-                  anyOf:
-                  - type: integer
-                  - type: string
-                  pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
-                  x-kubernetes-int-or-string: true
-                storageUri:
-                  type: string
-              required:
-              - framework
-              - memory
-              - storageUri
-              type: object
-          required:
-          - inferenceService
-          - model
-          type: object
-        status:
-          properties:
-            address:
-              properties:
-                url:
-                  type: string
-              type: object
-            annotations:
-              additionalProperties:
+  versions:
+  - additionalPrinterColumns:
+    - jsonPath: .status.url
+      name: URL
+      type: string
+    - jsonPath: .status.conditions[?(@.type=='Ready')].status
+      name: Ready
+      type: string
+    - jsonPath: .metadata.creationTimestamp
+      name: Age
+      type: date
+    name: v1alpha1
+    schema:
+      openAPIV3Schema:
+        properties:
+          apiVersion:
+            type: string
+          kind:
+            type: string
+          metadata:
+            type: object
+          spec:
+            properties:
+              inferenceService:
                 type: string
-              type: object
-            conditions:
-              items:
+              model:
                 properties:
-                  lastTransitionTime:
+                  framework:
                     type: string
-                  message:
-                    type: string
-                  reason:
-                    type: string
-                  severity:
-                    type: string
-                  status:
-                    type: string
-                  type:
+                  memory:
+                    anyOf:
+                    - type: integer
+                    - type: string
+                    pattern: ^(\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))(([KMGTPE]i)|[numkMGTPE]|([eE](\+|-)?(([0-9]+(\.[0-9]*)?)|(\.[0-9]+))))?$
+                    x-kubernetes-int-or-string: true
+                  storageUri:
                     type: string
                 required:
-                - status
-                - type
+                - framework
+                - memory
+                - storageUri
                 type: object
-              type: array
-            observedGeneration:
-              format: int64
-              type: integer
-            url:
-              type: string
-          type: object
-      type: object
-  version: v1alpha1
-  versions:
-  - name: v1alpha1
+            required:
+            - inferenceService
+            - model
+            type: object
+          status:
+            properties:
+              address:
+                properties:
+                  url:
+                    type: string
+                type: object
+              annotations:
+                additionalProperties:
+                  type: string
+                type: object
+              conditions:
+                items:
+                  properties:
+                    lastTransitionTime:
+                      type: string
+                    message:
+                      type: string
+                    reason:
+                      type: string
+                    severity:
+                      type: string
+                    status:
+                      type: string
+                    type:
+                      type: string
+                  required:
+                  - status
+                  - type
+                  type: object
+                type: array
+              observedGeneration:
+                format: int64
+                type: integer
+              url:
+                type: string
+            type: object
+        type: object
     served: true
     storage: true
+    subresources:
+      status: {}
 status:
   acceptedNames:
     kind: ""

--- a/config/default/cainjection_conversion_webhook.yaml
+++ b/config/default/cainjection_conversion_webhook.yaml
@@ -1,6 +1,6 @@
 # The following patch adds a directive for certmanager to inject CA into the CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:

--- a/config/default/inferenceservice_conversion_webhook.yaml
+++ b/config/default/inferenceservice_conversion_webhook.yaml
@@ -1,6 +1,6 @@
 # The following patch enables conversion webhook for CRD
 # CRD conversion requires k8s 1.13 or later.
-apiVersion: apiextensions.k8s.io/v1beta1
+apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   name: inferenceservices.serving.kubeflow.org
@@ -8,7 +8,7 @@ spec:
   preserveUnknownFields: false
   conversion:
     strategy: Webhook
-    conversionReviewVersions: ["v1alpha2","v1beta1"]
+    conversionReviewVersions: ["v1alpha2","v1beta1", "v1"]
     webhookClientConfig:
       # this is "\n" used as a placeholder, otherwise it will be rejected by the apiserver for being blank,
       # but we're going to set it later using the cert-manager (or potentially a patch if not using cert-manager)

--- a/config/default/webhookcainjection_patch.yaml
+++ b/config/default/webhookcainjection_patch.yaml
@@ -1,6 +1,6 @@
 # This patch add annotation to admission webhook config and
 # the variables $(CERTIFICATE_NAMESPACE) and $(CERTIFICATE_NAME) will be substituted by kustomize.
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   name: inferenceservice.serving.kubeflow.org
@@ -9,7 +9,7 @@ metadata:
 webhooks:
   - name: inferenceservice.kfserving-webhook-server.defaulter
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: inferenceservice.serving.kubeflow.org
@@ -18,7 +18,7 @@ metadata:
 webhooks:
   - name: inferenceservice.kfserving-webhook-server.validator
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   name: trainedmodel.serving.kubeflow.org

--- a/config/webhook/manifests.yaml
+++ b/config/webhook/manifests.yaml
@@ -1,5 +1,5 @@
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: MutatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -69,7 +69,7 @@ webhooks:
           - pods
 
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null
@@ -112,7 +112,7 @@ webhooks:
         resources:
           - inferenceservices
 ---
-apiVersion: admissionregistration.k8s.io/v1beta1
+apiVersion: admissionregistration.k8s.io/v1
 kind: ValidatingWebhookConfiguration
 metadata:
   creationTimestamp: null


### PR DESCRIPTION
**What this PR does / why we need it**:

The current configs have three warnings for deprecated `v1beta` usage

```
Warning: admissionregistration.k8s.io/v1beta1 MutatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 MutatingWebhookConfiguration

Warning: admissionregistration.k8s.io/v1beta1 ValidatingWebhookConfiguration is deprecated in v1.16+, unavailable in v1.22+; use admissionregistration.k8s.io/v1 ValidatingWebhookConfiguration

Warning: apiextensions.k8s.io/v1beta1 CustomResourceDefinition is deprecated in v1.16+, unavailable in v1.22+; use apiextensions.k8s.io/v1 CustomResourceDefinition
```

I have bumped the version of controllergen-tools to v0.4.0 which uses `v1` by default, and doesn't upgrade the k8s dependencies from the currently used v0.3 (which targets k8s v0.18.2) https://github.com/kubernetes-sigs/controller-tools/releases

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #1591

