### PR TITLE
fix(timeseries): use correct err_type kwarg in forecast error response

### DIFF
--- a/python/kserve/kserve/protocol/rest/timeseries/dataplane.py
+++ b/python/kserve/kserve/protocol/rest/timeseries/dataplane.py
@@ -58,7 +58,7 @@ class TimeSeriesDataPlane(DataPlane):
             return create_error_response(
                 message=f"Model {model_name} does not support Time Series API",
                 status_code=HTTPStatus.NOT_IMPLEMENTED,
-                error_type="not_implemented",
+                err_type="not_implemented",
             )
 
         context = {"headers": dict(headers), "response": response}

--- a/python/kserve/test/test_timeseries_dataplane.py
+++ b/python/kserve/test/test_timeseries_dataplane.py
@@ -1,0 +1,75 @@
+# Copyright 2025 The KServe Authors.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from http import HTTPStatus
+
+import pytest
+from starlette.datastructures import Headers
+
+from kserve.model import Model
+from kserve.model_repository import ModelRepository
+from kserve.protocol.rest.timeseries.dataplane import TimeSeriesDataPlane
+from kserve.protocol.rest.timeseries.types import (
+    ErrorResponse,
+    ForecastOptions,
+    ForecastRequest,
+    Frequency,
+    TimeSeriesInput,
+    TimeSeriesType,
+)
+
+
+class NotATimeSeriesModel(Model):
+    """A model that does not implement the Time Series API."""
+
+    def __init__(self, name):
+        super().__init__(name)
+        self.ready = True
+
+
+def _forecast_request(model_name: str) -> ForecastRequest:
+    return ForecastRequest(
+        model=model_name,
+        inputs=[
+            TimeSeriesInput(
+                type=TimeSeriesType.UNIVARIATE,
+                name="series-1",
+                series=[1.0, 2.0, 3.0],
+                frequency=Frequency.DAY,
+            )
+        ],
+        options=ForecastOptions(horizon=3),
+    )
+
+
+@pytest.mark.asyncio
+async def test_forecast_unsupported_model_returns_501():
+    """A model that is not a HuggingFaceTimeSeriesModel must yield a clean
+    501 ErrorResponse instead of crashing with a TypeError."""
+    model_name = "not-a-timeseries-model"
+    registry = ModelRepository()
+    registry.update(NotATimeSeriesModel(model_name))
+    dataplane = TimeSeriesDataPlane(model_registry=registry)
+
+    result = await dataplane.forecast(
+        request_body=_forecast_request(model_name),
+        raw_request=None,
+        headers=Headers({}),
+        response=None,
+    )
+
+    assert isinstance(result, ErrorResponse)
+    assert result.error.code == str(HTTPStatus.NOT_IMPLEMENTED.value)
+    assert result.error.type == "not_implemented"
+    assert "does not support Time Series API" in result.error.message


### PR DESCRIPTION

**What this PR does / why we need it**:

`TimeSeriesDataPlane.forecast` returns a 501 for models that do not implement
the Time Series API, but it builds that response by calling
`create_error_response(..., error_type="not_implemented")`. The function's
parameter is named `err_type`, not `error_type` (see
`kserve/protocol/rest/timeseries/error.py`), so this call raises:

```
TypeError: create_error_response() got an unexpected keyword argument 'error_type'
```

As a result, every request to the forecast endpoint whose target model is not a
`HuggingFaceTimeSeriesModel` hits an unhandled `TypeError` and surfaces as a 500
instead of the intended clean 501 `ErrorResponse`. The Time Series Forecast API
was added in #4615 and the sibling caller in the same package already uses
`err_type=` correctly, which confirms the intended keyword.

This PR passes `err_type=` to match the function signature so the
unsupported-model path returns the intended `ErrorResponse`, and adds a
regression test.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] New regression test `python/kserve/test/test_timeseries_dataplane.py::test_forecast_unsupported_model_returns_501`
      drives `TimeSeriesDataPlane.forecast` with a non-`HuggingFaceTimeSeriesModel`
      and asserts a 501 `ErrorResponse` (code `501`, type `not_implemented`).
      Confirmed red before the fix (raises the `TypeError` above) and green after.
- [x] `ruff check` and `ruff format --check` on both changed files pass.

- Logs

```
$ python -m pytest test/test_timeseries_dataplane.py
1 passed

$ ruff check --config ruff.toml \
    kserve/protocol/rest/timeseries/dataplane.py test/test_timeseries_dataplane.py
All checks passed!

$ ruff format --config ruff.toml --check \
    kserve/protocol/rest/timeseries/dataplane.py test/test_timeseries_dataplane.py
2 files already formatted
```

**Special notes for your reviewer**:

Single-line fix plus a colocated regression test; no behavior changes beyond
making the already-intended 501 path return instead of crashing. The
unsupported-model branch condition itself (a class-name string comparison) is
untouched and out of scope.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas? (n/a; one-word kwarg fix)
- [ ] Have you made corresponding changes to the documentation? (n/a; no user-facing API/doc change)

**Release note**:

```release-note
Fix the Time Series forecast endpoint returning a 500 (TypeError) instead of a
501 when the target model does not implement the Time Series API.
```

---

## Commit(s)

```
11a2c49b fix(timeseries): use correct err_type kwarg in forecast error response
```

Diff: 2 files, +76 / -1
- `python/kserve/kserve/protocol/rest/timeseries/dataplane.py` (1 line: `error_type=` -> `err_type=`)
- `python/kserve/test/test_timeseries_dataplane.py` (new regression test, 75 lines)

Signed off (DCO). Author is the GitHub noreply identity.
