### PR TITLE
feat(llmisvc): add heterogeneous GPUs load balancing sample

### DIFF
--- a/docs/samples/llmisvc/multi-gpu-vendor/README.md
+++ b/docs/samples/llmisvc/multi-gpu-vendor/README.md
@@ -1,0 +1,141 @@
+# Multi-GPU-Vendor Deployment Example
+
+Deploy the same model across NVIDIA and AMD GPUs using two LLMInferenceService instances that share a single
+scheduler/EPP via a custom InferencePool selector.
+
+## Problem
+
+A cluster has both NVIDIA and AMD GPU nodes. A single LLMInferenceService can only target one GPU type because all
+replicas share the same pod template. Without this pattern, one GPU vendor's capacity sits idle.
+
+## Solution
+
+1. **NVIDIA instance** (`qwen2-7b-instruct-nvidia`) — creates the scheduler/EPP, InferencePool, HTTPRoute, and Gateway.
+   The InferencePool uses a custom selector (`llm-pool: qwen2-7b`) instead of the default name-based selector.
+2. **AMD instance** (`qwen2-7b-instruct-amd`) — has **no router** (no scheduler, no route, no gateway). Its pods carry
+   the same `llm-pool: qwen2-7b` label, so the EPP from the NVIDIA instance discovers and routes traffic to them.
+
+## Architecture
+
+```
+                         ┌──────────────┐
+                         │   Gateway    │
+                         └──────┬───────┘
+                                │
+                         ┌──────┴───────┐
+                         │  HTTPRoute   │
+                         └──────┬───────┘
+                                │
+                    ┌───────────┴───────────┐
+                    │   Scheduler / EPP     │
+                    │  (from NVIDIA isvc)   │
+                    └───────────┬───────────┘
+                                │
+                    InferencePool selector:
+                      llm-pool: qwen2-7b
+                      kserve.io/component: workload
+                                │
+              ┌─────────────────┼─────────────────┐
+              │                                   │
+   ┌──────────┴──────────┐             ┌──────────┴──────────┐
+   │  NVIDIA vLLM Pods   │             │   AMD vLLM Pods     │
+   │  (3 replicas)       │             │   (2 replicas)      │
+   │  nvidia.com/gpu: 1  │             │  amd.com/gpu: 1     │
+   └─────────────────────┘             └─────────────────────┘
+```
+
+## How It Works
+
+By default, the controller sets the InferencePool selector to match on `app.kubernetes.io/name: <service-name>`,
+which only selects pods from that single LLMInferenceService. To pool pods from multiple instances together, the
+NVIDIA instance overrides the selector with a shared custom label:
+
+```yaml
+# NVIDIA instance — custom pool selector
+spec:
+  labels:
+    llm-pool: qwen2-7b          # added to all workload pods
+  router:
+    scheduler:
+      pool:
+        spec:
+          selector:
+            matchLabels:
+              llm-pool: qwen2-7b           # shared across instances
+              kserve.io/component: workload # only select workload pods
+```
+
+The AMD instance carries the same label but has no router:
+
+```yaml
+# AMD instance — no router, shared label
+spec:
+  labels:
+    llm-pool: qwen2-7b          # matches the InferencePool selector
+  # no router section
+```
+
+## Prerequisites
+
+- Kubernetes cluster with both NVIDIA and AMD GPU nodes
+- Nodes labeled appropriately (e.g., `nvidia.com/gpu.present: "true"`, `amd.com/gpu.present: "true"`)
+- Model weights accessible via HuggingFace
+
+## Deployment
+
+```bash
+# 1. Deploy the NVIDIA instance (creates InferencePool, EPP, HTTPRoute, Gateway)
+kubectl apply -f llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
+
+# 2. Deploy the AMD instance (pods join the existing InferencePool via shared label)
+kubectl apply -f llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
+```
+
+## Configuration Summary
+
+| Feature         | NVIDIA Instance                   | AMD Instance         |
+|-----------------|-----------------------------------|----------------------|
+| Replicas        | 3                                 | 2                    |
+| GPU             | 1x NVIDIA per replica             | 1x AMD per replica   |
+| Scheduler / EPP | Yes (creates InferencePool + EPP) | No                   |
+| Route / Gateway | Yes                               | No                   |
+| Shared label    | `llm-pool: qwen2-7b`              | `llm-pool: qwen2-7b` |
+
+## Verification
+
+```bash
+# Check both services
+kubectl get llminferenceservice
+
+# Verify pods are on the correct GPU nodes
+kubectl get pods -o wide -l llm-pool=qwen2-7b
+
+# Confirm the InferencePool selects pods from both instances
+kubectl get inferencepool -o yaml
+
+# Check scheduler logs for routing across all replicas
+kubectl logs -l app.kubernetes.io/component=llminferenceservice-scheduler -f
+
+# Send a test request
+curl -k https://<route-url>/v1/completions \
+  -H "Content-Type: application/json" \
+  -d '{
+    "model": "Qwen/Qwen2.5-7B-Instruct",
+    "prompt": "What is Kubernetes?",
+    "max_tokens": 100
+  }'
+```
+
+## Scaling
+
+Each instance can be scaled independently:
+
+```bash
+# Scale NVIDIA replicas
+kubectl patch llmisvc qwen2-7b-instruct-nvidia --type merge -p '{"spec":{"replicas":5}}'
+
+# Scale AMD replicas
+kubectl patch llmisvc qwen2-7b-instruct-amd --type merge -p '{"spec":{"replicas":4}}'
+```
+
+The EPP automatically discovers new pods as they match the shared `llm-pool: qwen2-7b` label.

