### PR TITLE
fix(isvc): isvc headless status.address.url has incorrect port

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/rawkube_controller_test.go
@@ -9842,6 +9842,171 @@ var _ = Describe("v1beta1 inference service controller", func() {
 		})
 	})
 
+	Context("When creating inference service with headless service and custom container port", func() {
+		It("Should include the actual container port in status.address.url instead of the default 8080", func() {
+			By("By creating a ServingRuntime with rest_port=8888 and headless service enabled")
+			ctx := context.Background()
+
+			configs := map[string]string{
+				"ingress": `{
+					"ingressGateway": "knative-serving/knative-ingress-gateway",
+					"localGateway": "knative-serving/knative-local-gateway",
+					"localGatewayService": "knative-local-gateway.istio-system.svc.cluster.local"
+				}`,
+				"storageInitializer": `{
+					"image": "kserve/storage-initializer:latest",
+					"memoryRequest": "100Mi",
+					"memoryLimit": "1Gi",
+					"cpuRequest": "100m",
+					"cpuLimit": "1",
+					"caBundleConfigMapName": "",
+					"caBundleVolumeMountPath": "/etc/ssl/custom-certs",
+					"cpuModelcar": "10m",
+					"memoryModelcar": "15Mi"
+				}`,
+				"service": `{"serviceClusterIPNone": true}`,
+			}
+			configMap := createInferenceServiceConfigMap(configs)
+			Expect(k8sClient.Create(ctx, configMap)).NotTo(HaveOccurred())
+			defer k8sClient.Delete(ctx, configMap)
+
+			// Create a ServingRuntime with a non-default port (8888), similar to OVMS
+			servingRuntime := &v1alpha1.ServingRuntime{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "ovms-like-runtime",
+					Namespace: "default",
+				},
+				Spec: v1alpha1.ServingRuntimeSpec{
+					SupportedModelFormats: []v1alpha1.SupportedModelFormat{
+						{
+							Name:       "tensorflow",
+							Version:    ptr.To("1"),
+							AutoSelect: ptr.To(true),
+						},
+					},
+					ServingRuntimePodSpec: v1alpha1.ServingRuntimePodSpec{
+						Containers: []corev1.Container{
+							{
+								Name:    constants.InferenceServiceContainerName,
+								Image:   "tensorflow/serving:1.14.0",
+								Command: []string{"/usr/bin/tensorflow_model_server"},
+								Args: []string{
+									"--port=9000",
+									"--rest_api_port=8888",
+									"--model_base_path=/mnt/models",
+								},
+								Ports: []corev1.ContainerPort{
+									{
+										ContainerPort: 8888,
+										Protocol:      corev1.ProtocolTCP,
+									},
+								},
+								Resources: defaultResource,
+							},
+						},
+					},
+					Disabled: ptr.To(false),
+				},
+			}
+			Expect(k8sClient.Create(ctx, servingRuntime)).Should(Succeed())
+			defer k8sClient.Delete(ctx, servingRuntime)
+
+			serviceName := "raw-headless-custom-port"
+			expectedRequest := reconcile.Request{NamespacedName: types.NamespacedName{Name: serviceName, Namespace: "default"}}
+			serviceKey := expectedRequest.NamespacedName
+			storageUri := "s3://test/mnist/export"
+
+			isvc := &v1beta1.InferenceService{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      serviceKey.Name,
+					Namespace: serviceKey.Namespace,
+					Annotations: map[string]string{
+						constants.DeploymentMode: string(constants.Standard),
+					},
+				},
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptr.To(int32(1)),
+							MaxReplicas: 3,
+						},
+						Tensorflow: &v1beta1.TFServingSpec{
+							PredictorExtensionSpec: v1beta1.PredictorExtensionSpec{
+								StorageURI:     &storageUri,
+								RuntimeVersion: ptr.To("1.14.0"),
+								Container: corev1.Container{
+									Name:      constants.InferenceServiceContainerName,
+									Resources: defaultResource,
+								},
+							},
+						},
+					},
+				},
+			}
+			isvc.DefaultInferenceService(nil, nil, &v1beta1.SecurityConfig{AutoMountServiceAccountToken: false}, nil, nil)
+			Expect(k8sClient.Create(ctx, isvc)).Should(Succeed())
+			defer k8sClient.Delete(ctx, isvc)
+
+			inferenceService := &v1beta1.InferenceService{}
+			Eventually(func() bool {
+				err := k8sClient.Get(ctx, serviceKey, inferenceService)
+				return err == nil
+			}, timeout, interval).Should(BeTrue())
+
+			// Wait for deployment to be created
+			actualDeployment := &appsv1.Deployment{}
+			predictorDeploymentKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorDeploymentKey, actualDeployment)
+			}, timeout, interval).Should(Succeed())
+
+			// Wait for service to be created and verify it's headless
+			actualService := &corev1.Service{}
+			predictorServiceKey := types.NamespacedName{
+				Name:      constants.PredictorServiceName(serviceKey.Name),
+				Namespace: serviceKey.Namespace,
+			}
+			Eventually(func() error {
+				return k8sClient.Get(ctx, predictorServiceKey, actualService)
+			}, timeout, interval).Should(Succeed())
+
+			Expect(actualService.Spec.ClusterIP).To(Equal(corev1.ClusterIPNone),
+				"Service should be headless (ClusterIP: None)")
+
+			// Verify the service has the correct target port from the ServingRuntime
+			Expect(actualService.Spec.Ports).NotTo(BeEmpty())
+			Expect(actualService.Spec.Ports[0].TargetPort.IntValue()).To(Equal(8888),
+				"Service target port should match the container port from ServingRuntime")
+
+			// Update deployment status to trigger status reconciliation
+			updatedDeployment := actualDeployment.DeepCopy()
+			updatedDeployment.Status.Conditions = []appsv1.DeploymentCondition{
+				{
+					Type:   appsv1.DeploymentAvailable,
+					Status: corev1.ConditionTrue,
+				},
+			}
+			Expect(k8sClient.Status().Update(ctx, updatedDeployment)).NotTo(HaveOccurred())
+
+			// Verify status.address.url includes the actual container port (8888), not the default (8080)
+			Eventually(func() bool {
+				isvc := &v1beta1.InferenceService{}
+				if err := k8sClient.Get(ctx, serviceKey, isvc); err != nil {
+					return false
+				}
+				if isvc.Status.Address == nil || isvc.Status.Address.URL == nil {
+					return false
+				}
+				expectedHost := serviceKey.Name + "-predictor." + serviceKey.Namespace + ".svc.cluster.local:8888"
+				return isvc.Status.Address.URL.Host == expectedHost
+			}, timeout, interval).Should(BeTrue(),
+				"status.address.url should include :8888 for headless service with custom container port")
+		})
+	})
+
 	Context("When creating an inference service with modelcar and raw deployment", func() {
 		configs := map[string]string{
 			"ingress": `{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -164,6 +164,9 @@ func createAddress(ctx context.Context, cl client.Client, isvc *v1beta1.Inferenc
 		port := constants.InferenceServiceDefaultHttpPort
 		if p := httpTargetPort(entryPointSvc); p != "" {
 			port = p
+		} else {
+			log.Info("No HTTP target port found on service, defaulting to InferenceServiceDefaultHttpPort",
+				"defaultPort", constants.InferenceServiceDefaultHttpPort, "service", entryPointSvc.Name)
 		}
 		host = host + ":" + port
 	}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler.go
@@ -19,6 +19,7 @@ package ingress
 import (
 	"context"
 	"fmt"
+	"strconv"
 
 	corev1 "k8s.io/api/core/v1"
 	netv1 "k8s.io/api/networking/v1"
@@ -160,7 +161,11 @@ func createAddress(ctx context.Context, cl client.Client, isvc *v1beta1.Inferenc
 		return nil, fmt.Errorf("failed to get entry point service %s: %w", entryPointSvcName, err)
 	}
 	if entryPointSvc.Spec.ClusterIP == corev1.ClusterIPNone {
-		host = host + ":" + constants.InferenceServiceDefaultHttpPort
+		port := constants.InferenceServiceDefaultHttpPort
+		if p := httpTargetPort(entryPointSvc); p != "" {
+			port = p
+		}
+		host = host + ":" + port
 	}
 	return &duckv1.Addressable{
 		URL: &apis.URL{
@@ -169,6 +174,25 @@ func createAddress(ctx context.Context, cl client.Client, isvc *v1beta1.Inferenc
 			Path:   "",
 		},
 	}, nil
+}
+
+// httpTargetPort returns the target port (as a string) of the first non-gRPC
+// port on the Service, which is the port the container actually listens on.
+// For headless Services the address must use this port directly because there
+// is no ClusterIP to perform port remapping.
+func httpTargetPort(svc *corev1.Service) string {
+	for _, p := range svc.Spec.Ports {
+		if isGrpcPortByName(p.Name) {
+			continue
+		}
+		if p.AppProtocol != nil && *p.AppProtocol == "kubernetes.io/h2c" {
+			continue
+		}
+		if p.TargetPort.IntValue() > 0 {
+			return strconv.Itoa(p.TargetPort.IntValue())
+		}
+	}
+	return ""
 }
 
 func generateRule(ingressHost string, componentName string, path string, port int32) netv1.IngressRule { //nolint:unparam

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
@@ -46,6 +46,8 @@ func testScheme() *runtime.Scheme {
 	return s
 }
 
+func strPtr(s string) *string { return &s }
+
 func makeService(name string, headless bool) *corev1.Service {
 	svc := &corev1.Service{
 		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: testNamespace},
@@ -104,6 +106,61 @@ func TestCreateAddress(t *testing.T) {
 			},
 			wantScheme: "http",
 			wantHost:   predictorHost() + ":8888",
+		},
+		{
+			name:     "headless service skips grpc port and picks http port",
+			headless: true,
+			svcPorts: []corev1.ServicePort{
+				{
+					Name:       "grpc",
+					Port:       8001,
+					TargetPort: intstr.FromInt32(8001),
+					Protocol:   corev1.ProtocolTCP,
+				},
+				{
+					Name:       "http",
+					Port:       constants.CommonDefaultHttpPort,
+					TargetPort: intstr.FromInt32(8888),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+			wantScheme: "http",
+			wantHost:   predictorHost() + ":8888",
+		},
+		{
+			name:     "headless service with named target port falls back to default",
+			headless: true,
+			svcPorts: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       constants.CommonDefaultHttpPort,
+					TargetPort: intstr.FromString("http-serving"),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+			wantScheme: "http",
+			wantHost:   predictorHost() + ":" + constants.InferenceServiceDefaultHttpPort,
+		},
+		{
+			name:     "headless service skips h2c AppProtocol port and picks http port",
+			headless: true,
+			svcPorts: []corev1.ServicePort{
+				{
+					Name:        "h2c",
+					Port:        8001,
+					TargetPort:  intstr.FromInt32(8001),
+					Protocol:    corev1.ProtocolTCP,
+					AppProtocol: strPtr("kubernetes.io/h2c"),
+				},
+				{
+					Name:       "http",
+					Port:       constants.CommonDefaultHttpPort,
+					TargetPort: intstr.FromInt32(9000),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+			wantScheme: "http",
+			wantHost:   predictorHost() + ":9000",
 		},
 	}
 

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/kube_ingress_reconciler_test.go
@@ -25,6 +25,7 @@ import (
 	netv1 "k8s.io/api/networking/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 
@@ -74,6 +75,7 @@ func TestCreateAddress(t *testing.T) {
 	tests := []struct {
 		name       string
 		headless   bool
+		svcPorts   []corev1.ServicePort
 		wantScheme string
 		wantHost   string
 	}{
@@ -84,10 +86,24 @@ func TestCreateAddress(t *testing.T) {
 			wantHost:   predictorHost(),
 		},
 		{
-			name:       "headless service appends port 8080",
+			name:       "headless service without ports falls back to default port",
 			headless:   true,
 			wantScheme: "http",
 			wantHost:   predictorHost() + ":" + constants.InferenceServiceDefaultHttpPort,
+		},
+		{
+			name:     "headless service uses actual target port from service",
+			headless: true,
+			svcPorts: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       constants.CommonDefaultHttpPort,
+					TargetPort: intstr.FromInt32(8888),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+			wantScheme: "http",
+			wantHost:   predictorHost() + ":8888",
 		},
 	}
 
@@ -98,6 +114,7 @@ func TestCreateAddress(t *testing.T) {
 
 			svcName := constants.PredictorServiceName(testIsvcName)
 			svc := makeService(svcName, tc.headless)
+			svc.Spec.Ports = tc.svcPorts
 			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
 
 			isvc := &v1beta1.InferenceService{
@@ -153,6 +170,7 @@ func TestRawIngressReconciler_URLAndAddress(t *testing.T) {
 	tests := []struct {
 		name           string
 		headless       bool
+		svcPorts       []corev1.ServicePort
 		urlScheme      string
 		wantAddrScheme string
 		wantAddrHost   string
@@ -185,6 +203,21 @@ func TestRawIngressReconciler_URLAndAddress(t *testing.T) {
 			wantAddrScheme: "http",
 			wantAddrHost:   pHost + ":" + constants.InferenceServiceDefaultHttpPort,
 		},
+		{
+			name:     "headless with custom target port uses actual container port",
+			headless: true,
+			svcPorts: []corev1.ServicePort{
+				{
+					Name:       "http",
+					Port:       constants.CommonDefaultHttpPort,
+					TargetPort: intstr.FromInt32(8888),
+					Protocol:   corev1.ProtocolTCP,
+				},
+			},
+			urlScheme:      "http",
+			wantAddrScheme: "http",
+			wantAddrHost:   pHost + ":8888",
+		},
 	}
 
 	for _, tc := range tests {
@@ -194,6 +227,7 @@ func TestRawIngressReconciler_URLAndAddress(t *testing.T) {
 
 			svcName := constants.PredictorServiceName(testIsvcName)
 			svc := makeService(svcName, tc.headless)
+			svc.Spec.Ports = tc.svcPorts
 			cl := fake.NewClientBuilder().WithScheme(s).WithObjects(svc).Build()
 
 			isvc := &v1beta1.InferenceService{


### PR DESCRIPTION
chore:  ISVC status.address.url incorrectly reports port 8080 for OVMS deployment listening on 8888

**What this PR does / why we need it**:
When serviceClusterIPNone is enabled, status.address.url hardcodes port 8080 regardless of the actual container port defined in the ServingRuntime. This causes issues for runtimes like OVMS that listen on a different port (e.g., 8888), since headless services have no ClusterIP to remap ports 
  — traffic goes directly to the pod.                                                                                                                                                                                                                                    
                                                                                                                                                                                                                                                                         
 The fix reads the Service's TargetPort (which reflects the container's actual listening port) instead of using the hardcoded default. Falls back to 8080 if no ports are defined.

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #


**Feature/Issue validation/testing**:
- [x] Tests to verify if the headless service maps the correct port to the model pod
- [x] unit tests


**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
fix(isvc): fix headless service serving port mapping
```
