### PR TITLE
fix(router): surface json.Marshal errors instead of silent 200

### DIFF
--- a/cmd/router/main.go
+++ b/cmd/router/main.go
@@ -48,6 +48,11 @@ import (
 // _isInMesh is an auxiliary global variable for isInIstioMesh function.
 var _isInMesh *bool
 
+// jsonMarshal is a seam over json.Marshal so the defensive marshal-error
+// branches in routeStep can be exercised by unit tests. The values marshalled
+// there are normally derived from json.Unmarshal and so never fail in practice.
+var jsonMarshal = json.Marshal
+
 // isInIstioMesh checks if the InferenceGraph pod belongs to the mesh by
 // checking the presence of the sidecar. It is known that when the sidecar
 // is present, Envoy will be using port 15000 with standard HTTP. Thus, the
@@ -302,8 +307,12 @@ func routeStep(nodeName string, graph v1alpha1.InferenceGraphSpec, input []byte,
 			case ensembleStepOutput = <-resultChan:
 				if !isSuccessFul(ensembleStepOutput.StepStatusCode) && currentNode.Steps[i].Dependency == v1alpha1.Hard {
 					log.Info("This step is a hard dependency and it is unsuccessful", "stepName", currentNode.Steps[i].StepName, "statusCode", ensembleStepOutput.StepStatusCode)
-					stepResponse, _ := json.Marshal(ensembleStepOutput.StepResponse) // TODO check if you need err handling for Marshalling
-					return stepResponse, ensembleStepOutput.StepStatusCode, nil      // First failed hard dependency will decide the response and response code for ensemble node
+					stepResponse, err := jsonMarshal(ensembleStepOutput.StepResponse)
+					if err != nil {
+						log.Error(err, "failed to marshal hard dependency step response", "nodeName", nodeName, "stepName", currentNode.Steps[i].StepName)
+						return nil, 500, err
+					}
+					return stepResponse, ensembleStepOutput.StepStatusCode, nil // First failed hard dependency will decide the response and response code for ensemble node
 				} else {
 					response[key] = ensembleStepOutput.StepResponse
 				}
@@ -311,8 +320,11 @@ func routeStep(nodeName string, graph v1alpha1.InferenceGraphSpec, input []byte,
 				return nil, 500, err
 			}
 		}
-		// return json.Marshal(response)
-		combinedResponse, _ := json.Marshal(response) // TODO check if you need err handling for Marshalling
+		combinedResponse, err := jsonMarshal(response)
+		if err != nil {
+			log.Error(err, "failed to marshal combined ensemble response", "nodeName", nodeName)
+			return nil, 500, err
+		}
 		return combinedResponse, 200, nil
 	}
 	if currentNode.RouterType == v1alpha1.Sequence {
@@ -341,7 +353,11 @@ func routeStep(nodeName string, graph v1alpha1.InferenceGraphSpec, input []byte,
 				if err == nil && len(decoded.Predictions) > 0 {
 					decoded.Instances = decoded.Predictions
 					decoded.Predictions = []interface{}{}
-					request, _ = json.Marshal(decoded) // TODO check if you need err handling for Marshalling
+					request, err = jsonMarshal(decoded)
+					if err != nil {
+						log.Error(err, "failed to marshal sequence request", "nodeName", nodeName, "stepName", step.StepName)
+						return nil, 500, err
+					}
 				}
 			}
 

--- a/cmd/router/main_test.go
+++ b/cmd/router/main_test.go
@@ -1095,3 +1095,55 @@ func TestCryptoRandIntUpperBoundWithFix(t *testing.T) {
 			"rand.Int(100) returned out-of-range value %d on iteration %d", n.Int64(), i)
 	}
 }
+
+// TestEnsembleMarshalErrorReturns500 verifies that when marshalling the
+// ensemble response fails, routeStep surfaces a 500 with an error instead of
+// silently returning an empty body with a success status (issue #5640).
+func TestEnsembleMarshalErrorReturns500(t *testing.T) {
+	// Force json.Marshal to fail at the response-marshalling seam. The step
+	// responses themselves are still marshalled/unmarshalled with the real
+	// encoder via the HTTP server + json.Unmarshal, so only routeStep's
+	// defensive marshal branch is exercised.
+	original := jsonMarshal
+	jsonMarshal = func(any) ([]byte, error) { return nil, assert.AnError }
+	defer func() { jsonMarshal = original }()
+
+	model := httptest.NewServer(http.HandlerFunc(func(rw http.ResponseWriter, req *http.Request) {
+		_, err := io.ReadAll(req.Body)
+		if err != nil {
+			t.Errorf("failed to read request body: %v", err)
+			rw.WriteHeader(http.StatusInternalServerError)
+			return
+		}
+		_, err = rw.Write([]byte(`{"predictions": "1"}`))
+		if err != nil {
+			t.Errorf("failed to write response: %v", err)
+		}
+	}))
+	defer model.Close()
+	modelURL, err := apis.ParseURL(model.URL)
+	if err != nil {
+		t.Fatalf("Failed to parse model url")
+	}
+
+	graphSpec := v1alpha1.InferenceGraphSpec{
+		Nodes: map[string]v1alpha1.InferenceRouter{
+			"root": {
+				RouterType: v1alpha1.Ensemble,
+				Steps: []v1alpha1.InferenceStep{
+					{
+						StepName: "model1",
+						InferenceTarget: v1alpha1.InferenceTarget{
+							ServiceURL: modelURL.String(),
+						},
+					},
+				},
+			},
+		},
+	}
+	res, statusCode, err := routeStep("root", graphSpec, []byte(`{"instances": ["test"]}`), http.Header{})
+
+	require.Error(t, err, "routeStep must surface the marshal error instead of silently succeeding")
+	assert.Equal(t, 500, statusCode, "a marshal failure must return HTTP 500, not a silent 200")
+	assert.Nil(t, res, "no partial/corrupt body should be returned on marshal failure")
+}


### PR DESCRIPTION
**What this PR does / why we need it**:

In `cmd/router/main.go`, the `routeStep` function discarded the error from three `json.Marshal` calls using the blank identifier (each marked with a `TODO`). On a marshal failure the router returned an empty or corrupt body while still reporting a success status code, so a caller could receive a broken 200 with no signal that anything went wrong.

Each of the three sites now checks the error, logs it with context, and returns HTTP 500:

- ensemble hard-dependency step response
- ensemble combined response
- sequence `MapPredictionsToInstances` re-marshal

A small package-level `jsonMarshal` seam (defaulting to `json.Marshal`) lets a unit test force the failure and assert the 500 path. The happy path is unchanged.

**Which issue(s) this PR fixes**:
Fixes #5640

**Feature/Issue validation/testing**:

- [x] `gofmt -l cmd/router/main.go cmd/router/main_test.go` — clean
- [x] `go vet ./cmd/router/` — no issues
- [x] `go test ./cmd/router/ -run TestEnsembleMarshalErrorReturns500 -race` — pass

`TestEnsembleMarshalErrorReturns500` overrides the `jsonMarshal` seam to always fail, drives a real `httptest.Server` through `routeStep`, and asserts `err != nil`, `statusCode == 500`, and a `nil` body — proving the marshal error is surfaced instead of silently succeeding.

**Special notes for your reviewer**:

The `jsonMarshal` seam is the minimal indirection needed to exercise the defensive branches, which are otherwise unreachable because the marshalled values are derived from a prior `json.Unmarshal` and never fail in practice.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the documentation?

**Release note**:
```release-note
Fix inference graph router silently returning HTTP 200 with an empty/corrupt body when a response fails to marshal; it now returns HTTP 500.
```