--- a/docs/samples/llmisvc/multi-gpu-vendor/README.md
+++ b/docs/samples/llmisvc/multi-gpu-vendor/README.md
@@ -1,7 +1,7 @@
 # Multi-GPU-Vendor Deployment Example
 
 Deploy the same model across NVIDIA and AMD GPUs using two LLMInferenceService instances that share a single
-scheduler/EPP via a custom InferencePool selector.
+scheduler/EPP via workload label propagation.
 
 ## Problem
 
@@ -11,9 +11,10 @@ replicas share the same pod template. Without this pattern, one GPU vendor's cap
 ## Solution
 
 1. **NVIDIA instance** (`qwen2-7b-instruct-nvidia`) — creates the scheduler/EPP, InferencePool, HTTPRoute, and Gateway.
-   The InferencePool uses a custom selector (`llm-pool: qwen2-7b`) instead of the default name-based selector.
+   The InferencePool uses the default selector (`app.kubernetes.io/name: qwen2-7b-instruct-nvidia`,
+   `app.kubernetes.io/part-of: llminferenceservice`, `kserve.io/component: workload`).
 2. **AMD instance** (`qwen2-7b-instruct-amd`) — has **no router** (no scheduler, no route, no gateway). Its pods carry
-   the same `llm-pool: qwen2-7b` label, so the EPP from the NVIDIA instance discovers and routes traffic to them.
+   the NVIDIA instance's workload labels via `spec.labels`, so the EPP discovers and routes traffic to them.
 
 ## Architecture
 
@@ -32,7 +33,8 @@ replicas share the same pod template. Without this pattern, one GPU vendor's cap
                     └───────────┬───────────┘
                                 │
                     InferencePool selector:
-                      llm-pool: qwen2-7b
+                      app.kubernetes.io/name: qwen2-7b-instruct-nvidia
+                      app.kubernetes.io/part-of: llminferenceservice
                       kserve.io/component: workload
                                 │
               ┌─────────────────┼─────────────────┐
@@ -46,34 +48,26 @@ replicas share the same pod template. Without this pattern, one GPU vendor's cap
 
 ## How It Works
 
-By default, the controller sets the InferencePool selector to match on `app.kubernetes.io/name: <service-name>`,
-which only selects pods from that single LLMInferenceService. To pool pods from multiple instances together, the
-NVIDIA instance overrides the selector with a shared custom label:
+The controller sets the InferencePool selector using the NVIDIA instance's default workload labels
+(`app.kubernetes.io/name`, `app.kubernetes.io/part-of`, `kserve.io/component`). To make the AMD pods
+discoverable by the same InferencePool, the AMD instance overrides these labels via `spec.labels`:
 
 ```yaml
-# NVIDIA instance — custom pool selector
+# AMD instance — no router, labels match the NVIDIA InferencePool selector
 spec:
   labels:
-    llm-pool: qwen2-7b          # added to all workload pods
-  router:
-    scheduler:
-      pool:
-        spec:
-          selector:
-            matchLabels:
-              llm-pool: qwen2-7b           # shared across instances
-              kserve.io/component: workload # only select workload pods
-```
-
-The AMD instance carries the same label but has no router:
-
-```yaml
-# AMD instance — no router, shared label
-spec:
-  labels:
-    llm-pool: qwen2-7b          # matches the InferencePool selector
+    app.kubernetes.io/name: qwen2-7b-instruct-nvidia
+    app.kubernetes.io/part-of: llminferenceservice
+    kserve.io/component: workload
   # no router section
 ```
