### PR TITLE
prevent nested directories in s3 to be created as file inside model directory /mnt/models

### DIFF
--- a/pkg/agent/storage/gcs.go
+++ b/pkg/agent/storage/gcs.go
@@ -78,7 +78,7 @@ func (g *GCSObjectDownloader) Download(client stiface.Client, it stiface.ObjectI
 	var errs []error
 	// flag to help determine if query prefix returned an empty iterator
 	var foundObject = false
-	filePath := filepath.Join(g.ModelDir, g.ModelName)
+	
 	for {
 		attrs, err := it.Next()
 		if err == iterator.Done {
@@ -89,9 +89,7 @@ func (g *GCSObjectDownloader) Download(client stiface.Client, it stiface.ObjectI
 		}
 		objectValue := strings.TrimPrefix(attrs.Name, g.Item)
 		fileName := filepath.Join(g.ModelDir, g.ModelName, objectValue)
-		if fileName == filePath {
-			continue
-		}
+		
 		foundObject = true
 		if FileExists(fileName) {
 			log.Info("Deleting", fileName)

--- a/pkg/agent/storage/s3.go
+++ b/pkg/agent/storage/s3.go
@@ -88,14 +88,14 @@ func (s *S3ObjectDownloader) GetAllObjects(s3Svc s3iface.S3API) ([]s3manager.Bat
 	}
 
 	var foundObject = false
-	filePath := filepath.Join(s.ModelDir, s.ModelName)
 
 	for _, object := range resp.Contents {
-		subObjectKey := strings.TrimPrefix(*object.Key, s.Prefix)
-		fileName := filepath.Join(s.ModelDir, s.ModelName, subObjectKey)
-		if fileName == filePath {
+		if strings.HasSuffix(*object.Key, "/") {
 			continue
 		}
+		subObjectKey := strings.TrimPrefix(*object.Key, s.Prefix)
+		fileName := filepath.Join(s.ModelDir, s.ModelName, subObjectKey)
+		
 		if FileExists(fileName) {
 			// File got corrupted or is mid-download :(
 			// TODO: Figure out if we can maybe continue?


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:
If a model is stored in a bucket in the format 
```
models/modelname/1/model.onnx
```
ListObjects API with the prefix `models/modelname/`  will return the below keys incase of s3
```
models/modelname/
models/modelname/1/
models/modelname/1/model.onnx
```

whereas in case of GCS it would return 
```
models/modelname/1/model.onnx
```

Incase of s3, the nested directories get's created as file inside the model directory /mnt/models. This fix will prevent that from happening. 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #1769 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
