### PR TITLE
Upgrade Feast transformer for v0.12.1

### DIFF
--- a/docs/samples/v1beta1/transformer/feast/README.md
+++ b/docs/samples/v1beta1/transformer/feast/README.md
@@ -70,13 +70,13 @@ Expected Output
 >
 * upload completely sent off: 57 out of 57 bytes
 < HTTP/1.1 200 OK
-< content-length: 117
+< content-length: 119
 < content-type: application/json; charset=UTF-8
-< date: Thu, 27 May 2021 00:34:21 GMT
+< date: Thu, 02 Sep 2021 19:27:55 GMT
 < server: istio-envoy
-< x-envoy-upstream-service-time: 47
+< x-envoy-upstream-service-time: 30
 <
 * Connection #0 to host 1.2.3.4 left intact
-{"predictions": [1.8440737040128852, 1.7381656744054226, 3.6771303027855993, 2.241143189554492, 0.06753551272342406]}
+{"predictions": [-1.7783805127914718, 2.7682636004737162, 3.8109928578957977, 0.31319656700671317, 0.7741179292417257]}
 ```
 

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer.Dockerfile
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer.Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.7-slim
+FROM python:3.8-slim
 
 RUN apt-get update \
 && apt-get install -y --no-install-recommends git

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer.yaml
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer.yaml
@@ -17,9 +17,9 @@ spec:
       - --entity_ids
       - driver_id
       - --feature_refs
-      - driver_statistics:acc_rate 
-      - driver_statistics:avg_daily_trips 
-      - driver_statistics:conv_rate
+      - driver_hourly_stats:acc_rate
+      - driver_hourly_stats:avg_daily_trips
+      - driver_hourly_stats:conv_rate
   predictor:
     sklearn:
       storageUri: "gs://pv-kfserving/driver"

--- a/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
+++ b/docs/samples/v1beta1/transformer/feast/driver_transformer/__main__.py
@@ -32,7 +32,7 @@ parser.add_argument(
 parser.add_argument(
     "--feast_serving_url",
     type=str,
-    help="The url of the Feast Serving Service.", required=True)
+    help="The url of the Feast feature server.", required=True)
 parser.add_argument(
     "--entity_ids",
     type=str, nargs="+",

--- a/docs/samples/v1beta1/transformer/feast/setup.py
+++ b/docs/samples/v1beta1/transformer/feast/setup.py
@@ -22,7 +22,7 @@ tests_require = [
 
 setup(
     name='driver_transformer',
-    version='0.1.0',
+    version='0.2.0',
     author_email='chhuang@us.ibm.com',
     license='../../LICENSE.txt',
     url='https://github.com/kubeflow/kfserving/docs/samples/v1beta1/fesat/driver_transformer',
@@ -31,10 +31,9 @@ setup(
     python_requires='>=3.6',
     packages=find_packages("driver_transformer"),
     install_requires=[
-        "kfserving>=0.5.1",
+        "kfserving>=0.6.0",
         "requests>=2.22.0",
-        "numpy>=1.16.3",
-        "feast==0.9.0"
+        "numpy>=1.16.3"
     ],
     tests_require=tests_require,
     extras_require={'test': tests_require}


### PR DESCRIPTION
Made the following changes for Feast transformer to support the
latest Feast v0.12.1
1. Change the python client API to rest API
2. Use the new Feast feature server
3. Use python 3.8
4. Update sample outputs in doc

<!--  Thanks for sending a pull request!  Here are some tips for you:
1. If this is your first time, read our contributor guidelines https://www.kubeflow.org/docs/about/contributing/ and developer guide https://github.com/kubeflow/kfserving/blob/master/docs/DEVELOPER_GUIDE.md
2. If you want *faster* PR reviews, read how: https://git.k8s.io/community/contributors/guide/pull-requests.md#best-practices-for-faster-reviews
3. Follow the instructions for writing a release note: https://git.k8s.io/community/contributors/guide/release-notes.md
4. If the PR is unfinished, see how to mark it: https://git.k8s.io/community/contributors/guide/pull-requests.md#marking-unfinished-pull-requests
-->

**What this PR does / why we need it**:

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

1. Please confirm that if this PR changes any image versions, then that's the sole change this PR makes.

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