+
+Because `spec.labels` is propagated to the pod template **after** the controller sets its own default labels,
+the AMD pods' `app.kubernetes.io/name` is overwritten from `qwen2-7b-instruct-amd` to
+`qwen2-7b-instruct-nvidia`, making them match the NVIDIA InferencePool's selector.
+
+The two Deployments do not conflict despite sharing label values because Kubernetes injects a unique
+`pod-template-hash` label into each Deployment's ReplicaSet selector, keeping pod ownership isolated.
 
 ## Prerequisites
 
@@ -87,19 +81,19 @@ spec:
 # 1. Deploy the NVIDIA instance (creates InferencePool, EPP, HTTPRoute, Gateway)
 kubectl apply -f llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
 
-# 2. Deploy the AMD instance (pods join the existing InferencePool via shared label)
+# 2. Deploy the AMD instance (pods join the existing InferencePool via shared labels)
 kubectl apply -f llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
 ```
 
 ## Configuration Summary
 
-| Feature         | NVIDIA Instance                   | AMD Instance         |
-|-----------------|-----------------------------------|----------------------|
-| Replicas        | 3                                 | 2                    |
-| GPU             | 1x NVIDIA per replica             | 1x AMD per replica   |
-| Scheduler / EPP | Yes (creates InferencePool + EPP) | No                   |
-| Route / Gateway | Yes                               | No                   |
-| Shared label    | `llm-pool: qwen2-7b`              | `llm-pool: qwen2-7b` |
+| Feature         | NVIDIA Instance                   | AMD Instance                           |
+|-----------------|-----------------------------------|----------------------------------------|
+| Replicas        | 3                                 | 2                                      |
+| GPU             | 1x NVIDIA per replica             | 1x AMD per replica                     |
+| Scheduler / EPP | Yes (creates InferencePool + EPP) | No                                     |
+| Route / Gateway | Yes                               | No                                     |
+| Labels override | None (uses defaults)              | Overrides `app.kubernetes.io/name` etc. |
 
 ## Verification
 
@@ -108,7 +102,7 @@ kubectl apply -f llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
 kubectl get llminferenceservice
 
 # Verify pods are on the correct GPU nodes
-kubectl get pods -o wide -l llm-pool=qwen2-7b
+kubectl get pods -o wide -l app.kubernetes.io/name=qwen2-7b-instruct-nvidia
 
 # Confirm the InferencePool selects pods from both instances
 kubectl get inferencepool -o yaml
@@ -138,4 +132,4 @@ kubectl patch llmisvc qwen2-7b-instruct-nvidia --type merge -p '{"spec":{"replic
 kubectl patch llmisvc qwen2-7b-instruct-amd --type merge -p '{"spec":{"replicas":4}}'
 ```
 
-The EPP automatically discovers new pods as they match the shared `llm-pool: qwen2-7b` label.
+The EPP automatically discovers new pods as they match the workload labels.

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
@@ -1,0 +1,29 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: qwen2-7b-instruct-amd
+spec:
+  model:
+    uri: hf://Qwen/Qwen2.5-7B-Instruct
+    name: Qwen/Qwen2.5-7B-Instruct
+  replicas: 2
+  # Same shared label as the NVIDIA instance so that the InferencePool
+  # selector (llm-pool: qwen2-7b) matches these pods too.
+  labels:
+    llm-pool: qwen2-7b
+  # No router — no scheduler, no route, no gateway.
+  # Traffic reaches these pods through the shared InferencePool
+  # managed by the NVIDIA LLMInferenceService's scheduler/EPP.
+  template:
+    containers:
+      - name: main
+        image: ghcr.io/llm-d/llm-d-rocm:v0.6.0
+        resources:
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            amd.com/gpu: "1"
+          requests:
+            cpu: '2'
+            memory: 16Gi
+            amd.com/gpu: "1"

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-amd-no-scheduler.yaml
@@ -8,9 +8,12 @@ spec:
     name: Qwen/Qwen2.5-7B-Instruct
   replicas: 2
   # Same shared label as the NVIDIA instance so that the InferencePool
-  # selector (llm-pool: qwen2-7b) matches these pods too.
+  # selector matches these pods too.
   labels:
