### PR TITLE
fix(agent): store the new model spec on a spec change

### DIFF
--- a/pkg/agent/watcher.go
+++ b/pkg/agent/watcher.go
@@ -146,7 +146,7 @@ func (w *Watcher) parseConfig(modelConfigs modelconfig.ModelConfigs, initializin
 			w.modelAdded(name, &spec, initializing)
 		case !cmp.Equal(spec, *existing.Spec):
 			w.ModelTracker[name] = modelWrapper{
-				Spec:  existing.Spec,
+				Spec:  &spec,
 				stale: false,
 			}
 			// Changed - replace

--- a/pkg/agent/watcher_test.go
+++ b/pkg/agent/watcher_test.go
@@ -306,6 +306,11 @@ var _ = Describe("Watcher", func() {
 				Eventually(func() int { return puller.opStats["model1"][Add] }).Should(Equal(1))
 				Eventually(func() int { return puller.opStats["model2"][Add] }).Should(Equal(2))
 				Eventually(func() int { return puller.opStats["model2"][Remove] }).Should(Equal(1))
+				// Re-applying the same config must be a no-op: the tracker should now
+				// hold the updated spec, so no redundant unload+reload is triggered.
+				watcher.parseConfig(modelConfigs, false)
+				Consistently(func() int { return puller.opStats["model2"][Add] }).Should(Equal(2))
+				Consistently(func() int { return puller.opStats["model2"][Remove] }).Should(Equal(1))
 			})
 		})
 


### PR DESCRIPTION

**What this PR does / why we need it**:

The model agent's `Watcher.parseConfig` handles each model in the config with a
three-way switch: add a new model, replace a changed one, or leave an unchanged
one alone. The "changed - replace" branch called `modelAdded(name, &spec, ...)`
to load the new spec, but recorded the *previous* spec in `ModelTracker`:

```go
case !cmp.Equal(spec, *existing.Spec):
    w.ModelTracker[name] = modelWrapper{
        Spec:  existing.Spec, // old spec, but modelAdded loaded &spec
        stale: false,
    }
    w.modelRemoved(name)
    w.modelAdded(name, &spec, initializing)
```

The agent re-runs `parseConfig` on every model-config CREATE event (an initial
sync event is seeded on startup, and each ConfigMap `..data` symlink swap fires
another). On the next reconcile, `parseConfig` compares the on-disk spec against
the stored spec via `cmp.Equal(spec, *existing.Spec)`. Because the stored spec is
the stale *old* one, they still differ, so the "changed" branch fires again and
re-runs `modelRemoved` + `modelAdded`. The net effect: after any model spec change
(for example a `storageUri` update) the model is unloaded and re-downloaded on
every reconcile cycle and never converges to a steady state.

The `!exists` ("new - add") branch already stores `&spec` correctly, and the
`default` ("unchanged") branch correctly keeps `existing.Spec` (the specs are
equal there). Only the "changed" branch was inconsistent with what it actually
loaded.

The fix records `&spec` (the newly loaded spec) in the "changed" branch so the
tracker reflects what is really loaded. Subsequent reconciles with the same
config then take the `default` branch and become a no-op.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:

Fixes #<none>

No existing tracking issue: this was found by code inspection of the agent
watcher. Happy to open one first if maintainers prefer that flow.

**Feature/Issue validation/testing**:

Extended the existing `Watcher` spec "When models uri are updated in config",
which already applies a base config and then an updated config for `model2` and
asserts `model2` is reloaded once (`Add == 2`, `Remove == 1`). I re-apply the
same updated config a third time and assert the model is not reloaded again:

```go
// Re-applying the same config must be a no-op: the tracker should now
// hold the updated spec, so no redundant unload+reload is triggered.
watcher.parseConfig(modelConfigs, false)
Consistently(func() int { return puller.opStats["model2"][Add] }).Should(Equal(2))
Consistently(func() int { return puller.opStats["model2"][Remove] }).Should(Equal(1))
```

- [x] `go build ./pkg/agent/...` - clean.
- [x] `go test ./pkg/agent -count=1` - full agent suite passes.
- [x] Regression proof: with only the source line reverted (test kept), the
      focused test fails (`model2` `Add` reaches 3); with the fix, it passes.
- [x] Focused rerun x5, no flake:
      `go test ./pkg/agent -count=1 -args -ginkgo.focus='When models uri are updated in config'`
- [x] `gofmt -l`, `gofumpt -l`, `go vet ./pkg/agent/...` - all clean.

- Logs

```
ok  	github.com/kserve/kserve/pkg/agent	1.085s
```

**Special notes for your reviewer**:

Single-line behavior fix plus a two-line assertion added to an existing spec; no
new test scaffolding and no change to the download path. The only reader of the
stored spec is the `cmp.Equal(spec, *existing.Spec)` self-comparison in
`parseConfig`; the actual model load always used `&spec` via `modelAdded`, so
this is purely a bookkeeping correction with no effect on what gets downloaded.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:

```release-note
Fix the model agent re-downloading a model on every reconcile after its spec changes; the watcher now records the newly loaded spec so a repeated config becomes a no-op.
```

