### PR TITLE
chore: change docker.io image to quay.io for seaweedfs 

### DIFF
--- a/config/overlays/test/s3-local-backend/seaweedfs-deployment.yaml
+++ b/config/overlays/test/s3-local-backend/seaweedfs-deployment.yaml
@@ -31,7 +31,7 @@ spec:
             secretKeyRef:
               name: mlpipeline-s3-artifact
               key: secretkey
-        image: docker.io/chrislusf/seaweedfs:4.07@sha256:10fa7df90911dd83439f4d3d792a1c5c6c630121cb2094ba209f42d4b0ca975d
+        image: quay.io/flysangel/chrislusf/seaweedfs@sha256:a27e9c432f1dfaafb5bb3f5b39065c0df7a15423a3894025c714b3f06f998aeb
         imagePullPolicy: Always
         name: seaweedfs
         readinessProbe:


### PR DESCRIPTION
**What this PR does / why we need it**:
chore: change docker.io image to quay.io for seaweedfs to avoid rate limit 

```
"toomanyrequests: You have reached your unauthenticated pull rate limit"
```

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:
- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note

```