-    llm-pool: qwen2-7b
+    app.kubernetes.io/name: qwen2-7b-instruct-nvidia
+    app.kubernetes.io/part-of: llminferenceservice
+    kserve.io/component: workload
+
   # No router — no scheduler, no route, no gateway.
   # Traffic reaches these pods through the shared InferencePool
   # managed by the NVIDIA LLMInferenceService's scheduler/EPP.

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
@@ -7,22 +7,8 @@ spec:
     uri: hf://Qwen/Qwen2.5-7B-Instruct
     name: Qwen/Qwen2.5-7B-Instruct
   replicas: 3
-  # Shared label so the InferencePool selector can match pods from both
-  # the NVIDIA and AMD LLMInferenceService instances.
-  labels:
-    llm-pool: qwen2-7b
   router:
-    scheduler:
-      pool:
-        spec:
-          # Select all workload pods with the shared "llm-pool: qwen2-7b" label,
-          # regardless of which LLMInferenceService created them.
-          selector:
-            matchLabels:
-              llm-pool: qwen2-7b
-              kserve.io/component: workload
-          targetPorts:
-            - port: 8000
+    scheduler: { }
     route: { }
     gateway: { }
   template:

--- a/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
+++ b/docs/samples/llmisvc/multi-gpu-vendor/llm-inference-service-qwen2-7b-nvidia-with-scheduler.yaml
@@ -1,0 +1,39 @@
+apiVersion: serving.kserve.io/v1alpha1
+kind: LLMInferenceService
+metadata:
+  name: qwen2-7b-instruct-nvidia
+spec:
+  model:
+    uri: hf://Qwen/Qwen2.5-7B-Instruct
+    name: Qwen/Qwen2.5-7B-Instruct
+  replicas: 3
+  # Shared label so the InferencePool selector can match pods from both
+  # the NVIDIA and AMD LLMInferenceService instances.
+  labels:
+    llm-pool: qwen2-7b
+  router:
+    scheduler:
+      pool:
+        spec:
+          # Select all workload pods with the shared "llm-pool: qwen2-7b" label,
+          # regardless of which LLMInferenceService created them.
+          selector:
+            matchLabels:
+              llm-pool: qwen2-7b
+              kserve.io/component: workload
+          targetPorts:
+            - port: 8000
+    route: { }
+    gateway: { }
+  template:
+    containers:
+      - name: main
+        resources:
+          limits:
+            cpu: '4'
+            memory: 32Gi
+            nvidia.com/gpu: "1"
+          requests:
+            cpu: '2'
+            memory: 16Gi
+            nvidia.com/gpu: "1"

--- a/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/config_merge_test.go
@@ -1282,6 +1282,136 @@ func TestMergeSpecs(t *testing.T) {
 				},
 			},
 		},
