### PR TITLE
Fix AWS_REGION and add AWS_CA_BUNDLE to s3_secrets.go

### DIFF
--- a/pkg/credentials/s3/s3_secret.go
+++ b/pkg/credentials/s3/s3_secret.go
@@ -27,7 +27,7 @@ const (
 	AWSAccessKeyIdName     = "awsAccessKeyID"
 	AWSSecretAccessKeyName = "awsSecretAccessKey"
 	AWSEndpointUrl         = "AWS_ENDPOINT_URL"
-	AWSRegion              = "AWS_REGION"
+	AWSRegion              = "AWS_DEFAULT_REGION"
 	S3Endpoint             = "S3_ENDPOINT"
 	S3UseHttps             = "S3_USE_HTTPS"
 	S3VerifySSL            = "S3_VERIFY_SSL"

--- a/pkg/credentials/s3/s3_secret.go
+++ b/pkg/credentials/s3/s3_secret.go
@@ -21,6 +21,11 @@ import (
 	"k8s.io/api/core/v1"
 )
 
+/*
+For a quick reference about AWS ENV variables:
+AWS Cli: https://docs.aws.amazon.com/cli/latest/userguide/cli-configure-envvars.html
+Boto: https://boto3.amazonaws.com/v1/documentation/api/latest/guide/configuration.html#using-environment-variables
+*/
 const (
 	AWSAccessKeyId         = "AWS_ACCESS_KEY_ID"
 	AWSSecretAccessKey     = "AWS_SECRET_ACCESS_KEY"
@@ -33,6 +38,7 @@ const (
 	S3VerifySSL            = "S3_VERIFY_SSL"
 	S3UseVirtualBucket     = "S3_USER_VIRTUAL_BUCKET"
 	AWSAnonymousCredential = "awsAnonymousCredential"
+	AWSCABundle            = "AWS_CA_BUNDLE"
 )
 
 type S3Config struct {
@@ -49,6 +55,7 @@ var (
 	InferenceServiceS3SecretHttpsAnnotation      = constants.KFServingAPIGroupName + "/" + "s3-usehttps"
 	InferenceServiceS3UseVirtualBucketAnnotation = constants.KFServingAPIGroupName + "/" + "s3-usevirtualbucket"
 	InferenceServiceS3UseAnonymousCredential     = constants.KFServingAPIGroupName + "/" + "s3-useanoncredential"
+	InferenceServiceS3CABundleAnnotation         = constants.KFServingAPIGroupName + "/" + "s3-cabundle"
 )
 
 func BuildSecretEnvs(secret *v1.Secret, s3Config *S3Config) []v1.EnvVar {
@@ -151,6 +158,13 @@ func BuildSecretEnvs(secret *v1.Secret, s3Config *S3Config) []v1.EnvVar {
 		envs = append(envs, v1.EnvVar{
 			Name:  S3UseVirtualBucket,
 			Value: useVirtualBucket,
+		})
+	}
+
+	if customCABundle, ok := secret.Annotations[InferenceServiceS3CABundleAnnotation]; ok {
+		envs = append(envs, v1.EnvVar{
+			Name:  AWSCABundle,
+			Value: customCABundle,
 		})
 	}
 	return envs

--- a/python/kfserving/kfserving/api/creds_utils.py
+++ b/python/kfserving/kfserving/api/creds_utils.py
@@ -67,7 +67,7 @@ def set_s3_credentials(namespace, credentials_file, service_account,
                               is specified, will attach created secret with the service account,
                               otherwise will create new one and attach with created secret.
         s3_endpoint(str): S3 settings variable S3_ENDPOINT.
-        s3_region(str): S3 settings variable AWS_REGION.
+        s3_region(str): S3 settings variable AWS_DEFAULT_REGION.
         s3_use_https(str): S3 settings variable S3_USE_HTTPS.
         s3_verify_ssl(str): S3 settings variable S3_VERIFY_SSL.
     """

--- a/python/kfserving/kfserving/api/creds_utils.py
+++ b/python/kfserving/kfserving/api/creds_utils.py
@@ -56,7 +56,7 @@ def set_gcs_credentials(namespace, credentials_file, service_account):
 def set_s3_credentials(namespace, credentials_file, service_account,
                        s3_profile='default',  # pylint: disable=too-many-locals,too-many-arguments
                        s3_endpoint=None, s3_region=None, s3_use_https=None,
-                       s3_verify_ssl=None):  # pylint: disable=unused-argument
+                       s3_verify_ssl=None, s3_cabundle=None):  # pylint: disable=unused-argument
     """
     Set S3 Credentails (secret and service account).
     Args:
@@ -70,6 +70,7 @@ def set_s3_credentials(namespace, credentials_file, service_account,
         s3_region(str): S3 settings variable AWS_DEFAULT_REGION.
         s3_use_https(str): S3 settings variable S3_USE_HTTPS.
         s3_verify_ssl(str): S3 settings variable S3_VERIFY_SSL.
+        s3_cabundle(str): S3 settings variable AWS_CA_BUNDLE.
     """
 
     config = configparser.ConfigParser()
@@ -99,6 +100,7 @@ def set_s3_credentials(namespace, credentials_file, service_account,
         's3_region': constants.KFSERVING_GROUP + "/s3-region",
         's3_use_https': constants.KFSERVING_GROUP + "/s3-usehttps",
         's3_verify_ssl': constants.KFSERVING_GROUP + "/s3-verifyssl",
+        's3_cabundle': constants.KFSERVING_GROUP + "/s3-cabundle",
     }
 
     s3_annotations = {}


### PR DESCRIPTION
The boto3 package seems to look for AWS_DEFAULT_REGION, meanwhile
kfserving uses AWS_REGION, that doesn't seem to be working
(tested following
https://github.com/kubeflow/kfserving/blob/master/docs/samples/storage/s3/README.md).

This change doesn't replace all occurrences of AWS_REGION, but only
the ones that set the environment variables.

GH-1765

Add also the possibility to force boto to use a custom CA Bundle path when validating the TLS certificate of the S3 endpoint. Our use case is related to using an internal S3 endpoint (based on Openstack Swift) offering a TLS certificate signed by our internal CA.

GH-1766

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
