### PR TITLE
fix(helm): correct storageSecretNameAnnotation default in charts

### DIFF
--- a/charts/_common/common-sections.yaml
+++ b/charts/_common/common-sections.yaml
@@ -41,7 +41,7 @@ kserve:
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config
-    storageSecretNameAnnotation: serving.kserve.io/secretName
+    storageSecretNameAnnotation: serving.kserve.io/storageSecretName
     s3:
       accessKeyIdName: AWS_ACCESS_KEY_ID
       secretAccessKeyName: AWS_SECRET_ACCESS_KEY

--- a/charts/kserve-llmisvc-resources/README.md
+++ b/charts/kserve-llmisvc-resources/README.md
@@ -173,7 +173,7 @@ $ helm install kserve-llmisvc-resources oci://ghcr.io/kserve/charts/kserve-llmis
 | kserve.storage.s3.useHttps | string | `""` |  |
 | kserve.storage.s3.useVirtualBucket | string | `""` |  |
 | kserve.storage.s3.verifySSL | string | `""` |  |
-| kserve.storage.storageSecretNameAnnotation | string | `"serving.kserve.io/secretName"` |  |
+| kserve.storage.storageSecretNameAnnotation | string | `"serving.kserve.io/storageSecretName"` |  |
 | kserve.storage.storageSpecSecretName | string | `"storage-config"` |  |
 | kserve.storage.tag | string | `""` |  |
 | kserve.storage.uidModelcar | int | `1010` |  |

--- a/charts/kserve-llmisvc-resources/values.yaml
+++ b/charts/kserve-llmisvc-resources/values.yaml
@@ -41,7 +41,7 @@ kserve:
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config
-    storageSecretNameAnnotation: serving.kserve.io/secretName
+    storageSecretNameAnnotation: serving.kserve.io/storageSecretName
     s3:
       accessKeyIdName: AWS_ACCESS_KEY_ID
       secretAccessKeyName: AWS_SECRET_ACCESS_KEY

--- a/charts/kserve-localmodel-resources/README.md
+++ b/charts/kserve-localmodel-resources/README.md
@@ -113,7 +113,7 @@ $ helm install kserve-localmodel-resources oci://ghcr.io/kserve/charts/kserve-lo
 | kserve.storage.s3.useHttps | string | `""` |  |
 | kserve.storage.s3.useVirtualBucket | string | `""` |  |
 | kserve.storage.s3.verifySSL | string | `""` |  |
-| kserve.storage.storageSecretNameAnnotation | string | `"serving.kserve.io/secretName"` |  |
+| kserve.storage.storageSecretNameAnnotation | string | `"serving.kserve.io/storageSecretName"` |  |
 | kserve.storage.storageSpecSecretName | string | `"storage-config"` |  |
 | kserve.storage.tag | string | `""` |  |
 | kserve.storage.uidModelcar | int | `1010` |  |

--- a/charts/kserve-localmodel-resources/values.yaml
+++ b/charts/kserve-localmodel-resources/values.yaml
@@ -41,7 +41,7 @@ kserve:
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config
-    storageSecretNameAnnotation: serving.kserve.io/secretName
+    storageSecretNameAnnotation: serving.kserve.io/storageSecretName
     s3:
       accessKeyIdName: AWS_ACCESS_KEY_ID
       secretAccessKeyName: AWS_SECRET_ACCESS_KEY

--- a/charts/kserve-resources/README.md
+++ b/charts/kserve-resources/README.md
@@ -141,7 +141,7 @@ $ helm install kserve-resources oci://ghcr.io/kserve/charts/kserve-resources --v
 | kserve.storage.s3.useHttps | string | `""` |  |
 | kserve.storage.s3.useVirtualBucket | string | `""` |  |
 | kserve.storage.s3.verifySSL | string | `""` |  |
-| kserve.storage.storageSecretNameAnnotation | string | `"serving.kserve.io/secretName"` |  |
+| kserve.storage.storageSecretNameAnnotation | string | `"serving.kserve.io/storageSecretName"` |  |
 | kserve.storage.storageSpecSecretName | string | `"storage-config"` |  |
 | kserve.storage.tag | string | `""` |  |
 | kserve.storage.uidModelcar | int | `1010` |  |

