### PR TITLE
fix(webhook): normalize deploymentMode annotation before comparing to status

### DIFF
--- a/pkg/apis/serving/v1beta1/inference_service_validation.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation.go
@@ -693,8 +693,15 @@ func validateDeploymentMode(newIsvc *InferenceService, oldIsvc *InferenceService
 		return nil
 	}
 	statusDeploymentMode := string(constants.ParseDeploymentMode(oldIsvc.Status.DeploymentMode))
-	annotationDeploymentMode, ok := newIsvc.Annotations[constants.DeploymentMode]
-	if ok && annotationDeploymentMode != statusDeploymentMode {
+	rawAnnotationDeploymentMode, ok := newIsvc.Annotations[constants.DeploymentMode]
+	if !ok {
+		return nil
+	}
+	// Normalize the annotation the same way the status side is normalized, so a legacy
+	// alias (e.g. "Serverless"/"RawDeployment") that is semantically unchanged doesn't
+	// get compared as a raw string against its normalized counterpart ("Knative"/"Standard").
+	annotationDeploymentMode := string(constants.ParseDeploymentMode(rawAnnotationDeploymentMode))
+	if annotationDeploymentMode != statusDeploymentMode {
 		return fmt.Errorf("update rejected: deploymentMode cannot be changed from '%s' to '%s'", statusDeploymentMode, annotationDeploymentMode)
 	}
 	return nil

--- a/pkg/apis/serving/v1beta1/inference_service_validation_test.go
+++ b/pkg/apis/serving/v1beta1/inference_service_validation_test.go
@@ -1513,6 +1513,44 @@ func TestDeploymentModeUpdate(t *testing.T) {
 	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcEmptyStatus, updatedIsvcNoAnnotation)
 	g.Expect(warnings).Should(gomega.BeEmpty())
 	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Normalized status "Knative" should accept an unchanged legacy "Serverless" annotation.
+	// Regression test for issue #5885: the annotation side must be normalized before comparing,
+	// otherwise an isvc created with the legacy alias is permanently rejected on every update.
+	oldIsvcKnativeStatus := makeTestInferenceService()
+	oldIsvcKnativeStatus.Status = InferenceServiceStatus{
+		DeploymentMode: string(constants.Knative),
+	}
+	updatedIsvcLegacyServerlessAnnotation := oldIsvcKnativeStatus.DeepCopy()
+	updatedIsvcLegacyServerlessAnnotation.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.LegacyServerless),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcKnativeStatus, updatedIsvcLegacyServerlessAnnotation)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Normalized status "Standard" should accept an unchanged legacy "RawDeployment" annotation.
+	oldIsvcStandardStatus := makeTestInferenceService()
+	oldIsvcStandardStatus.Status = InferenceServiceStatus{
+		DeploymentMode: string(constants.Standard),
+	}
+	updatedIsvcLegacyRawAnnotation := oldIsvcStandardStatus.DeepCopy()
+	updatedIsvcLegacyRawAnnotation.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.LegacyRawDeployment),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcStandardStatus, updatedIsvcLegacyRawAnnotation)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).Should(gomega.Succeed())
+
+	// Test: Normalized status "Knative" with a legacy "RawDeployment" annotation is a real mode
+	// change (normalizes to "Standard") and must still be rejected.
+	updatedIsvcLegacyRawMismatch := oldIsvcKnativeStatus.DeepCopy()
+	updatedIsvcLegacyRawMismatch.Annotations = map[string]string{
+		constants.DeploymentMode: string(constants.LegacyRawDeployment),
+	}
+	warnings, err = validator.ValidateUpdate(t.Context(), &oldIsvcKnativeStatus, updatedIsvcLegacyRawMismatch)
+	g.Expect(warnings).Should(gomega.BeEmpty())
+	g.Expect(err).ShouldNot(gomega.Succeed())
 }
 
 func TestValidateUpdateDuringDeletion(t *testing.T) {


### PR DESCRIPTION
**What this PR does / why we need it**:

`validateDeploymentMode` normalizes `status.DeploymentMode` through `constants.ParseDeploymentMode` before comparing it to the `deploymentMode` annotation, but the annotation side was left as a raw string. Legacy aliases (`Serverless`/`RawDeployment`) normalize to `Knative`/`Standard` respectively, so an `InferenceService` created with a legacy alias annotation had its (unchanged) annotation compared against the normalized status value as raw strings — permanently rejecting every subsequent update, including no-op `kubectl apply`s and (on versions without the `DeletionTimestamp` bypass) the controller's own finalizer-removal update during deletion.

This PR normalizes the annotation side the same way before comparing, so a legacy alias that hasn't actually changed compares equal to its normalized counterpart, while a genuine mode change is still rejected.

**Which issue(s) this PR fixes**:
Fixes #5885

**Feature/Issue validation/testing**:

- [x] Added regression tests to `TestDeploymentModeUpdate` in `pkg/apis/serving/v1beta1/inference_service_validation_test.go`:
  - normalized status (`Knative`) accepts an unchanged legacy `Serverless` annotation
  - normalized status (`Standard`) accepts an unchanged legacy `RawDeployment` annotation
  - normalized status (`Knative`) still rejects a legacy `RawDeployment` annotation that represents a real mode change
- [x] `go test ./pkg/apis/serving/v1beta1/...` passes
- [x] `go vet` and `golangci-lint run` pass on the changed package

**Special notes for your reviewer**:

The `DeletionTimestamp` bypass in `ValidateUpdate` referenced in the issue is already present on `master`; this PR only addresses the annotation/status comparison bug, which reproduces independently of that bypass.

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [ ] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Fix a webhook validation bug where an InferenceService created with a legacy `deploymentMode` annotation alias (`Serverless`/`RawDeployment`) was rejected on every subsequent update once `status.deploymentMode` was populated, because the annotation was compared against the normalized status value as a raw string.
```