+		{
+			name: "custom pool selector overrides base empty selector",
+			cfgs: []v1alpha2.LLMInferenceServiceSpec{
+				// Base config with pool spec but no selector
+				{
+					Router: &v1alpha2.RouterSpec{
+						Route:   &v1alpha2.GatewayRoutesSpec{},
+						Gateway: &v1alpha2.GatewaySpec{},
+						Scheduler: &v1alpha2.SchedulerSpec{
+							Pool: &v1alpha2.InferencePoolSpec{
+								Spec: &igwapi.InferencePoolSpec{
+									TargetPorts: []igwapi.Port{{Number: 8000}},
+								},
+							},
+							Template: &corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main"}},
+							},
+						},
+					},
+				},
+				// Override with custom selector for multi-GPU-vendor pooling
+				{
+					Router: &v1alpha2.RouterSpec{
+						Scheduler: &v1alpha2.SchedulerSpec{
+							Pool: &v1alpha2.InferencePoolSpec{
+								Spec: &igwapi.InferencePoolSpec{
+									Selector: igwapi.LabelSelector{
+										MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+											"llm-pool":            "qwen2-7b",
+											"kserve.io/component": "workload",
+										},
+									},
+									TargetPorts: []igwapi.Port{{Number: 8000}},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Route:   &v1alpha2.GatewayRoutesSpec{},
+					Gateway: &v1alpha2.GatewaySpec{},
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Pool: &v1alpha2.InferencePoolSpec{
+							Spec: &igwapi.InferencePoolSpec{
+								Selector: igwapi.LabelSelector{
+									MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+										"llm-pool":            "qwen2-7b",
+										"kserve.io/component": "workload",
+									},
+								},
+								TargetPorts: []igwapi.Port{{Number: 8000}},
+							},
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "main"}},
+						},
+					},
+				},
+			},
+		},
+		{
+			name: "custom pool selector merge base selector",
+			cfgs: []v1alpha2.LLMInferenceServiceSpec{
+				// Base config with pool spec but no selector
+				{
+					Router: &v1alpha2.RouterSpec{
+						Route:   &v1alpha2.GatewayRoutesSpec{},
+						Gateway: &v1alpha2.GatewaySpec{},
+						Scheduler: &v1alpha2.SchedulerSpec{
+							Pool: &v1alpha2.InferencePoolSpec{
+								Spec: &igwapi.InferencePoolSpec{
+									Selector: igwapi.LabelSelector{
+										MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+											"x": "x",
+										},
+									},
+									TargetPorts: []igwapi.Port{{Number: 8000}},
+								},
+							},
+							Template: &corev1.PodSpec{
+								Containers: []corev1.Container{{Name: "main"}},
+							},
+						},
+					},
+				},
+				// Override with custom selector for multi-GPU-vendor pooling
+				{
+					Router: &v1alpha2.RouterSpec{
+						Scheduler: &v1alpha2.SchedulerSpec{
+							Pool: &v1alpha2.InferencePoolSpec{
+								Spec: &igwapi.InferencePoolSpec{
+									Selector: igwapi.LabelSelector{
+										MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+											"llm-pool":            "qwen2-7b",
+											"kserve.io/component": "workload",
+										},
+									},
+									TargetPorts: []igwapi.Port{{Number: 8000}},
+								},
+							},
+						},
+					},
+				},
+			},
+			want: v1alpha2.LLMInferenceServiceSpec{
+				Router: &v1alpha2.RouterSpec{
+					Route:   &v1alpha2.GatewayRoutesSpec{},
+					Gateway: &v1alpha2.GatewaySpec{},
+					Scheduler: &v1alpha2.SchedulerSpec{
+						Pool: &v1alpha2.InferencePoolSpec{
+							Spec: &igwapi.InferencePoolSpec{
+								Selector: igwapi.LabelSelector{
+									MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+										"llm-pool":            "qwen2-7b",
+										"kserve.io/component": "workload",
+										"x":                   "x",
+									},
+								},
+								TargetPorts: []igwapi.Port{{Number: 8000}},
+							},
+						},
+						Template: &corev1.PodSpec{
+							Containers: []corev1.Container{{Name: "main"}},
+						},
+					},
+				},
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -1298,6 +1428,21 @@ func TestMergeSpecs(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestGetWorkloadLabelSelectorUsedAsDefaultPoolSelector(t *testing.T) {
+	// Verify that GetWorkloadLabelSelector returns the labels used as default
+	// InferencePool selector in combineBaseRefsConfig (config_merge.go:232-244).
+	// When a user provides custom MatchLabels (e.g., for multi-GPU-vendor pooling),
+	// the default selector is not applied because MatchLabels is non-empty.
+	meta := metav1.ObjectMeta{Name: "test-svc", Namespace: "default"}
+	selector := llmisvc.GetWorkloadLabelSelector(meta, nil)
+
+	g := NewWithT(t)
+	g.Expect(selector).To(HaveKeyWithValue("app.kubernetes.io/name", "test-svc"))
+	g.Expect(selector).To(HaveKeyWithValue("app.kubernetes.io/part-of", "llminferenceservice"))
+	g.Expect(selector).To(HaveKeyWithValue("kserve.io/component", "workload"))
+	g.Expect(selector).To(HaveLen(3))
 }
 
 func TestReplaceVariables(t *testing.T) {

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1514,7 +1514,7 @@ schedulingProfiles:
 			// Verify InferencePool is created with default workload label selector
 			ip := &igwapi.InferencePool{}
 			Eventually(func(g Gomega, ctx context.Context) error {
-				return envTest.Client.Get(ctx, client.ObjectKey{
+				return envTest.Get(ctx, client.ObjectKey{
 					Name:      nvidiaSvcName + "-inference-pool",
 					Namespace: testNs.Name,
 				}, ip)
@@ -1570,7 +1570,7 @@ schedulingProfiles:
 
 			// Verify no scheduler deployment was created for the AMD instance
 			amdScheduler := &appsv1.Deployment{}
-			err = envTest.Client.Get(ctx, client.ObjectKey{
+			err = envTest.Get(ctx, client.ObjectKey{
 				Name:      amdSvcName + "-kserve-epp",
 				Namespace: testNs.Name,
 			}, amdScheduler)

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -1547,7 +1547,7 @@ schedulingProfiles:
 			// match the NVIDIA InferencePool selector
 			amdDeployment := &appsv1.Deployment{}
 			Eventually(func(g Gomega, ctx context.Context) error {
-				return envTest.Client.Get(ctx, client.ObjectKey{
+				return envTest.Get(ctx, client.ObjectKey{
 					Name:      amdSvcName + "-kserve",
 					Namespace: testNs.Name,
 				}, amdDeployment)
@@ -1561,7 +1561,7 @@ schedulingProfiles:
 
 			// Verify no InferencePool was created for the AMD instance
 			amdIP := &igwapi.InferencePool{}
-			err := envTest.Client.Get(ctx, client.ObjectKey{
+			err := envTest.Get(ctx, client.ObjectKey{
 				Name:      amdSvcName + "-inference-pool",
 				Namespace: testNs.Name,
 			}, amdIP)

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -33,6 +33,8 @@ import (
 	"knative.dev/pkg/kmeta"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 
+	igwapi "sigs.k8s.io/gateway-api-inference-extension/api/v1"
+
 	"github.com/kserve/kserve/pkg/apis/serving/v1alpha2"
 	"github.com/kserve/kserve/pkg/constants"
 	. "github.com/kserve/kserve/pkg/controller/v1alpha2/llmisvc/fixture"
@@ -1482,6 +1484,103 @@ schedulingProfiles:
 					corev1.LocalObjectReference{Name: "new-secret"}))
 				return nil
 			}).WithContext(ctx).Should(Succeed())
+		})
+	})
+
+	Context("Custom InferencePool selector for multi-GPU-vendor pooling", func() {
+		It("should use custom pool selector when MatchLabels are provided", func(ctx SpecContext) {
+			// This test verifies the multi-GPU-vendor pooling pattern where a user provides
+			// a custom InferencePool selector (e.g., llm-pool: qwen2-7b) so that pods from
+			// multiple LLMInferenceService instances (NVIDIA + AMD) can be pooled together.
+			svcName := "test-llm-custom-pool-selector"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+				WithWorkloadLabels(map[string]string{
+					"llm-pool": "qwen2-7b",
+				}),
+			)
+			// Set custom pool selector with required endpointPickerRef
+			llmSvc.Spec.Router.Scheduler.Pool = &v1alpha2.InferencePoolSpec{
+				Spec: &igwapi.InferencePoolSpec{
+					Selector: igwapi.LabelSelector{
+						MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
+							"llm-pool":            "qwen2-7b",
+							"kserve.io/component": "workload",
+						},
+					},
+					TargetPorts: []igwapi.Port{{Number: 8000}},
+					EndpointPickerRef: igwapi.EndpointPickerRef{
+						Kind:        "Service",
+						Name:        igwapi.ObjectName(svcName + "-kserve-epp"),
+						Port:        &igwapi.Port{Number: 9002},
+						FailureMode: igwapi.EndpointPickerFailOpen,
+					},
+				},
+			}
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - verify the InferencePool is created with the custom selector
+			ip := &igwapi.InferencePool{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Client.Get(ctx, client.ObjectKey{
+					Name:      svcName + "-inference-pool",
+					Namespace: testNs.Name,
+				}, ip)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveLen(2))
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("llm-pool"), igwapi.LabelValue("qwen2-7b")))
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("kserve.io/component"), igwapi.LabelValue("workload")))
+			// Should NOT contain the default app.kubernetes.io/name selector
+			Expect(ip.Spec.Selector.MatchLabels).ToNot(HaveKey(igwapi.LabelKey("app.kubernetes.io/name")))
+		})
+
+		It("should default pool selector to workload labels when no MatchLabels are provided", func(ctx SpecContext) {
+			svcName := "test-llm-default-pool-selector"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+
+			llmSvc := LLMInferenceService(svcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithManagedRoute(),
+				WithManagedGateway(),
+				WithManagedScheduler(),
+			)
+
+			// when
+			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, llmSvc)
+			}()
+
+			// then - verify the InferencePool uses default workload label selector
+			ip := &igwapi.InferencePool{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Client.Get(ctx, client.ObjectKey{
+					Name:      svcName + "-inference-pool",
+					Namespace: testNs.Name,
+				}, ip)
+			}).WithContext(ctx).Should(Succeed())
+
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("app.kubernetes.io/name"), igwapi.LabelValue(svcName)))
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("kserve.io/component"), igwapi.LabelValue("workload")))
+			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
+				igwapi.LabelKey("app.kubernetes.io/part-of"), igwapi.LabelValue("llminferenceservice")))
 		})
 	})
 })

