### PR TITLE
fix(isvc): gate canary traffic on readiness to prevent transient 503s

### DIFF
--- a/pkg/controller/v1beta1/inferenceservice/canary_controller_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/canary_controller_test.go
@@ -80,6 +80,32 @@ var _ = Describe("Canary deployment controller", func() {
 		}
 	}
 
+	// markCanaryAvailable simulates the Deployment controller by setting
+	// AvailableReplicas on the canary Deployment so that the KServe controller
+	// marks the canary as Ready and reduces the stable minReplicas accordingly.
+	markCanaryAvailable := func(ctx context.Context, key types.NamespacedName) {
+		Eventually(func() error {
+			deploy := &appsv1.Deployment{}
+			if err := k8sClient.Get(ctx, key, deploy); err != nil {
+				return err
+			}
+			replicas := int32(1)
+			if deploy.Spec.Replicas != nil {
+				replicas = *deploy.Spec.Replicas
+			}
+			updated := deploy.DeepCopy()
+			updated.Status.AvailableReplicas = replicas
+			updated.Status.ReadyReplicas = replicas
+			updated.Status.Replicas = replicas
+			updated.Status.UpdatedReplicas = replicas
+			updated.Status.Conditions = []appsv1.DeploymentCondition{
+				{Type: appsv1.DeploymentAvailable, Status: corev1.ConditionTrue},
+				{Type: appsv1.DeploymentProgressing, Status: corev1.ConditionTrue, Reason: "NewReplicaSetAvailable"},
+			}
+			return k8sClient.Status().Update(ctx, updated)
+		}, timeout, interval).Should(Succeed())
+	}
+
 	Context("When creating an InferenceService with a canary", func() {
 		It("Should create separate Deployments for stable and canary", func() {
 			configMap := createInferenceServiceConfigMap(configs)
@@ -101,6 +127,9 @@ var _ = Describe("Canary deployment controller", func() {
 
 			stableKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceName), Namespace: "default"}
 			canaryKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceName, "v2"), Namespace: "default"}
+
+			// Mark canary as available so the controller reduces stable minReplicas.
+			markCanaryAvailable(ctx, canaryKey)
 
 			// Stable gets 3 replicas (4 - 1), canary gets 1 (25% of 4)
 			Eventually(func() int32 {
@@ -161,6 +190,9 @@ var _ = Describe("Canary deployment controller", func() {
 			Eventually(func() error {
 				return k8sClient.Get(ctx, canaryKey, &appsv1.Deployment{})
 			}, timeout, interval).Should(Succeed())
+
+			// Mark canary as available so the controller reduces stable minReplicas.
+			markCanaryAvailable(ctx, canaryKey)
 
 			// Bump traffic to 50%
 			Expect(retry.RetryOnConflict(retry.DefaultRetry, func() error {
@@ -341,6 +373,10 @@ var _ = Describe("Canary deployment controller", func() {
 			stableKey := types.NamespacedName{Name: constants.PredictorServiceName(serviceName), Namespace: "default"}
 			canaryV2Key := types.NamespacedName{Name: constants.PredictorServiceName(serviceName, "v2"), Namespace: "default"}
 			canaryV3Key := types.NamespacedName{Name: constants.PredictorServiceName(serviceName, "v3"), Namespace: "default"}
+
+			// Mark both canaries as available so the controller reduces stable minReplicas.
+			markCanaryAvailable(ctx, canaryV2Key)
+			markCanaryAvailable(ctx, canaryV3Key)
 
 			// 4 total: 2 stable, 1 v2 (25%), 1 v3 (25%)
 			Eventually(func() int32 {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor.go
@@ -224,13 +224,16 @@ func (p *Predictor) Reconcile(ctx context.Context, isvc *v1beta1.InferenceServic
 	if p.deploymentMode == constants.Standard {
 		rawDeployment = true
 		podLabelKey = constants.RawDeploymentAppLabel
+		// Reconcile canary first so CanaryStatuses is fresh when the stable
+		// minReplicas reduction decision is made below. This ensures the
+		// stable Deployment is not scaled down until canary pods are Ready.
+		if err := p.reconcileCanaryDeployments(ctx, isvc); err != nil {
+			return ctrl.Result{}, errors.Wrapf(err, "fails to reconcile canary deployments")
+		}
 		// This is main RawKubeReconciler to create objects (deployment, svc, scaler)
 		if err := p.reconcileRawDeployment(ctx, isvc, objectMeta, workerObjectMeta, &podSpec, workerPodSpec); err != nil {
 			isvc.Status.PropagateRawStatusWithMessages(v1beta1.PredictorComponent, "ReconcileFailed", err.Error(), corev1.ConditionFalse)
 			return ctrl.Result{}, err
-		}
-		if err := p.reconcileCanaryDeployments(ctx, isvc); err != nil {
-			return ctrl.Result{}, errors.Wrapf(err, "fails to reconcile canary deployments")
 		}
 	} else {
 		var err error
@@ -792,15 +795,7 @@ func (p *Predictor) reconcileRawDeployment(ctx context.Context, isvc *v1beta1.In
 	}
 
 	componentExt := isvc.Spec.Predictor.ComponentExtensionSpec
-	if len(isvc.Spec.Canary) > 0 && componentExt.MinReplicas != nil {
-		var totalCanaryReplicas int32
-		for i := range isvc.Spec.Canary {
-			totalCanaryReplicas += canaryReplicaCount(isvc, &isvc.Spec.Canary[i])
-		}
-		adjusted := *componentExt.MinReplicas - totalCanaryReplicas
-		adjusted = max(adjusted, 1)
-		componentExt.MinReplicas = &adjusted
-	}
+	adjustStableMinReplicasForCanaries(isvc, &componentExt)
 
 	r, err := raw.NewRawKubeReconciler(ctx, p.client, p.clientset, p.scheme, objectMeta, workerObjectMeta, &componentExt,
 		podSpec, workerPodSpec, &isvc.Spec.Predictor.StorageUris, storageInitializerConfig, storageSpec, credentialBuilder, storageContainerSpec)
@@ -872,6 +867,36 @@ func canaryReplicaCount(isvc *v1beta1.InferenceService, canary *v1beta1.CanarySp
 		stableReplicas = *isvc.Spec.Predictor.MinReplicas
 	}
 	return int32(math.Ceil(float64(stableReplicas) * float64(canary.TrafficPercent) / 100))
+}
+
+// adjustStableMinReplicasForCanaries reduces the stable predictor's minReplicas
+// by the replica count of canaries that are actually Ready (as reported in
+// isvc.Status.CanaryStatuses). Not-ready canaries are not counted, so the
+// stable Deployment is not scaled down until canary pods can serve traffic.
+// This prevents a transient capacity gap during canary rollout.
+func adjustStableMinReplicasForCanaries(isvc *v1beta1.InferenceService, componentExt *v1beta1.ComponentExtensionSpec) {
+	if len(isvc.Spec.Canary) == 0 || componentExt.MinReplicas == nil {
+		return
+	}
+
+	readyMap := make(map[string]bool, len(isvc.Status.CanaryStatuses))
+	for _, cs := range isvc.Status.CanaryStatuses {
+		readyMap[cs.Name] = cs.Ready
+	}
+
+	var readyCanaryReplicas int32
+	for i := range isvc.Spec.Canary {
+		canary := &isvc.Spec.Canary[i]
+		if !readyMap[canary.Predictor.Name] {
+			continue
+		}
+		readyCanaryReplicas += canaryReplicaCount(isvc, canary)
+	}
+
+	if readyCanaryReplicas > 0 {
+		adjusted := max(*componentExt.MinReplicas-readyCanaryReplicas, 1)
+		componentExt.MinReplicas = &adjusted
+	}
 }
 
 func buildCanaryPredictor(stable v1beta1.PredictorSpec, canary v1beta1.CanarySpec, replicas int32) (v1beta1.PredictorSpec, error) {

--- a/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/components/predictor_test.go
@@ -105,3 +105,134 @@ func TestAddStorageInitializerAnnotationsOciNative(t *testing.T) {
 	assert.True(t, hasAnnotation, "oci+native:// must set StorageInitializerSourceUriInternalAnnotationKey so InjectModelcar can inject the ImageVolume")
 	assert.Equal(t, ociNativeURI, annotationVal)
 }
+
+func ptrInt32(v int32) *int32 { return &v }
+
+func TestAdjustStableMinReplicasForCanaries(t *testing.T) {
+	tests := []struct {
+		name             string
+		stableMinReplica int32
+		canaries         []v1beta1.CanarySpec
+		canaryStatuses   []v1beta1.CanaryStatus
+		expectedStable   int32
+	}{
+		{
+			name:             "no canaries - unchanged",
+			stableMinReplica: 10,
+			canaries:         nil,
+			canaryStatuses:   nil,
+			expectedStable:   10,
+		},
+		{
+			name:             "canary not in status - stable unchanged",
+			stableMinReplica: 10,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+			},
+			canaryStatuses: nil,
+			expectedStable: 10,
+		},
+		{
+			name:             "canary ready=false - stable unchanged",
+			stableMinReplica: 10,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+			},
+			canaryStatuses: []v1beta1.CanaryStatus{
+				{Name: "v2", Ready: false, TrafficPercent: 20},
+			},
+			expectedStable: 10,
+		},
+		{
+			name:             "canary ready=true - stable reduced by computed count",
+			stableMinReplica: 10,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+			},
+			canaryStatuses: []v1beta1.CanaryStatus{
+				{Name: "v2", Ready: true, TrafficPercent: 20},
+			},
+			expectedStable: 8, // 10 - ceil(10*20/100)=2
+		},
+		{
+			name:             "mixed readiness - only ready canary counted",
+			stableMinReplica: 10,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				{TrafficPercent: 30, Predictor: v1beta1.PredictorSpec{Name: "v3"}},
+			},
+			canaryStatuses: []v1beta1.CanaryStatus{
+				{Name: "v2", Ready: true, TrafficPercent: 20},
+				{Name: "v3", Ready: false, TrafficPercent: 30},
+			},
+			expectedStable: 8, // 10 - ceil(10*20/100)=2
+		},
+		{
+			name:             "all canaries ready - stable reduced by full sum",
+			stableMinReplica: 10,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				{TrafficPercent: 30, Predictor: v1beta1.PredictorSpec{Name: "v3"}},
+			},
+			canaryStatuses: []v1beta1.CanaryStatus{
+				{Name: "v2", Ready: true, TrafficPercent: 20},
+				{Name: "v3", Ready: true, TrafficPercent: 30},
+			},
+			expectedStable: 5, // 10 - 2 - 3
+		},
+		{
+			name:             "reduction floored at 1",
+			stableMinReplica: 2,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 50, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+			},
+			canaryStatuses: []v1beta1.CanaryStatus{
+				{Name: "v2", Ready: true, TrafficPercent: 50},
+			},
+			expectedStable: 1, // max(2-1, 1)
+		},
+		{
+			name:             "explicit canary minReplicas honored when ready",
+			stableMinReplica: 10,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2", ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptrInt32(3)}}},
+			},
+			canaryStatuses: []v1beta1.CanaryStatus{
+				{Name: "v2", Ready: true, TrafficPercent: 20},
+			},
+			expectedStable: 7, // 10 - 3 (explicit)
+		},
+		{
+			name:             "explicit canary minReplicas ignored when not ready",
+			stableMinReplica: 10,
+			canaries: []v1beta1.CanarySpec{
+				{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2", ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{MinReplicas: ptrInt32(3)}}},
+			},
+			canaryStatuses: []v1beta1.CanaryStatus{
+				{Name: "v2", Ready: false, TrafficPercent: 20},
+			},
+			expectedStable: 10,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			isvc := &v1beta1.InferenceService{
+				Spec: v1beta1.InferenceServiceSpec{
+					Predictor: v1beta1.PredictorSpec{
+						ComponentExtensionSpec: v1beta1.ComponentExtensionSpec{
+							MinReplicas: ptrInt32(tt.stableMinReplica),
+						},
+					},
+					Canary: tt.canaries,
+				},
+				Status: v1beta1.InferenceServiceStatus{
+					CanaryStatuses: tt.canaryStatuses,
+				},
+			}
+			componentExt := isvc.Spec.Predictor.ComponentExtensionSpec
+			adjustStableMinReplicasForCanaries(isvc, &componentExt)
+			assert.Equal(t, tt.expectedStable, *componentExt.MinReplicas)
+		})
+	}
+}

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler.go
@@ -682,13 +682,23 @@ func createRawTopLevelHTTPRoute(ctx context.Context, client client.Client, isvc 
 }
 
 // applyCanaryWeights modifies the HTTPRoute's backend refs to include weighted
-// backends for canary traffic splitting.
+// backends for canary traffic splitting. Only canaries whose deployments are
+// Ready (as reported in isvc.Status.CanaryStatuses) receive traffic; not-ready
+// canaries are omitted so no traffic is routed to a backend without ready
+// endpoints.
 func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPRoute) {
-	var totalCanaryPercent int32
-	for _, canary := range isvc.Spec.Canary {
-		totalCanaryPercent += canary.TrafficPercent
+	readyMap := make(map[string]bool, len(isvc.Status.CanaryStatuses))
+	for _, cs := range isvc.Status.CanaryStatuses {
+		readyMap[cs.Name] = cs.Ready
 	}
-	stableWeight := int32(100) - totalCanaryPercent
+
+	var totalReadyCanaryPercent int32
+	for _, canary := range isvc.Spec.Canary {
+		if readyMap[canary.Predictor.Name] {
+			totalReadyCanaryPercent += canary.TrafficPercent
+		}
+	}
+	stableWeight := int32(100) - totalReadyCanaryPercent
 
 	for i := range httpRoute.Spec.Rules {
 		rule := &httpRoute.Spec.Rules[i]
@@ -709,6 +719,9 @@ func applyCanaryWeights(isvc *v1beta1.InferenceService, httpRoute *gwapiv1.HTTPR
 		weightedBackends = append(weightedBackends, stable)
 
 		for _, canary := range isvc.Spec.Canary {
+			if !readyMap[canary.Predictor.Name] {
+				continue
+			}
 			canaryServiceName := constants.PredictorServiceName(isvc.Name, canary.Predictor.Name)
 			cw := canary.TrafficPercent
 			backend := gwapiv1.HTTPBackendRef{

--- a/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
+++ b/pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/httproute_reconciler_test.go
@@ -3463,9 +3463,8 @@ func TestCreateRawPredictorHTTPRouteDisableTimeout(t *testing.T) {
 }
 
 func TestApplyCanaryWeights(t *testing.T) {
-	g := NewGomegaWithT(t)
-
-	t.Run("single canary", func(t *testing.T) {
+	t.Run("single canary ready", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		isvc := &v1beta1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
 			Spec: v1beta1.InferenceServiceSpec{
@@ -3474,6 +3473,11 @@ func TestApplyCanaryWeights(t *testing.T) {
 						TrafficPercent: 20,
 						Predictor:      v1beta1.PredictorSpec{Name: "v2"},
 					},
+				},
+			},
+			Status: v1beta1.InferenceServiceStatus{
+				CanaryStatuses: []v1beta1.CanaryStatus{
+					{Name: "v2", Ready: true, TrafficPercent: 20},
 				},
 			},
 		}
@@ -3508,13 +3512,20 @@ func TestApplyCanaryWeights(t *testing.T) {
 		g.Expect(string(backends[1].Name)).To(Equal("my-model-v2-predictor"))
 	})
 
-	t.Run("multiple canaries", func(t *testing.T) {
+	t.Run("multiple canaries all ready", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		isvc := &v1beta1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
 			Spec: v1beta1.InferenceServiceSpec{
 				Canary: []v1beta1.CanarySpec{
 					{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
 					{TrafficPercent: 30, Predictor: v1beta1.PredictorSpec{Name: "v3"}},
+				},
+			},
+			Status: v1beta1.InferenceServiceStatus{
+				CanaryStatuses: []v1beta1.CanaryStatus{
+					{Name: "v2", Ready: true, TrafficPercent: 20},
+					{Name: "v3", Ready: true, TrafficPercent: 30},
 				},
 			},
 		}
@@ -3547,12 +3558,18 @@ func TestApplyCanaryWeights(t *testing.T) {
 		g.Expect(string(backends[2].Name)).To(Equal("my-model-v3-predictor"))
 	})
 
-	t.Run("dual-protocol rules", func(t *testing.T) {
+	t.Run("dual-protocol rules all ready", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		isvc := &v1beta1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
 			Spec: v1beta1.InferenceServiceSpec{
 				Canary: []v1beta1.CanarySpec{
 					{TrafficPercent: 25, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+			Status: v1beta1.InferenceServiceStatus{
+				CanaryStatuses: []v1beta1.CanaryStatus{
+					{Name: "v2", Ready: true, TrafficPercent: 25},
 				},
 			},
 		}
@@ -3584,11 +3601,17 @@ func TestApplyCanaryWeights(t *testing.T) {
 	})
 
 	t.Run("skips rules with no backends", func(t *testing.T) {
+		g := NewGomegaWithT(t)
 		isvc := &v1beta1.InferenceService{
 			ObjectMeta: metav1.ObjectMeta{Name: "my-model"},
 			Spec: v1beta1.InferenceServiceSpec{
 				Canary: []v1beta1.CanarySpec{
 					{TrafficPercent: 10, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+			Status: v1beta1.InferenceServiceStatus{
+				CanaryStatuses: []v1beta1.CanaryStatus{
+					{Name: "v2", Ready: true, TrafficPercent: 10},
 				},
 			},
 		}
@@ -3602,6 +3625,116 @@ func TestApplyCanaryWeights(t *testing.T) {
 
 		applyCanaryWeights(isvc, httpRoute)
 		g.Expect(httpRoute.Spec.Rules[0].BackendRefs).To(BeNil())
+	})
+
+	t.Run("canary not ready - excluded from backends", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+			Status: v1beta1.InferenceServiceStatus{
+				CanaryStatuses: []v1beta1.CanaryStatus{
+					{Name: "v2", Ready: false, TrafficPercent: 20},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: []gwapiv1.HTTPBackendRef{
+						{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+							Kind: ptr.To(gwapiv1.Kind(constants.ServiceKind)),
+							Name: "my-model-predictor",
+							Port: ptr.To(int32(80)),
+						}}},
+					}},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		backends := httpRoute.Spec.Rules[0].BackendRefs
+		g.Expect(backends).To(HaveLen(1))
+		g.Expect(*backends[0].Weight).To(Equal(int32(100)))
+		g.Expect(string(backends[0].Name)).To(Equal("my-model-predictor"))
+	})
+
+	t.Run("mixed readiness - only ready canary gets traffic", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+					{TrafficPercent: 30, Predictor: v1beta1.PredictorSpec{Name: "v3"}},
+				},
+			},
+			Status: v1beta1.InferenceServiceStatus{
+				CanaryStatuses: []v1beta1.CanaryStatus{
+					{Name: "v2", Ready: true, TrafficPercent: 20},
+					{Name: "v3", Ready: false, TrafficPercent: 30},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: []gwapiv1.HTTPBackendRef{
+						{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+							Kind: ptr.To(gwapiv1.Kind(constants.ServiceKind)),
+							Name: "my-model-predictor",
+							Port: ptr.To(int32(80)),
+						}}},
+					}},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		backends := httpRoute.Spec.Rules[0].BackendRefs
+		g.Expect(backends).To(HaveLen(2))
+		g.Expect(*backends[0].Weight).To(Equal(int32(80)))
+		g.Expect(string(backends[0].Name)).To(Equal("my-model-predictor"))
+		g.Expect(*backends[1].Weight).To(Equal(int32(20)))
+		g.Expect(string(backends[1].Name)).To(Equal("my-model-v2-predictor"))
+	})
+
+	t.Run("no canary statuses - all canaries excluded", func(t *testing.T) {
+		g := NewGomegaWithT(t)
+		isvc := &v1beta1.InferenceService{
+			ObjectMeta: metav1.ObjectMeta{Name: "my-model", Namespace: "default"},
+			Spec: v1beta1.InferenceServiceSpec{
+				Canary: []v1beta1.CanarySpec{
+					{TrafficPercent: 20, Predictor: v1beta1.PredictorSpec{Name: "v2"}},
+				},
+			},
+		}
+		httpRoute := &gwapiv1.HTTPRoute{
+			Spec: gwapiv1.HTTPRouteSpec{
+				Rules: []gwapiv1.HTTPRouteRule{
+					{BackendRefs: []gwapiv1.HTTPBackendRef{
+						{BackendRef: gwapiv1.BackendRef{BackendObjectReference: gwapiv1.BackendObjectReference{
+							Kind: ptr.To(gwapiv1.Kind(constants.ServiceKind)),
+							Name: "my-model-predictor",
+							Port: ptr.To(int32(80)),
+						}}},
+					}},
+				},
+			},
+		}
+
+		applyCanaryWeights(isvc, httpRoute)
+
+		backends := httpRoute.Spec.Rules[0].BackendRefs
+		g.Expect(backends).To(HaveLen(1))
+		g.Expect(*backends[0].Weight).To(Equal(int32(100)))
+		g.Expect(string(backends[0].Name)).To(Equal("my-model-predictor"))
 	})
 }
 


### PR DESCRIPTION
**What this PR does / why we need it:**

Canary rollout in RawDeployment mode caused transient 503s because traffic was routed to not-ready canary backends and the stable predictor was scaled down before canary pods could serve. This PR makes canary rollout zero-downtime with three changes:

1. **Reconcile canaries before stable** (`predictor.go`): `reconcileCanaryDeployments` now runs before `reconcileRawDeployment` so `isvc.Status.CanaryStatuses` is fresh when the stable `minReplicas` decision is made.
2. **Gate minReplicas reduction on canary readiness** (`predictor.go`): New `adjustStableMinReplicasForCanaries` only subtracts the replica count of canaries whose `CanaryStatus.Ready == true`. Not-ready canaries are skipped, so the stable Deployment keeps full capacity until canary pods are ready.
3. **Skip not-ready canary backendRefs** (`httproute_reconciler.go`): `applyCanaryWeights` builds a readiness map from `CanaryStatuses` and only includes canaries that are Ready in the `HTTPRoute` backend refs; the stable weight is rebalanced against ready canaries only.

**Which issue(s) this PR fixes**:
Fixes #5983


**Feature/Issue validation/testing**:

- [x] `TestAdjustStableMinReplicasForCanaries` — table-driven unit tests for `adjustStableMinReplicasForCanaries` covering: no canaries, canary not in status, canary not-ready (stable unchanged), canary ready (stable reduced), mixed readiness (only ready canary counted), all canaries ready, reduction floored at 1, explicit canary `minReplicas` honored when ready and ignored when not ready.
- [x] `TestApplyCanaryWeights` — extended with cases for: not-ready canary excluded from backends (stable gets 100%), mixed readiness (only ready canary gets traffic), and no canary statuses (all canaries excluded).

Reproduce with:
```
KUBEBUILDER_ASSETS="$(./bin/setup-envtest use $(go list -m -f '{{ .Version }}' k8s.io/api | awk -F'[v.]' '{printf "1.%d", $3}') -p path)" \
  go test ./pkg/controller/v1beta1/inferenceservice/components/... -run TestAdjustStableMinReplicasForCanaries -v
KUBEBUILDER_ASSETS="$(./bin/setup-envtest use $(go list -m -f '{{ .Version }}' k8s.io/api | awk -F'[v.]' '{printf "1.%d", $3}') -p path)" \
  go test ./pkg/controller/v1beta1/inferenceservice/reconcilers/ingress/... -run TestApplyCanaryWeights -v
```

- Logs

**Special notes for your reviewer**:

This PR changes only controller reconciliation logic and tests; no image version changes. The canary-readiness gating mirrors the existing pattern used for LLMISVC group traffic splitting (#5820).

**Checklist**:

- [x] Have you added unit/e2e tests that prove your fix is effective or that this feature works?
- [x] Has code been commented, particularly in hard-to-understand areas?
- [ ] Have you made corresponding changes to the [documentation](https://github.com/kserve/website)?

**Release note**:
```release-note
Canary rollout in RawDeployment mode now gates traffic on canary readiness: the stable predictor is not scaled down until canary pods are Ready, and not-ready canary backends are skipped in the HTTPRoute. This eliminates transient 503s during canary rollout.
```