### PR TITLE
fix: skip validation on update during deletion for all resource types

### DIFF
--- a/pkg/apis/serving/v1alpha1/inference_graph_validation.go
+++ b/pkg/apis/serving/v1alpha1/inference_graph_validation.go
@@ -91,6 +91,9 @@ func (v *InferenceGraphValidator) ValidateUpdate(ctx context.Context, oldObj, ne
 		validatorLogger.Error(err, "Unable to convert object to InferenceGraph")
 		return nil, err
 	}
+	if ig.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
 	validatorLogger.Info("validate update", "name", ig.Name)
 	return validateInferenceGraph(ig)
 }

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_config_validation.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_config_validation.go
@@ -77,6 +77,9 @@ func (l *LLMInferenceServiceConfigValidator) ValidateUpdate(ctx context.Context,
 	if err != nil {
 		return warnings, err
 	}
+	if newConfig.GetDeletionTimestamp() != nil {
+		return warnings, nil
+	}
 
 	// Warn if modifying a well-known config
 	if l.WellKnownConfigChecker != nil && l.WellKnownConfigChecker(oldConfig.Name) &&

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation.go
@@ -70,6 +70,9 @@ func (l *LLMInferenceServiceValidator) ValidateUpdate(ctx context.Context, oldOb
 	if err != nil {
 		return warnings, err
 	}
+	if llmSvc.GetDeletionTimestamp() != nil {
+		return warnings, nil
+	}
 
 	return warnings, l.validate(ctx, prev, llmSvc)
 }

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
@@ -50,7 +50,7 @@ func TestValidateUpdate_DeletionBypass(t *testing.T) {
 
 	oldSvc := newBaseLLMInferenceService()
 	newSvc := newBaseLLMInferenceService()
-	newSvc.Spec.WorkloadSpec.Worker = &corev1.PodSpec{}
+	newSvc.Spec.Worker = &corev1.PodSpec{}
 
 	// Without DeletionTimestamp, this should be rejected (worker without parallelism)
 	warnings, err := validator.ValidateUpdate(t.Context(), oldSvc, newSvc)

--- a/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha1/llm_inference_service_validation_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	autoscalingv2 "k8s.io/api/autoscaling/v2"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/validation/field"
 	"k8s.io/utils/ptr"
@@ -42,6 +43,27 @@ func newBaseLLMInferenceService() *LLMInferenceService {
 			},
 		},
 	}