--- a/charts/kserve-resources/values.yaml
+++ b/charts/kserve-resources/values.yaml
@@ -41,7 +41,7 @@ kserve:
     caBundleConfigMapName: ''
     caBundleVolumeMountPath: /etc/ssl/custom-certs
     storageSpecSecretName: storage-config
-    storageSecretNameAnnotation: serving.kserve.io/secretName
+    storageSecretNameAnnotation: serving.kserve.io/storageSecretName
     s3:
       accessKeyIdName: AWS_ACCESS_KEY_ID
       secretAccessKeyName: AWS_SECRET_ACCESS_KEY


### PR DESCRIPTION

**What this PR does / why we need it**:

The Helm charts default `kserve.storage.storageSecretNameAnnotation` to
`serving.kserve.io/secretName`, while every other install path and the docs use
`serving.kserve.io/storageSecretName`:

- the kustomize config: `config/configmap/inferenceservice.yaml`
- the chart's own base configmap that the Helm patch overlays:
  `charts/kserve-resources/files/common/configmap.yaml`
- the unit-test golden value: `pkg/credentials/service_account_credentials_test.go`
- the docs, which tell users to annotate with `serving.kserve.io/storageSecretName`:
  `docs/samples/storage/uri/README.md`

The controller reads the InferenceService annotation named by this config key
verbatim, with no hardcoded fallback (`CredentialBuilder` in
`pkg/credentials/service_account_credentials.go`). On a Helm install the
`values.yaml` default is templated into the `credentials` block of
`inferenceservice-config` and deep-merge replaces the correct base value. As a
result, a user who installs KServe via Helm and follows the documentation to set
`serving.kserve.io/storageSecretName: <secret>` on their InferenceService has
that annotation silently ignored, so the per-InferenceService storage-secret
override never takes effect (the cluster is actually looking for
`serving.kserve.io/secretName`).

This corrects the default in the source-of-truth
`charts/_common/common-sections.yaml` and regenerates the per-chart `values.yaml`
and README tables so Helm matches kustomize, the chart base file, the golden
test, and the docs. Kustomize-derived artifacts (`install/**`,
`hack/setup/quick-install/*.sh`) already carry the correct value and are not
touched.

**Which issue(s) this PR fixes**:
Fixes #

**Feature/Issue validation/testing**:

- [x] `helm template charts/kserve-resources` before/after: the functional
  `data.credentials` block previously rendered `serving.kserve.io/secretName`
  (while the `_example` block in the same ConfigMap rendered
  `serving.kserve.io/storageSecretName`); it now renders
  `serving.kserve.io/storageSecretName` in both, matching kustomize and the docs.
  Same result for `charts/kserve-llmisvc-resources`.
- [x] `bash hack/setup/scripts/verify-helm-helpers.sh` -> exit 0 ("All helper
  functions are consistent across charts").
- [x] `helm lint charts/{kserve-resources,kserve-llmisvc-resources,kserve-localmodel-resources}`
  -> `0 chart(s) failed` each (only the pre-existing `v0.19.0` SemVer-format
  warning already on master).
- [x] Regeneration is reproducible: the three `values.yaml` are byte-identical to
  the `yq eval-all` merge used by `hack/setup/scripts/generate_chart_manifests.sh`,
  and the READMEs are idempotent under the pinned `helm-docs v1.12.0`
  (`--chart-search-root=charts --output-file=README.md`, as in
  `.pre-commit-config.yaml`).
- [x] `git grep serving.kserve.io/secretName` -> 0 matches after the change (the
  wrong value is gone repo-wide).

**Special notes for your reviewer**:

Pure configuration fix: one value changed in the source-of-truth
`charts/_common/common-sections.yaml`, then the generated `values.yaml` and
README tables regenerated with the repo's own tooling. No Go/Python code changes.

**Checklist**:

- [ ] Have you added unit/e2e tests that prove your fix is effective or that this
  feature works?
- [x] Has code been commented, particularly in hard-to-understand areas? (n/a,
  config-only)
- [x] Have you made corresponding changes to the documentation? (docs already use
  the correct value; this change makes Helm match them)

**Release note**:
```release-note
Fix the Helm chart default for `storageSecretNameAnnotation`, which was `serving.kserve.io/secretName` instead of `serving.kserve.io/storageSecretName`. Helm installs now honor the documented `serving.kserve.io/storageSecretName` annotation for per-InferenceService storage-secret overrides, matching the kustomize install and the docs.
```