--- a/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
+++ b/pkg/controller/v1alpha2/llmisvc/controller_int_scheduler_config_test.go
@@ -26,6 +26,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	rbacv1 "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/client-go/util/retry"
@@ -1487,72 +1488,17 @@ schedulingProfiles:
 		})
 	})
 
-	Context("Custom InferencePool selector for multi-GPU-vendor pooling", func() {
-		It("should use custom pool selector when MatchLabels are provided", func(ctx SpecContext) {
-			// This test verifies the multi-GPU-vendor pooling pattern where a user provides
-			// a custom InferencePool selector (e.g., llm-pool: qwen2-7b) so that pods from
-			// multiple LLMInferenceService instances (NVIDIA + AMD) can be pooled together.
-			svcName := "test-llm-custom-pool-selector"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
+	Context("Multi-GPU-vendor pooling via workload label propagation", func() {
+		It("should create InferencePool with default workload labels that AMD pods can match", func(ctx SpecContext) {
+			// This test verifies the multi-GPU-vendor pooling pattern:
+			// 1. NVIDIA instance with default scheduler creates InferencePool with default workload labels
+			// 2. AMD instance with no router uses spec.labels to match the NVIDIA InferencePool selector
+			nvidiaSvcName := "test-llm-nvidia"
+			amdSvcName := "test-llm-amd"
+			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(nvidiaSvcName))
 
-			llmSvc := LLMInferenceService(svcName,
-				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
-				WithModelURI("hf://facebook/opt-125m"),
-				WithManagedRoute(),
-				WithManagedGateway(),
-				WithManagedScheduler(),
-				WithWorkloadLabels(map[string]string{
-					"llm-pool": "qwen2-7b",
-				}),
-			)
-			// Set custom pool selector with required endpointPickerRef
-			llmSvc.Spec.Router.Scheduler.Pool = &v1alpha2.InferencePoolSpec{
-				Spec: &igwapi.InferencePoolSpec{
-					Selector: igwapi.LabelSelector{
-						MatchLabels: map[igwapi.LabelKey]igwapi.LabelValue{
-							"llm-pool":            "qwen2-7b",
-							"kserve.io/component": "workload",
-						},
-					},
-					TargetPorts: []igwapi.Port{{Number: 8000}},
-					EndpointPickerRef: igwapi.EndpointPickerRef{
-						Kind:        "Service",
-						Name:        igwapi.ObjectName(svcName + "-kserve-epp"),
-						Port:        &igwapi.Port{Number: 9002},
-						FailureMode: igwapi.EndpointPickerFailOpen,
-					},
-				},
-			}
-
-			// when
-			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
-			defer func() {
-				testNs.DeleteAndWait(ctx, llmSvc)
-			}()
-
-			// then - verify the InferencePool is created with the custom selector
-			ip := &igwapi.InferencePool{}
-			Eventually(func(g Gomega, ctx context.Context) error {
-				return envTest.Client.Get(ctx, client.ObjectKey{
-					Name:      svcName + "-inference-pool",
-					Namespace: testNs.Name,
-				}, ip)
-			}).WithContext(ctx).Should(Succeed())
-
-			Expect(ip.Spec.Selector.MatchLabels).To(HaveLen(2))
-			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
-				igwapi.LabelKey("llm-pool"), igwapi.LabelValue("qwen2-7b")))
-			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
-				igwapi.LabelKey("kserve.io/component"), igwapi.LabelValue("workload")))
-			// Should NOT contain the default app.kubernetes.io/name selector
-			Expect(ip.Spec.Selector.MatchLabels).ToNot(HaveKey(igwapi.LabelKey("app.kubernetes.io/name")))
-		})
-
-		It("should default pool selector to workload labels when no MatchLabels are provided", func(ctx SpecContext) {
-			svcName := "test-llm-default-pool-selector"
-			testNs := NewTestNamespace(ctx, envTest, WithIstioShadowService(svcName))
-
-			llmSvc := LLMInferenceService(svcName,
+			// Create NVIDIA instance with default scheduler
+			nvidiaLLMSvc := LLMInferenceService(nvidiaSvcName,
 				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
 				WithModelURI("hf://facebook/opt-125m"),
 				WithManagedRoute(),
@@ -1560,27 +1506,76 @@ schedulingProfiles:
 				WithManagedScheduler(),
 			)
 
-			// when
-			Expect(envTest.Create(ctx, llmSvc)).To(Succeed())
+			Expect(envTest.Create(ctx, nvidiaLLMSvc)).To(Succeed())
 			defer func() {
-				testNs.DeleteAndWait(ctx, llmSvc)
+				testNs.DeleteAndWait(ctx, nvidiaLLMSvc)
 			}()
 
-			// then - verify the InferencePool uses default workload label selector
+			// Verify InferencePool is created with default workload label selector
 			ip := &igwapi.InferencePool{}
 			Eventually(func(g Gomega, ctx context.Context) error {
 				return envTest.Client.Get(ctx, client.ObjectKey{
-					Name:      svcName + "-inference-pool",
+					Name:      nvidiaSvcName + "-inference-pool",
 					Namespace: testNs.Name,
 				}, ip)
 			}).WithContext(ctx).Should(Succeed())
 
 			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
-				igwapi.LabelKey("app.kubernetes.io/name"), igwapi.LabelValue(svcName)))
+				igwapi.LabelKey("app.kubernetes.io/name"), igwapi.LabelValue(nvidiaSvcName)))
 			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
 				igwapi.LabelKey("kserve.io/component"), igwapi.LabelValue("workload")))
 			Expect(ip.Spec.Selector.MatchLabels).To(HaveKeyWithValue(
 				igwapi.LabelKey("app.kubernetes.io/part-of"), igwapi.LabelValue("llminferenceservice")))
