### PR TITLE
fix(ci): add MEMBER association to cherry-pick workflow permissions

### DIFF
--- a/.github/workflows/comment-cherry-pick.yml
+++ b/.github/workflows/comment-cherry-pick.yml
@@ -7,7 +7,7 @@ on:
 jobs:
   validate:
     name: Validate Cherry Pick Request
-    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/cherry-pick') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR')
+    if: github.event.issue.pull_request != '' && contains(github.event.comment.body, '/cherry-pick') && (github.event.comment.author_association == 'OWNER' || github.event.comment.author_association == 'MEMBER' || github.event.comment.author_association == 'COLLABORATOR' || github.event.comment.author_association == 'CONTRIBUTOR')
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
**What this PR does / why we need it**:
Organization members with MEMBER association should be able to trigger cherry-pick workflow but were excluded from the current permission check. This adds MEMBER to the allowed associations alongside OWNER, COLLABORATOR, and CONTRIBUTOR.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:
- [ ] Test A
- [ ] Test B

- Logs

**Special notes for your reviewer**:

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note

```