+}
+
+func TestValidateUpdate_DeletionBypass(t *testing.T) {
+	validator := &LLMInferenceServiceValidator{}
+
+	oldSvc := newBaseLLMInferenceService()
+	newSvc := newBaseLLMInferenceService()
+	newSvc.Spec.WorkloadSpec.Worker = &corev1.PodSpec{}
+
+	// Without DeletionTimestamp, this should be rejected (worker without parallelism)
+	warnings, err := validator.ValidateUpdate(t.Context(), oldSvc, newSvc)
+	assert.Empty(t, warnings)
+	assert.Error(t, err)
+
+	// With DeletionTimestamp set, the same object should be accepted
+	deletingSvc := newSvc.DeepCopy()
+	now := metav1.Now()
+	deletingSvc.DeletionTimestamp = &now
+	warnings, err = validator.ValidateUpdate(t.Context(), oldSvc, deletingSvc)
+	assert.Empty(t, warnings)
+	assert.NoError(t, err)
 }
 
 func TestValidateWorkloadScaling(t *testing.T) {

--- a/pkg/apis/serving/v1alpha1/trainedmodel_webhook.go
+++ b/pkg/apis/serving/v1alpha1/trainedmodel_webhook.go
@@ -88,6 +88,9 @@ func (v *TrainedModelValidator) ValidateUpdate(ctx context.Context, oldObj, newO
 		tmLogger.Error(err, "Unable to convert object to TrainedModel")
 		return nil, err
 	}
+	if newTm.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
 	tmLogger.Info("validate update", "name", newTm.Name)
 
 	return nil, utils.FirstNonNilError([]error{

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_config_validation.go
@@ -77,6 +77,9 @@ func (l *LLMInferenceServiceConfigValidator) ValidateUpdate(ctx context.Context,
 	if err != nil {
 		return warnings, err
 	}
+	if newConfig.GetDeletionTimestamp() != nil {
+		return warnings, nil
+	}
 
 	// Warn if modifying a well-known config
 	if l.WellKnownConfigChecker != nil && l.WellKnownConfigChecker(oldConfig.Name) &&

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_validation.go
@@ -74,6 +74,9 @@ func (l *LLMInferenceServiceValidator) ValidateUpdate(ctx context.Context, oldOb
 	if err != nil {
 		return nil, err
 	}
+	if llmSvc.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
 
 	return l.validate(ctx, prev, llmSvc)
 }

--- a/pkg/apis/serving/v1alpha2/llm_inference_service_validation_test.go
+++ b/pkg/apis/serving/v1alpha2/llm_inference_service_validation_test.go
@@ -217,6 +217,37 @@ func newBaseLLMInferenceServiceV1Alpha2() *LLMInferenceService {
 	}
 }
 
+func TestValidateUpdate_DeletionBypass(t *testing.T) {
+	validator := &LLMInferenceServiceValidator{}
+
+	oldSvc := newBaseLLMInferenceServiceV1Alpha2()
+	newSvc := newBaseLLMInferenceServiceV1Alpha2()
+	newSvc.Spec.WorkloadSpec = WorkloadSpec{
+		Replicas: ptr.To(int32(3)),
+		Scaling: &ScalingSpec{
+			MaxReplicas: 5,
+			WVA: &WVASpec{
+				ActuatorSpec: ActuatorSpec{
+					HPA: &HPAScalingSpec{},
+				},
+			},
+		},
+	}
+
+	// Without DeletionTimestamp, this should be rejected (replicas + scaling are mutually exclusive)
+	warnings, err := validator.ValidateUpdate(t.Context(), oldSvc, newSvc)
+	assert.Empty(t, warnings)
+	assert.Error(t, err)
+
+	// With DeletionTimestamp set, the same object should be accepted
+	deletingSvc := newSvc.DeepCopy()
+	now := metav1.Now()
+	deletingSvc.DeletionTimestamp = &now
+	warnings, err = validator.ValidateUpdate(t.Context(), oldSvc, deletingSvc)
+	assert.Empty(t, warnings)
+	assert.NoError(t, err)
+}
+
 func TestValidateWorkloadScaling(t *testing.T) {
 	tests := []struct {
 		name           string

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -89,10 +89,10 @@ func (v *InferenceServiceValidator) ValidateUpdate(ctx context.Context, oldObj, 
 	if err != nil {
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
 	}
-	validatorLogger.Info("validate update", "name", isvc.Name)
 	if isvc.GetDeletionTimestamp() != nil {
 		return nil, nil
 	}
+	validatorLogger.Info("validate update", "name", isvc.Name)
 	err = validateDeploymentMode(isvc, oldIsvc)
 	if err != nil {
 		return nil, err

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -90,11 +90,12 @@ func (v *InferenceServiceValidator) ValidateUpdate(ctx context.Context, oldObj, 
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
 	}
 	validatorLogger.Info("validate update", "name", isvc.Name)
-	if isvc.GetDeletionTimestamp() == nil {
-		err = validateDeploymentMode(isvc, oldIsvc)
-		if err != nil {
-			return nil, err
-		}
+	if isvc.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
+	err = validateDeploymentMode(isvc, oldIsvc)
+	if err != nil {
+		return nil, err
 	}
 	return validateInferenceService(isvc)
 }

--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -88,6 +88,7 @@ func (v *InferenceServiceValidator) ValidateUpdate(ctx context.Context, oldObj, 
 	oldIsvc, err := utils.Convert[*InferenceService](oldObj)
 	if err != nil {
 		validatorLogger.Error(err, "Unable to convert object to InferenceService")
+		return nil, err
 	}
 	if isvc.GetDeletionTimestamp() != nil {
 		return nil, nil

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1434,6 +1434,47 @@ func TestDeploymentModeUpdate(t *testing.T) {
 	g.Expect(err).Should(gomega.Succeed())
 }
 
+func TestValidateUpdateDuringDeletion(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	validator := InferenceServiceValidator{}
+	pvcStorageUri := "pvc://my-pvc/model"
+
+	oldIsvc := InferenceService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "multinode-isvc",
+			Namespace: "default",
+			Annotations: map[string]string{
+				constants.AutoscalerClass: string(constants.AutoscalerClassExternal),
+				constants.DeploymentMode:  string(constants.LegacyRawDeployment),
+			},
+		},
+		Spec: InferenceServiceSpec{
+			Predictor: PredictorSpec{
+				Model: &ModelSpec{
+					ModelFormat: ModelFormat{Name: "huggingface"},
+					PredictorExtensionSpec: PredictorExtensionSpec{
+						StorageURI: &pvcStorageUri,
+					},
+				},
+				WorkerSpec: &WorkerSpec{},
+			},
+		},
+	}
+
+	// Without DeletionTimestamp, this ISVC should be rejected (autoscalerClass: external is invalid for multinode)
+	warnings, err := validator.ValidateUpdate(t.Context(), &oldIsvc, oldIsvc.DeepCopy())
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).ShouldNot(gomega.Succeed())
+
+	// With DeletionTimestamp set, the same ISVC should be accepted so finalizers can be removed
+	deletingIsvc := oldIsvc.DeepCopy()
+	now := metav1.Now()
+	deletingIsvc.DeletionTimestamp = &now
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvc, deletingIsvc)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+}
+
 func TestValidateDelete(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	validator := InferenceServiceValidator{}

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator.go
@@ -76,6 +76,9 @@ func (v *LocalModelCacheValidator) ValidateUpdate(ctx context.Context, oldObj, n
 		localModelCacheValidatorLogger.Error(err, "Unable to convert object to LocalModelCache")
 		return nil, err
 	}
+	if localModelCache.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
 	localModelCacheValidatorLogger.Info("validate update", "name", localModelCache.Name)
 	localModelCacheWithSameStorageURI, err := v.validateUniqueStorageURI(ctx, localModelCache)
 	if err != nil {

--- a/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
+++ b/pkg/webhook/admission/localmodelcache/localmodelcache_validator_test.go
@@ -176,6 +176,25 @@ func TestValidateUpdate_LocalModelCacheWithUniqueStorageURI(t *testing.T) {
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
+func TestValidateUpdate_DeletionBypass(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	existingLmc := makeTestLocalModelCache()
+	s := runtime.NewScheme()
+	err := v1alpha1.AddToScheme(s)
+	if err != nil {
+		t.Errorf("unable to add scheme : %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithObjects(&existingLmc).WithScheme(s).Build()
+	validator := LocalModelCacheValidator{fakeClient}
+	oldLmc := makeTestLocalModelCacheWithDifferentStorageURI()
+	newLmc := makeTestLocalModelCacheWithSameStorageURI()
+	now := metav1.Now()
+	newLmc.DeletionTimestamp = &now
+	warnings, err := validator.ValidateUpdate(t.Context(), &oldLmc, &newLmc)
+	g.Expect(warnings).To(gomega.BeNil())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+}
+
 func TestValidateUpdate_InvalidObjectType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	s := runtime.NewScheme()

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation.go
@@ -73,6 +73,9 @@ func (v *LocalModelNamespaceCacheValidator) ValidateUpdate(ctx context.Context, 
 		localModelNamespaceCacheValidatorLogger.Error(err, "Unable to convert object to LocalModelNamespaceCache")
 		return nil, err
 	}
+	if localModelNamespaceCache.GetDeletionTimestamp() != nil {
+		return nil, nil
+	}
 	localModelNamespaceCacheValidatorLogger.Info("validate update", "name", localModelNamespaceCache.Name, "namespace", localModelNamespaceCache.Namespace)
 
 	if err := v.validateNodeGroups(ctx, localModelNamespaceCache); err != nil {

--- a/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation_test.go
+++ b/pkg/webhook/admission/localmodelnamespacecache/local_model_namespace_cache_validation_test.go
@@ -187,6 +187,25 @@ func TestValidateUpdate_LocalModelNamespaceCacheWithValidNodeGroups(t *testing.T
 	g.Expect(err).ToNot(gomega.HaveOccurred())
 }
 
+func TestValidateUpdate_LocalModelNamespaceCacheDeletionBypass(t *testing.T) {
+	g := gomega.NewGomegaWithT(t)
+	oldLmnc := makeTestLocalModelNamespaceCache()
+	newLmnc := makeTestLocalModelNamespaceCache()
+	newLmnc.Spec.NodeGroups = []string{"nonexistent-nodegroup"}
+	now := metav1.Now()
+	newLmnc.DeletionTimestamp = &now
+	s := runtime.NewScheme()
+	err := v1alpha1.AddToScheme(s)
+	if err != nil {
+		t.Errorf("unable to add scheme : %v", err)
+	}
+	fakeClient := fake.NewClientBuilder().WithScheme(s).Build()
+	validator := LocalModelNamespaceCacheValidator{Client: fakeClient}
+	warnings, err := validator.ValidateUpdate(t.Context(), &oldLmnc, &newLmnc)
+	g.Expect(warnings).To(gomega.BeNil())
+	g.Expect(err).ToNot(gomega.HaveOccurred())
+}
+
 func TestValidateUpdate_LocalModelNamespaceCacheInvalidObjectType(t *testing.T) {
 	g := gomega.NewGomegaWithT(t)
 	s := runtime.NewScheme()


### PR DESCRIPTION
**What this PR does / why we need it**:

When a resource is being deleted, controllers patch the object to remove finalizers. These patches go through `ValidateUpdate`, which runs all spec validation. If the resource was created before a validation rule was tightened (e.g. `autoscalerClass: external` for multinode), the webhook rejects the update and the resource gets stuck in Terminating forever.

This is the same class of bug fixed in #5025 for `validateDeploymentMode` -- any validation added to `ValidateUpdate` can block deletion of pre-existing resources. #5025 skipped only `validateDeploymentMode` during deletion; this PR generalizes the fix by checking `DeletionTimestamp` early in every `ValidateUpdate` webhook, preventing the entire class of bug across all resource types.

During deletion the only updates are metadata changes (finalizer removal), so spec validation is irrelevant.

**Affected validators (kserve):**

- `InferenceService` (v1beta1) -- moved existing check before the log line
- `InferenceGraph` (v1alpha1)
- `TrainedModel` (v1alpha1)
- `LLMInferenceService` (v1alpha2)
- `LLMInferenceServiceConfig` (v1alpha1 and v1alpha2)
- `LocalModelCache`
- `LocalModelNamespaceCache`

**Why this is safe:**

- `ValidateDelete` is unchanged -- deletion guards (e.g. LocalModelCache checking for active InferenceServices) still fire.
- The only validation being skipped is spec/structural checks on objects that are already terminating.
- `DeletionTimestamp` is immutable once set by the API server, so the check is reliable.

**Feature/Issue validation/testing**:

- [x] Unit test `TestValidateUpdateDuringDeletion`: verifies `ValidateUpdate` rejects a multinode ISVC with `autoscalerClass: external` normally, but accepts it when `DeletionTimestamp` is set
- [x] Manual verification on local cluster: created multinode ISVC with `autoscalerClass: external`, confirmed deletion completes without hanging

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

```release-note
Fix resources getting stuck in Terminating when validation rules reject finalizer-removal updates during deletion. Applies DeletionTimestamp bypass to all validating webhooks (InferenceService, InferenceGraph, TrainedModel, LLMInferenceService, LLMInferenceServiceConfig, LocalModelCache, LocalModelNamespaceCache).
```