+
+			// Create AMD instance with no router, using spec.labels to match NVIDIA's InferencePool
+			amdLLMSvc := LLMInferenceService(amdSvcName,
+				InNamespace[*v1alpha2.LLMInferenceService](testNs.Name),
+				WithModelURI("hf://facebook/opt-125m"),
+				WithWorkloadLabels(map[string]string{
+					"app.kubernetes.io/name":    nvidiaSvcName,
+					"app.kubernetes.io/part-of": "llminferenceservice",
+					"kserve.io/component":       "workload",
+				}),
+			)
+
+			Expect(envTest.Create(ctx, amdLLMSvc)).To(Succeed())
+			defer func() {
+				testNs.DeleteAndWait(ctx, amdLLMSvc)
+			}()
+
+			// Verify AMD workload deployment is created and its pod template labels
+			// match the NVIDIA InferencePool selector
+			amdDeployment := &appsv1.Deployment{}
+			Eventually(func(g Gomega, ctx context.Context) error {
+				return envTest.Client.Get(ctx, client.ObjectKey{
+					Name:      amdSvcName + "-kserve",
+					Namespace: testNs.Name,
+				}, amdDeployment)
+			}).WithContext(ctx).Should(Succeed())
+
+			podLabels := amdDeployment.Spec.Template.Labels
+			for labelKey, labelValue := range ip.Spec.Selector.MatchLabels {
+				Expect(podLabels).To(HaveKeyWithValue(string(labelKey), string(labelValue)),
+					"AMD pod template label %q should match NVIDIA InferencePool selector", labelKey)
+			}
+
+			// Verify no InferencePool was created for the AMD instance
+			amdIP := &igwapi.InferencePool{}
+			err := envTest.Client.Get(ctx, client.ObjectKey{
+				Name:      amdSvcName + "-inference-pool",
+				Namespace: testNs.Name,
+			}, amdIP)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"AMD instance should not create its own InferencePool")
+
+			// Verify no scheduler deployment was created for the AMD instance
+			amdScheduler := &appsv1.Deployment{}
+			err = envTest.Client.Get(ctx, client.ObjectKey{
+				Name:      amdSvcName + "-kserve-epp",
+				Namespace: testNs.Name,
+			}, amdScheduler)
+			Expect(errors.IsNotFound(err)).To(BeTrue(),
+				"AMD instance should not create a scheduler deployment")
 		})
 	})
 })


### PR DESCRIPTION
Deploy the same model across NVIDIA and AMD GPUs using two LLMInferenceService instances that share a single scheduler/EPP via a custom InferencePool selector.

Create one scheduler/EPP, n1-replicas of vllm using NVIDIA GPUs and n2-replicas of vllm using AMD GPUs in oder to utilise all cluster resources.

**Release note**:

```release-note
feat(llmisvc): add heterogeneous GPUs load balancing sample
```
