### PR TITLE
fix(utils): prevent panic in FindCommonParentPath on root-only mount path

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1855,6 +1855,19 @@ func TestValidateStorageUri(t *testing.T) {
 			},
 			expected: gomega.MatchError(gomega.ContainSubstring("storage paths must have a common parent directory")),
 		},
+		"MultipleStorageUrisWithRootMountPath": {
+			storageUris: []StorageUri{
+				{
+					Uri:       "gs://bucket/model1",
+					MountPath: "///",
+				},
+				{
+					Uri:       "s3://bucket/model2",
+					MountPath: "/mnt/models",
+				},
+			},
+			expected: gomega.MatchError(gomega.ContainSubstring("storage paths must have a common parent directory")),
+		},
 		"InvalidStorageUriInList": {
 			storageUris: []StorageUri{
 				{

--- a/pkg/utils/storage.go
+++ b/pkg/utils/storage.go
@@ -195,15 +195,18 @@ func FindCommonParentPath(paths []string) string {
 		// Clean the path and split by "/"
 		cleanPath := strings.Trim(path, "/")
 		if cleanPath == "" {
+			// A path that trims to empty (e.g. "/", "//") refers to the root and
+			// has no components. It must still lower minLength so the prefix loop
+			// below never indexes past this empty slice.
 			pathComponents[i] = []string{}
 		} else {
 			pathComponents[i] = strings.Split(cleanPath, "/")
+		}
 
-			if minLength == -1 {
-				minLength = len(pathComponents[i])
-			} else {
-				minLength = min(minLength, len(pathComponents[i]))
-			}
+		if minLength == -1 {
+			minLength = len(pathComponents[i])
+		} else {
+			minLength = min(minLength, len(pathComponents[i]))
 		}
 	}
 

--- a/pkg/utils/storage_test.go
+++ b/pkg/utils/storage_test.go
@@ -71,6 +71,27 @@ func TestFindCommonParentPath(t *testing.T) {
 			},
 			expected: "/",
 		},
+		"RootOnlyPath": {
+			paths: []string{
+				"///",
+				"/mnt/models",
+			},
+			expected: "/",
+		},
+		"RootOnlyPathFirst": {
+			paths: []string{
+				"/mnt/models",
+				"///",
+			},
+			expected: "/",
+		},
+		"AllRootPaths": {
+			paths: []string{
+				"/",
+				"//",
+			},
+			expected: "/",
+		},
 	}
 
 	for name, scenario := range scenarios {


### PR DESCRIPTION

**What this PR does / why we need it**:

`FindCommonParentPath` (`pkg/utils/storage.go`) splits each input path into
components but only updated `minLength` inside the branch that handled non-empty
paths. A mount path that trims to empty (for example `"/"`, `"//"` or `"///"`)
was stored as an empty component slice while `minLength` kept the length of
another, longer path. The common-prefix loop then indexed the empty slice and
panicked with `index out of range [0] with length 0`.

This is reachable from the validating webhook. `validateStorageURISpec` rejects a
mount path of exactly `"/"`, but `"///"` passes its absolute-prefix and `..`
traversal checks, so an `InferenceService` with two `storageUri` entries whose
`mountPath` values are e.g. `"///"` and `"/mnt/models"` crashed
`validateMultipleStorageURIsSpec` instead of returning a validation error.

The fix updates `minLength` for every path, including empty ones. A root-only
path lowers `minLength` to `0`, so the prefix loop runs zero times and the
function returns `"/"` (no common parent beyond root) rather than panicking.
Behavior for all non-empty inputs is unchanged: those lengths were already
counted in the same branch, so the computed `minLength` is identical to before.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Feature/Issue validation/testing**:

Added regression tests and confirmed red -> green (the new tests panic on the
current code and pass with the fix):

- [x] `pkg/utils/storage_test.go` - `TestFindCommonParentPath`: new cases
  `RootOnlyPath` (`["///","/mnt/models"]`), `RootOnlyPathFirst`
  (`["/mnt/models","///"]`) and `AllRootPaths` (`["/","//"]`), all expecting
  `"/"`.
- [x] `pkg/apis/serving/v1beta1/inference_service_validation_test.go` -
  `TestValidateStorageUri`: new case `MultipleStorageUrisWithRootMountPath`
  exercises the webhook path with `mountPath` `"///"` and `"/mnt/models"` and now
  gets the intended `storage paths must have a common parent directory`
  validation error instead of a panic.

- Logs

```
$ go build ./...
(exit 0)

$ go test ./pkg/utils/... ./pkg/apis/serving/v1beta1/...
ok  	github.com/kserve/kserve/pkg/utils
ok  	github.com/kserve/kserve/pkg/apis/serving/v1beta1

$ go test -run 'TestFindCommonParentPath|TestValidateStorageUri' -v ./pkg/utils/... ./pkg/apis/serving/v1beta1/...
--- PASS: TestFindCommonParentPath/RootOnlyPath (0.00s)
--- PASS: TestFindCommonParentPath/RootOnlyPathFirst (0.00s)
--- PASS: TestFindCommonParentPath/AllRootPaths (0.00s)
--- PASS: TestValidateStorageUri/MultipleStorageUrisWithRootMountPath (0.00s)

$ gofmt -l pkg/utils/storage.go pkg/utils/storage_test.go pkg/apis/serving/v1beta1/inference_service_validation_test.go
(no output)

$ go vet ./pkg/utils/... ./pkg/apis/serving/v1beta1/...
(exit 0)

$ golangci-lint run ./pkg/utils/... ./pkg/apis/serving/v1beta1/...
0 issues.
```

**Special notes for your reviewer**:

The change is a one-line-of-logic move: hoisting the `minLength` update out of the
non-empty `else` branch so it also applies to root-only paths. A short comment
explains why the empty case must still lower `minLength`. No image versions or
generated files are touched.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)? (N/A - internal robustness fix, no user-facing behavior or docs change)

**Release note**:
```release-note
Fix a panic in the InferenceService validating webhook when a storageUri mountPath normalizes to the root ("/", "//" or "///"); FindCommonParentPath now returns "/" instead of crashing.
```
