### PR TITLE
Pin image tags in release-0.6 branch

### DIFF
--- a/config/configmap/inferenceservice.yaml
+++ b/config/configmap/inferenceservice.yaml
@@ -27,7 +27,7 @@ data:
         "sklearn": {
           "v1": {
             "image": "gcr.io/kfserving/sklearnserver",
-            "defaultImageVersion": "latest",
+            "defaultImageVersion": "v0.6.0",
             "supportedFrameworks": [
               "sklearn"
             ],
@@ -45,7 +45,7 @@ data:
         "xgboost": {
           "v1": {
             "image": "gcr.io/kfserving/xgbserver",
-            "defaultImageVersion": "latest",
+            "defaultImageVersion": "v0.6.0",
             "supportedFrameworks": [
               "xgboost"
             ],
@@ -63,8 +63,8 @@ data:
         "pytorch": {
           "v1" : {
             "image": "gcr.io/kfserving/pytorchserver",
-            "defaultImageVersion": "latest",
-            "defaultGpuImageVersion": "latest-gpu",
+            "defaultImageVersion": "v0.6.0",
+            "defaultGpuImageVersion": "v0.5.1-gpu",
             "supportedFrameworks": [
               "pytorch"
             ],
@@ -94,7 +94,7 @@ data:
         },
         "pmml": {
             "image": "kfserving/pmmlserver",
-            "defaultImageVersion": "latest",
+            "defaultImageVersion": "v0.6.0",
             "supportedFrameworks": [
               "pmml"
             ],
@@ -102,7 +102,7 @@ data:
         },
         "lightgbm": {
             "image": "kfserving/lgbserver",
-            "defaultImageVersion": "latest",
+            "defaultImageVersion": "v0.6.0",
             "supportedFrameworks": [
               "lightgbm"
             ],
@@ -110,7 +110,7 @@ data:
         },
         "paddle": {
             "image": "kfserving/paddleserver",
-            "defaultImageVersion": "latest",
+            "defaultImageVersion": "v0.6.0",
             "supportedFrameworks": [
               "paddle"
             ],
@@ -124,20 +124,20 @@ data:
     {
         "alibi": {
             "image" : "kfserving/alibi-explainer",
-            "defaultImageVersion": "latest"
+            "defaultImageVersion": "v0.6.0"
         },
         "aix": {
             "image" : "kfserving/aix-explainer",
-            "defaultImageVersion": "latest"
+            "defaultImageVersion": "v0.6.0"
         },
         "art": {
             "image" : "kfserving/art-explainer",
-            "defaultImageVersion": "latest"
+            "defaultImageVersion": "v0.6.0"
         }
     }
   storageInitializer: |-
     {
-        "image" : "gcr.io/kfserving/storage-initializer:latest",
+        "image" : "gcr.io/kfserving/storage-initializer:v0.6.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -162,7 +162,7 @@ data:
     }
   logger: |-
     {
-        "image" : "kfserving/agent:latest",
+        "image" : "kfserving/agent:v0.6.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",
@@ -171,7 +171,7 @@ data:
     }
   batcher: |-
     {
-        "image" : "kfserving/agent:latest",
+        "image" : "kfserving/agent:v0.6.0",
         "memoryRequest": "1Gi",
         "memoryLimit": "1Gi",
         "cpuRequest": "1",
@@ -179,7 +179,7 @@ data:
     }
   agent: |-
     {
-        "image" : "kfserving/agent:latest",
+        "image" : "kfserving/agent:v0.6.0",
         "memoryRequest": "100Mi",
         "memoryLimit": "1Gi",
         "cpuRequest": "100m",

--- a/config/default/manager_image_patch.yaml
+++ b/config/default/manager_image_patch.yaml
@@ -8,5 +8,5 @@ spec:
     spec:
       containers:
       # Change the value of image field below to your controller image URL
-      - image: gcr.io/kfserving/kfserving-controller:latest
+      - image: gcr.io/kfserving/kfserving-controller:v0.6.0
         name: manager

--- a/config/web-app/deployment.yaml
+++ b/config/web-app/deployment.yaml
@@ -14,7 +14,7 @@ spec:
         app.kubernetes.io/component: kfserving-models-web-app
     spec:
       containers:
-      - image: kfserving/models-web-app:latest
+      - image: kfserving/models-web-app:v0.6.0
         imagePullPolicy: Always
         name: kfserving-models-web-app
         envFrom:


### PR DESCRIPTION
Note this is a PR into the release-0.6 branch and **not** master.

In preparation for using KFServing v0.6.0 in the next Kubeflow manifests 1.4 release, the image tags need to be pinned. This PR pins the image tags to v0.6.0 in the config YAMLs. This way kubeflow/manifests can use the config directory from this PR's commit.

This is similar to what we did in v0.5.1 (https://github.com/kubeflow/kfserving/pull/1465).

Note: I could not find an image tag for `v0.6.0-gpu` for  [`gcr.io/kfserving/pytorchserver`](https://console.cloud.google.com/gcr/images/kfserving/GLOBAL/pytorchserver), so I left it at `latest-gpu` as that is around the same time that v0.6.0 was tagged.

Ref: https://github.com/kubeflow/manifests/issues/1960 

