### PR TITLE
ci: add --maxfail=10 to e2e pytest invocation

### DIFF
--- a/test/scripts/gh-actions/run-e2e-tests.sh
+++ b/test/scripts/gh-actions/run-e2e-tests.sh
@@ -39,8 +39,8 @@ source python/kserve/.venv/bin/activate
 pushd test/e2e >/dev/null
   if [[ $MARKER == "raw" && $NETWORK_LAYER == "istio-ingress" ]]; then
     echo "Skipping explainer tests for raw deployment with ingress"
-    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER --ignore=explainer/ -vv --tb=long -s    
+    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER --ignore=explainer/ --maxfail=10 -vv --tb=long -s
   else
-    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER -vv --tb=long -s
+    pytest -m "$MARKER" --ignore=qpext --log-cli-level=INFO -n $PARALLELISM --dist worksteal --network-layer $NETWORK_LAYER --maxfail=10 -vv --tb=long -s
   fi
 popd


### PR DESCRIPTION
## Summary
- Adds `--maxfail=10` to both pytest invocations in `test/scripts/gh-actions/run-e2e-tests.sh`
- When a cluster is degraded, xdist workers each hit individual 10-minute timeouts, producing P99 execution times of **2 hours** vs a **22-minute median**
- `--maxfail=10` aborts the run after 10 failures, preventing cascading timeout burns while still capturing enough failures for useful signal

## Test plan
- [ ] CI runs that hit cascading failures abort within minutes instead of hours
- [ ] Normal passing runs are unaffected (10 failures is well above noise)

🤖 Generated with [Claude Code](https://claude.ai/code)