### PR TITLE
fix(ci): bump llmisvc e2e Python to 3.10

### DIFF
--- a/.github/workflows/e2e-test-llmisvc.yaml
+++ b/.github/workflows/e2e-test-llmisvc.yaml
@@ -205,7 +205,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Setup Minikube
         uses: ./.github/actions/minikube-setup
@@ -328,7 +328,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Setup Minikube
         uses: ./.github/actions/minikube-setup
@@ -433,7 +433,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Setup Minikube
         uses: ./.github/actions/minikube-setup
@@ -539,7 +539,7 @@ jobs:
       - name: Setup Python
         uses: actions/setup-python@a26af69be951a213d495a4c3e4e4022e16d87065 # v5.6.0
         with:
-          python-version: "3.9"
+          python-version: "3.10"
 
       - name: Setup Minikube
         uses: ./.github/actions/minikube-setup


### PR DESCRIPTION

**What this PR does / why we need it**:

The four "Setup Python" steps in `.github/workflows/e2e-test-llmisvc.yaml` pinned
`python-version: "3.9"`. That is below the project's supported floor and out of
step with the rest of CI:

- Every KServe Python package sets `requires-python = ">=3.10,<3.13"` (e.g.
  `python/kserve/pyproject.toml`), so 3.9 is below the minimum supported version.
- `.github/workflows/python-test.yml` only tests `["3.10", "3.11", "3.12"]`.
- Every other e2e workflow already provisions Python 3.10:
  `.github/workflows/e2e-test.yml` (all 12 "Setup Python" steps) and
  `.github/workflows/e2e-test-modelcache.yaml`.

`e2e-test-llmisvc.yaml` was the only workflow still on 3.9. This PR changes the
four occurrences to `"3.10"` so the llmisvc e2e workflow provisions a supported
interpreter consistent with the rest of CI. No source or test-code change.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] `git diff` shows exactly the 4 intended line changes (4 insertions, 4
  deletions) in `.github/workflows/e2e-test-llmisvc.yaml`, no collateral edits.
- [x] `rg '3\.9' .github/workflows/` returns nothing after the change (no stray
  references remain).
- [x] The workflow YAML still parses (PyYAML `safe_load`), top-level keys intact.
- [x] Sibling e2e workflows confirmed already on 3.10, so this aligns rather than
  diverges.

The llmisvc e2e job itself needs a live cluster and is not runnable outside CI.
It should continue to pass: the workflow installs `uv` and runs `uv venv` / `uv
sync`, which already self-select a `requires-python`-compatible (>=3.10)
interpreter, so this change removes misleading sub-floor config and makes the
provisioned Python match what actually runs.

**Special notes for your reviewer**:

Pure CI-config alignment. This is the sole change in the PR; no image versions or
source files are touched.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this
  feature works? (N/A: CI workflow config only; there is no unit-test harness for
  workflow YAML, matching repo convention. The sibling e2e workflows already
  exercise 3.10.)
- [x] Has code been commented, particularly in hard-to-understand areas? (N/A)
- [x] Have you made corresponding changes to the documentation? (N/A)

**Release note**:
```release-note
NONE
```
