### PR TITLE
Upgrade ray[serve] to version 1.5.0, allowing kfserving to be installed on python3.9

### DIFF
--- a/python/kfserving/kfserving/kfserver.py
+++ b/python/kfserving/kfserving/kfserver.py
@@ -29,7 +29,7 @@ from .utils import utils
 from kfserving.handlers.http import PredictHandler, ExplainHandler
 from kfserving import KFModel
 from kfserving.kfmodel_repository import KFModelRepository
-from ray.serve.api import RayServeHandle, ServeDeployment
+from ray.serve.api import Deployment, RayServeHandle
 from ray import serve
 
 DEFAULT_HTTP_PORT = 8080
@@ -95,7 +95,7 @@ class KFServer:
              UnloadHandler, dict(models=self.registered_models)),
         ])
 
-    def start(self, models: Union[List[KFModel], Dict[str, ServeDeployment]], nest_asyncio: bool = False):
+    def start(self, models: Union[List[KFModel], Dict[str, Deployment]], nest_asyncio: bool = False):
         if isinstance(models, list):
             for model in models:
                 if isinstance(model, KFModel):
@@ -103,7 +103,7 @@ class KFServer:
                 else:
                     raise RuntimeError("Model type should be KFModel")
         elif isinstance(models, dict):
-            if all([issubclass(v, ServeDeployment) for v in models.values()]):
+            if all([issubclass(v, Deployment) for v in models.values()]):
                 serve.start(detached=True, http_host='0.0.0.0', http_port=9071)
                 for key in models:
                     models[key].deploy()

--- a/python/kfserving/requirements.txt
+++ b/python/kfserving/requirements.txt
@@ -18,5 +18,5 @@ avro>=1.10.1
 boto3>=1.17.32
 botocore>=1.20.32
 psutil>=5.0
-ray[serve]==1.3.0
+ray[serve]>=1.5.0
 grpcio>=1.34.1

--- a/python/kfserving/setup.py
+++ b/python/kfserving/setup.py
@@ -25,7 +25,7 @@ with open('requirements.txt') as f:
 
 setuptools.setup(
     name='kfserving',
-    version='0.6.0',
+    version='0.6.1',
     author="Kubeflow Authors",
     author_email='ellisbigelow@google.com, hejinchi@cn.ibm.com, dsun20@bloomberg.net',
     license="Apache License Version 2.0",


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

`kfserving` currently cannot be installed on python versions >3.7 due to a hard dependency on `ray[serve]==1.3.0` which itself requires `python==3.7`. 

This PR updates the pinned `ray` version to `1.5.0` which does support newer python versions, and makes the necessary API changes. 

**Which issue(s) this PR fixes**:
Fixes #1753 

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note
Adds python3.9 support to KFServing.
```
