### PR TITLE
ci: add quick install e2e test for KServe + LocalModel + LLMISvc

### DIFF
--- a/.github/workflows/e2e-test-quick-install.yaml
+++ b/.github/workflows/e2e-test-quick-install.yaml
@@ -1,0 +1,189 @@
+name: E2E Tests - Quick Install (KServe + LocalModel + LLMISvc)
+
+on:
+  pull_request:
+    branches: [master, release*]
+    paths:
+      - "hack/kserve-install.sh"
+      - "hack/setup/**"
+      - "charts/**"
+      - "config/**"
+      - "cmd/**"
+      - "pkg/**"
+      - ".github/workflows/e2e-test-quick-install.yaml"
+      - ".github/actions/**"
+  merge_group:
+    types: [checks_requested]
+  workflow_dispatch:
+
+env:
+  GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  TAG: ${{ github.sha }}
+  DOCKER_IMAGES_PATH: "/mnt/docker-images"
+  KO_DOCKER_REPO: "kserve"
+  BASE_ARTIFACT_PREFIX: "base"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  detect-changes:
+    runs-on: ubuntu-latest
+    outputs:
+      install_methods: ${{ steps.set-matrix.outputs.install_methods }}
+    steps:
+      - uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+      - uses: dorny/paths-filter@de90cc6fb38fc0963ad72b210f1f284cd68cea36 # v3.0.2
+        id: filter
+        with:
+          filters: |
+            charts:
+              - 'charts/**'
+            non_charts:
+              - '**'
+              - '!charts/**'
+      - id: set-matrix
+        run: |
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo 'install_methods=["kustomize","helm"]' >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.filter.outputs.charts }}" == "true" && \
+                  "${{ steps.filter.outputs.non_charts }}" == "true" ]]; then
+            echo 'install_methods=["kustomize","helm"]' >> $GITHUB_OUTPUT
+          elif [[ "${{ steps.filter.outputs.charts }}" == "true" ]]; then
+            echo 'install_methods=["helm"]' >> $GITHUB_OUTPUT
+          else
+            echo 'install_methods=["kustomize"]' >> $GITHUB_OUTPUT
+          fi
+
+  controller-image-build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout source
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+      - name: Load KServe environment variables
+        run: ./kserve-images.sh --ci
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3.12.0
+        with:
+          cache-binary: true
+      - name: Build KServe controller images
+        run: |
+          sudo mkdir -p ${DOCKER_IMAGES_PATH}
+          sudo chown -R $USER ${DOCKER_IMAGES_PATH}
+          ./test/scripts/gh-actions/build-images.sh
+          docker image ls
+          sudo ls -lh ${DOCKER_IMAGES_PATH}
+      - name: Build LLMISvc controller image
+        run: |
+          ./test/scripts/gh-actions/build-images.sh llmisvc
+          docker image ls
+          sudo ls -lh ${DOCKER_IMAGES_PATH}
+      - name: Upload controller image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.CONTROLLER_IMG }}-${{ env.TAG }}
+          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.CONTROLLER_IMG }}-${{ env.TAG }}
+          compression-level: 0
+          if-no-files-found: error
+      - name: Upload localmodel controller image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.LOCALMODEL_CONTROLLER_IMG }}-${{ env.TAG }}
+          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.LOCALMODEL_CONTROLLER_IMG }}-${{ env.TAG }}
+          compression-level: 0
+          if-no-files-found: error
+      - name: Upload localmodel agent image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.BASE_ARTIFACT_PREFIX }}-${{ env.LOCALMODEL_AGENT_IMG }}-${{ env.TAG }}
+          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.LOCALMODEL_AGENT_IMG }}-${{ env.TAG }}
+          compression-level: 0
+          if-no-files-found: error
+      - name: Upload LLMISvc controller image
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4.6.2
+        with:
+          name: ${{ env.LLMISVC_CONTROLLER_IMG }}-${{ env.TAG }}
+          path: ${{ env.DOCKER_IMAGES_PATH }}/${{ env.LLMISVC_CONTROLLER_IMG }}-${{ env.TAG }}
+          compression-level: 0
+          if-no-files-found: error
+
+  test-quick-install:
+    runs-on: ubuntu-latest
+    needs: [detect-changes, controller-image-build]
+    strategy:
+      fail-fast: false
+      matrix:
+        install-method: ${{ fromJSON(needs.detect-changes.outputs.install_methods) }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4.3.1
+      - name: Merge target branch
+        if: github.event_name == 'pull_request'
+        run: |
+          git fetch --unshallow origin
+          git fetch origin ${{ github.event.pull_request.base.ref }}
+          git config user.email "ci@kserve.io"
+          git config user.name "CI Bot"
+          git merge --no-edit origin/${{ github.event.pull_request.base.ref }}
+      - name: Load KServe environment variables
+        run: ./kserve-images.sh --ci
+      - name: Free-up disk space
+        uses: ./.github/actions/free-up-disk-space
+      - name: Setup Minikube
+        uses: ./.github/actions/minikube-setup
+      - name: Download base images
+        uses: ./.github/actions/base-download
+      - name: Download LLMISvc controller image
+        uses: actions/download-artifact@d3f86a106a0bac45b974a628896c90dbdf5c8093 # v4.3.0
+        with:
+          name: ${{ env.LLMISVC_CONTROLLER_IMG }}-${{ env.TAG }}
+          path: ./tmp
+      - name: Load docker images
+        uses: ./.github/actions/load-docker-images
+        with:
+          directory: ./tmp
+      - name: Install all components via kserve-install.sh (KServe + LocalModel + LLMISvc)
+        run: |
+          if [ "${{ matrix.install-method }}" == "helm" ]; then
+            ./hack/kserve-install.sh --type kserve,localmodel,llmisvc --raw --helm --local-chart --kserve-version ${TAG}
+          else
+            ./hack/kserve-install.sh --type kserve,localmodel,llmisvc --raw --kustomize --kserve-version ${TAG}
+          fi
+      - name: Verify all controllers are running
+        run: |
+          echo "=== KServe namespace pods ==="
+          kubectl get pods -n kserve
+
+          echo "=== Waiting for all controllers to be available ==="
+          kubectl wait deployment/kserve-controller-manager \
+            -n kserve --for=condition=Available --timeout=120s
+          kubectl wait deployment/kserve-localmodel-controller-manager \
+            -n kserve --for=condition=Available --timeout=120s
+          kubectl wait deployment/llmisvc-controller-manager \
+            -n kserve --for=condition=Available --timeout=120s
+
+          echo "=== CRDs ==="
+          kubectl get crd | grep -E "(inferenceservice|llminference|localmodel)"
+      - name: Check system status
+        if: always()
+        run: |
+          ./test/scripts/gh-actions/status-check.sh "llmisvc"


### PR DESCRIPTION
**What this PR does / why we need it**:
As a follow-up to https://github.com/kserve/kserve/pull/5428, this PR introduces a GitHub Action to test the quick-install flow with all components installed together. Although our e2e tests verify each controller independently, we don’t currently validate the full integrated installation. This aims to address that gap 

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note

```
