### PR TITLE
fix: add approvers to reviewers in OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -8,6 +8,9 @@ approvers:
   - sivanantha321
 
 reviewers:
+  - Jooho
+  - lizzzcai
+  - sivanantha321
   - andyi2it
   - cjohannsen-cloudera
   - cmaddalozzo


### PR DESCRIPTION
Approvers should also have reviewer privileges in prow-github-actions.
Currently, approvers can't use `/lgtm` because the action checks the `reviewers` role in the OWNERS file. This adds all approvers to the reviewers list so they can use both `/lgtm` and `/approve`.